### PR TITLE
Phase 11a — API keys infrastructure

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/src/app.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/app.ts
@@ -5,6 +5,7 @@ import { errorHandler } from "./middleware/errorHandler";
 import { notFoundHandler } from "./middleware/notFoundHandler";
 import { apiLimiter, authLimiter, emailLimiter } from "./middleware/rateLimiter";
 import { installSentryErrorHandler } from "./lib/sentry";
+import { apiKeysRouter } from "./routes/apiKeys";
 import { authRouter } from "./routes/auth";
 import { healthRouter } from "./routes/health";
 import { commentsRouter } from "./routes/comments";
@@ -76,6 +77,7 @@ export function createApp(): Express {
   app.use("/api", apiLimiter);
   app.use("/api/v1/auth", authLimiter, authRouter);
   app.use("/api/v1/users", usersRouter);
+  app.use("/api/v1/me/api-keys", apiKeysRouter);
   app.use("/api/v1/stories", storiesRouter);
   app.use("/api/v1/comments", commentsRouter);
   app.use("/api/v1/teams", teamsRouter);

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/apiKeyController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/apiKeyController.ts
@@ -1,0 +1,172 @@
+import type { NextFunction, Request, Response } from "express";
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { apiKeys } from "../db/schema";
+import { generateApiKey } from "../services/apiKeyService";
+import { AppError } from "../middleware/errorHandler";
+
+const LABEL_MAX_LENGTH = 100;
+const MAX_ACTIVE_KEYS_PER_USER = 10;
+
+const createKeySchema = z.object({
+  label: z.string().trim().min(1).max(LABEL_MAX_LENGTH),
+});
+
+const idParamSchema = z.object({
+  id: z.string().uuid(),
+});
+
+function requireUserId(req: Request): string {
+  if (!req.user) {
+    throw new AppError("UNAUTHORIZED", "Not authenticated", 401);
+  }
+  return req.user.userId;
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "23505"
+  );
+}
+
+export async function createApiKey(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = requireUserId(req);
+    const { label } = createKeySchema.parse(req.body);
+
+    const activeCount = await db
+      .select({ id: apiKeys.id })
+      .from(apiKeys)
+      .where(and(eq(apiKeys.userId, userId), isNull(apiKeys.revokedAt)));
+    if (activeCount.length >= MAX_ACTIVE_KEYS_PER_USER) {
+      throw new AppError(
+        "API_KEY_LIMIT_REACHED",
+        `Active key limit reached (${MAX_ACTIVE_KEYS_PER_USER}). Revoke an existing key first.`,
+        409,
+      );
+    }
+
+    const generated = generateApiKey();
+
+    let inserted;
+    try {
+      [inserted] = await db
+        .insert(apiKeys)
+        .values({
+          userId,
+          label,
+          keyPrefix: generated.keyPrefix,
+          keyHash: generated.keyHash,
+        })
+        .returning({
+          id: apiKeys.id,
+          label: apiKeys.label,
+          keyPrefix: apiKeys.keyPrefix,
+          createdAt: apiKeys.createdAt,
+        });
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        throw new AppError(
+          "API_KEY_LABEL_TAKEN",
+          "An active API key with that label already exists",
+          409,
+        );
+      }
+      throw err;
+    }
+
+    if (!inserted) {
+      throw new AppError("API_KEY_CREATE_FAILED", "Failed to create API key", 500);
+    }
+
+    // Full key is returned exactly once. We never store it, and the client
+    // must save it immediately — subsequent list calls return only the
+    // prefix.
+    res.status(201).json({
+      data: {
+        id: inserted.id,
+        label: inserted.label,
+        key_prefix: inserted.keyPrefix,
+        created_at: inserted.createdAt,
+        key: generated.fullKey,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function listApiKeys(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = requireUserId(req);
+
+    const rows = await db
+      .select({
+        id: apiKeys.id,
+        label: apiKeys.label,
+        keyPrefix: apiKeys.keyPrefix,
+        createdAt: apiKeys.createdAt,
+        lastUsedAt: apiKeys.lastUsedAt,
+        revokedAt: apiKeys.revokedAt,
+      })
+      .from(apiKeys)
+      .where(eq(apiKeys.userId, userId))
+      .orderBy(asc(apiKeys.revokedAt), desc(apiKeys.createdAt));
+
+    res.json({
+      data: {
+        keys: rows.map((r) => ({
+          id: r.id,
+          label: r.label,
+          key_prefix: r.keyPrefix,
+          created_at: r.createdAt,
+          last_used_at: r.lastUsedAt,
+          revoked_at: r.revokedAt,
+        })),
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function revokeApiKey(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = requireUserId(req);
+    const { id } = idParamSchema.parse(req.params);
+
+    // Idempotent: only set revoked_at if currently NULL. Repeated DELETEs
+    // return 204 without overwriting the original revocation time and
+    // without leaking whether the key ever existed for this user.
+    await db
+      .update(apiKeys)
+      .set({ revokedAt: new Date() })
+      .where(
+        and(
+          eq(apiKeys.id, id),
+          eq(apiKeys.userId, userId),
+          isNull(apiKeys.revokedAt),
+        ),
+      );
+
+    res.status(204).end();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/0005_phase11_api_keys.sql
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/0005_phase11_api_keys.sql
@@ -1,0 +1,37 @@
+-- Phase 11a: self-service API keys for the Intelligence API.
+--
+-- Drops the Phase 0 placeholder api_keys table (never wired up, 0 rows in
+-- prod) and recreates it with the real shape:
+--   - user_id FK to users (not an abstract customer_id)
+--   - label + key_prefix for display/debug
+--   - HMAC-SHA256 hex digest (64 chars) in key_hash — NOT bcrypt; the input
+--     is a 256-bit random secret so work-factor hashing buys nothing and
+--     adds verify latency to every API request
+--   - revoked_at + partial unique index on (user_id, label) where active
+--     only, so rotation (revoke-then-recreate-with-same-label) works
+--
+-- The api_key_tier enum from migration 0000 is left in place — unused but
+-- cheap, and a future phase may reintroduce tiered limits.
+
+DROP TABLE IF EXISTS "api_keys";--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "api_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"label" varchar(100) NOT NULL,
+	"key_prefix" varchar(16) NOT NULL,
+	"key_hash" varchar(64) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	CONSTRAINT "api_keys_key_hash_unique" UNIQUE("key_hash")
+);--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "api_keys_user_id_idx" ON "api_keys" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "api_keys_user_label_active_unique" ON "api_keys" USING btree ("user_id","label") WHERE "revoked_at" IS NULL;

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/meta/_journal.json
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777284000003,
       "tag": "0004_phase9_invite_revoked_at",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777284000004,
+      "tag": "0005_phase11_api_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/OneDrive/Desktop/signal-app/backend/src/db/schema.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -8,6 +9,7 @@ import {
   text,
   timestamp,
   unique,
+  uniqueIndex,
   uuid,
   varchar,
   type AnyPgColumn,
@@ -268,16 +270,27 @@ export const userLearningProgress = pgTable(
 
 // ---------- API keys ----------
 
-export const apiKeys = pgTable("api_keys", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  customerId: uuid("customer_id").notNull(),
-  keyHash: varchar("key_hash", { length: 255 }).notNull().unique(),
-  tier: apiKeyTierEnum("tier"),
-  rateLimitDaily: integer("rate_limit_daily"),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  expiresAt: timestamp("expires_at", { withTimezone: true }),
-  lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
-});
+export const apiKeys = pgTable(
+  "api_keys",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    label: varchar("label", { length: 100 }).notNull(),
+    keyPrefix: varchar("key_prefix", { length: 16 }).notNull(),
+    keyHash: varchar("key_hash", { length: 64 }).notNull().unique(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+  },
+  (t) => ({
+    userIdIdx: index("api_keys_user_id_idx").on(t.userId),
+    userLabelActiveUnique: uniqueIndex("api_keys_user_label_active_unique")
+      .on(t.userId, t.label)
+      .where(sql`${t.revokedAt} IS NULL`),
+  }),
+);
 
 // ---------- Exported row types ----------
 
@@ -303,3 +316,4 @@ export type LearningPath = typeof learningPaths.$inferSelect;
 export type LearningPathStory = typeof learningPathStories.$inferSelect;
 export type UserLearningProgress = typeof userLearningProgress.$inferSelect;
 export type ApiKey = typeof apiKeys.$inferSelect;
+export type NewApiKey = typeof apiKeys.$inferInsert;

--- a/OneDrive/Desktop/signal-app/backend/src/lib/envCheck.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/lib/envCheck.ts
@@ -26,6 +26,11 @@ export const PROD_REQUIRED_ENV_VARS: RequiredEnvVar[] = [
     description:
       "invite and unsubscribe links — links in outbound emails will point at localhost",
   },
+  {
+    name: "API_KEY_HASH_SECRET",
+    description:
+      "HMAC secret for API key hashing — without it, generation throws and existing keys can't verify",
+  },
 ];
 
 function envIsPresent(env: NodeJS.ProcessEnv, name: string): boolean {

--- a/OneDrive/Desktop/signal-app/backend/src/middleware/apiKeyAuth.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,79 @@
+import type { NextFunction, Request, Response } from "express";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../db";
+import { apiKeys } from "../db/schema";
+import { hashApiKey } from "../services/apiKeyService";
+import { AppError } from "./errorHandler";
+
+export interface AuthenticatedApiKey {
+  id: string;
+  userId: string;
+  label: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      apiKey?: AuthenticatedApiKey;
+    }
+  }
+}
+
+// Middleware for v2 (public Intelligence API) routes. JWT-authed endpoints
+// under /api/v1/me/api-keys use requireAuth instead — this is strictly for
+// programmatic callers presenting a key in the `X-API-Key` header.
+export async function apiKeyAuth(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const raw = req.header("x-api-key")?.trim();
+  if (!raw) {
+    next(new AppError("UNAUTHORIZED", "Missing X-API-Key header", 401));
+    return;
+  }
+
+  // HMAC is deterministic, so we can look the key up by hash in O(1) rather
+  // than scan every row and timing-safe-compare each. The hash column has a
+  // unique index, and the HMAC secret prevents offline dictionary attacks
+  // if the DB leaks.
+  const keyHash = hashApiKey(raw);
+
+  try {
+    const rows = await db
+      .select({
+        id: apiKeys.id,
+        userId: apiKeys.userId,
+        label: apiKeys.label,
+        revokedAt: apiKeys.revokedAt,
+      })
+      .from(apiKeys)
+      .where(and(eq(apiKeys.keyHash, keyHash), isNull(apiKeys.revokedAt)))
+      .limit(1);
+
+    const row = rows[0];
+    if (!row) {
+      next(new AppError("UNAUTHORIZED", "Invalid or revoked API key", 401));
+      return;
+    }
+
+    req.apiKey = { id: row.id, userId: row.userId, label: row.label };
+
+    // Fire-and-forget last_used_at bump. We don't await because the request
+    // shouldn't wait on a non-critical write, and we don't want an error
+    // here to 500 an otherwise-valid request.
+    void db
+      .update(apiKeys)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(apiKeys.id, row.id))
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error("[apiKeyAuth] failed to update last_used_at", err);
+      });
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/routes/apiKeys.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/routes/apiKeys.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import {
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+} from "../controllers/apiKeyController";
+import { requireAuth } from "../middleware/auth";
+
+export const apiKeysRouter: Router = Router();
+
+apiKeysRouter.use(requireAuth);
+
+apiKeysRouter.post("/", createApiKey);
+apiKeysRouter.get("/", listApiKeys);
+apiKeysRouter.delete("/:id", revokeApiKey);

--- a/OneDrive/Desktop/signal-app/backend/src/services/apiKeyService.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/apiKeyService.ts
@@ -1,0 +1,50 @@
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+
+// SIGNAL key format: sgnl_live_<43 chars base64url> = 53 chars total.
+// The `sgnl_` vendor prefix (rather than the Stripe-style one) keeps us
+// out of third-party secret scanners' Stripe rules — which false-positive
+// on Stripe-shaped strings in committed test fixtures. The prefix is
+// env-overridable so staging can ship `sgnl_test_` and make leaked-into-
+// git scrubbing easier.
+const DEFAULT_PREFIX = "sgnl_live_";
+const SECRET_BYTES = 32; // 256-bit entropy
+const KEY_PREFIX_DISPLAY_LEN = 14; // "sgnl_live_ABCD" shown in list responses
+
+export interface GeneratedApiKey {
+  fullKey: string;
+  keyPrefix: string;
+  keyHash: string;
+}
+
+function getPrefix(): string {
+  const override = process.env.API_KEY_PREFIX?.trim();
+  return override && override.length > 0 ? override : DEFAULT_PREFIX;
+}
+
+function getHashSecret(): string {
+  const secret = process.env.API_KEY_HASH_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error("API_KEY_HASH_SECRET must be set and at least 32 characters");
+  }
+  return secret;
+}
+
+export function hashApiKey(fullKey: string): string {
+  return createHmac("sha256", getHashSecret()).update(fullKey).digest("hex");
+}
+
+export function generateApiKey(): GeneratedApiKey {
+  const secret = randomBytes(SECRET_BYTES).toString("base64url");
+  const fullKey = `${getPrefix()}${secret}`;
+  const keyPrefix = fullKey.slice(0, KEY_PREFIX_DISPLAY_LEN);
+  const keyHash = hashApiKey(fullKey);
+  return { fullKey, keyPrefix, keyHash };
+}
+
+export function verifyApiKey(candidate: string, storedHash: string): boolean {
+  const candidateHash = hashApiKey(candidate);
+  const a = Buffer.from(candidateHash, "hex");
+  const b = Buffer.from(storedHash, "hex");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/OneDrive/Desktop/signal-app/backend/tests/apiKeyAuth.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/apiKeyAuth.test.ts
@@ -1,0 +1,67 @@
+import type { NextFunction, Request, Response } from "express";
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import { apiKeyAuth } from "../src/middleware/apiKeyAuth";
+import { AppError } from "../src/middleware/errorHandler";
+import { generateApiKey } from "../src/services/apiKeyService";
+
+function makeReq(headers: Record<string, string> = {}): Request {
+  const lowered: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lowered[k.toLowerCase()] = v;
+  return {
+    headers: lowered,
+    header(name: string) {
+      return lowered[name.toLowerCase()];
+    },
+  } as unknown as Request;
+}
+
+describe("apiKeyAuth middleware", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("calls next with 401 when X-API-Key header is missing", async () => {
+    const req = makeReq();
+    const next: NextFunction = jest.fn();
+    await apiKeyAuth(req, {} as Response, next);
+    const err = (next as jest.Mock).mock.calls[0][0] as AppError;
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.status).toBe(401);
+    expect(err.code).toBe("UNAUTHORIZED");
+  });
+
+  it("calls next with 401 when the key does not match any row", async () => {
+    mock.queueSelect([]); // DB returns no match
+
+    const req = makeReq({ "X-API-Key": "sgnl_live_TEST_FIXTURE_unknown_key" });
+    const next: NextFunction = jest.fn();
+    await apiKeyAuth(req, {} as Response, next);
+    const err = (next as jest.Mock).mock.calls[0][0] as AppError;
+    expect(err.status).toBe(401);
+  });
+
+  it("attaches req.apiKey when the hash matches and calls next()", async () => {
+    const { fullKey } = generateApiKey();
+    mock.queueSelect([
+      { id: "key-1", userId: "user-1", label: "ci", revokedAt: null },
+    ]);
+
+    const req = makeReq({ "X-API-Key": fullKey });
+    const next: NextFunction = jest.fn();
+    await apiKeyAuth(req, {} as Response, next);
+    expect(next).toHaveBeenCalledWith();
+    expect(req.apiKey).toEqual({ id: "key-1", userId: "user-1", label: "ci" });
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/apiKeyService.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/apiKeyService.test.ts
@@ -1,0 +1,95 @@
+import {
+  generateApiKey,
+  hashApiKey,
+  verifyApiKey,
+} from "../src/services/apiKeyService";
+
+// Obviously-fake fixture. The TEST_FIXTURE_ infix and repeated "NOT_A_REAL_
+// KEY" body keep secret scanners from tripping on these literals. Length
+// (43 chars after the prefix) matches the production shape so prefix/
+// length assertions stay meaningful.
+const FAKE_KEY = "sgnl_live_TEST_FIXTURE_NOT_A_REAL_KEY_abcde_xyz0";
+
+describe("apiKeyService", () => {
+  describe("generateApiKey", () => {
+    it("returns a full key, prefix, and hex hash of the expected shapes", () => {
+      const { fullKey, keyPrefix, keyHash } = generateApiKey();
+      expect(fullKey).toMatch(/^sgnl_live_[A-Za-z0-9_-]{43}$/);
+      expect(fullKey).toHaveLength(53);
+      expect(keyPrefix).toHaveLength(14);
+      expect(fullKey.startsWith(keyPrefix)).toBe(true);
+      expect(keyHash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("produces distinct keys across calls", () => {
+      const a = generateApiKey();
+      const b = generateApiKey();
+      expect(a.fullKey).not.toEqual(b.fullKey);
+      expect(a.keyHash).not.toEqual(b.keyHash);
+    });
+
+    it("honors API_KEY_PREFIX override (e.g. sgnl_test_)", () => {
+      const prev = process.env.API_KEY_PREFIX;
+      process.env.API_KEY_PREFIX = "sgnl_test_";
+      try {
+        const { fullKey } = generateApiKey();
+        expect(fullKey.startsWith("sgnl_test_")).toBe(true);
+      } finally {
+        if (prev === undefined) delete process.env.API_KEY_PREFIX;
+        else process.env.API_KEY_PREFIX = prev;
+      }
+    });
+  });
+
+  describe("hashApiKey", () => {
+    it("is deterministic for the same input", () => {
+      expect(hashApiKey(FAKE_KEY)).toBe(hashApiKey(FAKE_KEY));
+    });
+
+    it("differs when the secret changes (fresh module import)", async () => {
+      const a = hashApiKey(FAKE_KEY);
+
+      const prev = process.env.API_KEY_HASH_SECRET;
+      process.env.API_KEY_HASH_SECRET = "a-completely-different-hmac-secret-32chars";
+      try {
+        jest.resetModules();
+        const { hashApiKey: hashFresh } = await import("../src/services/apiKeyService");
+        expect(hashFresh(FAKE_KEY)).not.toBe(a);
+      } finally {
+        if (prev !== undefined) process.env.API_KEY_HASH_SECRET = prev;
+      }
+    });
+
+    it("throws when API_KEY_HASH_SECRET is missing on a fresh import", async () => {
+      const prev = process.env.API_KEY_HASH_SECRET;
+      delete process.env.API_KEY_HASH_SECRET;
+      try {
+        jest.resetModules();
+        const { hashApiKey: hashFresh } = await import("../src/services/apiKeyService");
+        expect(() => hashFresh("sgnl_live_TEST_FIXTURE_short")).toThrow(
+          /API_KEY_HASH_SECRET/,
+        );
+      } finally {
+        if (prev !== undefined) process.env.API_KEY_HASH_SECRET = prev;
+      }
+    });
+  });
+
+  describe("verifyApiKey", () => {
+    it("returns true for a matching key/hash pair", () => {
+      const { fullKey, keyHash } = generateApiKey();
+      expect(verifyApiKey(fullKey, keyHash)).toBe(true);
+    });
+
+    it("returns false for a mismatched candidate", () => {
+      const a = generateApiKey();
+      const b = generateApiKey();
+      expect(verifyApiKey(a.fullKey, b.keyHash)).toBe(false);
+    });
+
+    it("returns false when the stored hash is malformed (length mismatch)", () => {
+      const { fullKey } = generateApiKey();
+      expect(verifyApiKey(fullKey, "deadbeef")).toBe(false);
+    });
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/apiKeys.integration.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/apiKeys.integration.test.ts
@@ -1,0 +1,180 @@
+import request from "supertest";
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import { createApp } from "../src/app";
+import { generateToken } from "../src/services/authService";
+
+const app = createApp();
+
+function auth(token: string): [string, string] {
+  return ["Authorization", `Bearer ${token}`];
+}
+
+describe("POST /api/v1/me/api-keys", () => {
+  const userId = "user-1";
+  const email = "a@b.com";
+  let token: string;
+
+  beforeEach(() => {
+    mock.reset();
+    token = generateToken(userId, email);
+  });
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).post("/api/v1/me/api-keys").send({ label: "ci" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when label is missing", async () => {
+    const res = await request(app)
+      .post("/api/v1/me/api-keys")
+      .set(...auth(token))
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when label is empty after trim", async () => {
+    const res = await request(app)
+      .post("/api/v1/me/api-keys")
+      .set(...auth(token))
+      .send({ label: "   " });
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a key and returns the full token exactly once", async () => {
+    mock.queueSelect([]); // active count check: 0 keys
+    mock.queueInsert([
+      {
+        id: "key-1",
+        label: "ci",
+        keyPrefix: "sgnl_live_TEST1",
+        createdAt: new Date("2026-04-19T00:00:00Z"),
+      },
+    ]);
+
+    const res = await request(app)
+      .post("/api/v1/me/api-keys")
+      .set(...auth(token))
+      .send({ label: "ci" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      id: "key-1",
+      label: "ci",
+    });
+    expect(res.body.data.key).toMatch(/^sgnl_live_[A-Za-z0-9_-]{43}$/);
+    expect(res.body.data.key_prefix).toBe("sgnl_live_TEST1");
+  });
+
+  it("returns 409 when the user already has 10 active keys", async () => {
+    mock.queueSelect(Array.from({ length: 10 }, (_v, i) => ({ id: `k${i}` })));
+
+    const res = await request(app)
+      .post("/api/v1/me/api-keys")
+      .set(...auth(token))
+      .send({ label: "eleventh" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("API_KEY_LIMIT_REACHED");
+  });
+});
+
+describe("GET /api/v1/me/api-keys", () => {
+  const userId = "user-2";
+  const email = "c@d.com";
+  let token: string;
+
+  beforeEach(() => {
+    mock.reset();
+    token = generateToken(userId, email);
+  });
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get("/api/v1/me/api-keys");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the caller's keys with metadata (no full key value)", async () => {
+    mock.queueSelect([
+      {
+        id: "key-a",
+        label: "ci",
+        keyPrefix: "sgnl_live_TEST1",
+        createdAt: new Date("2026-04-18T00:00:00Z"),
+        lastUsedAt: null,
+        revokedAt: null,
+      },
+      {
+        id: "key-b",
+        label: "old",
+        keyPrefix: "sgnl_live_TEST2",
+        createdAt: new Date("2026-03-01T00:00:00Z"),
+        lastUsedAt: new Date("2026-03-05T00:00:00Z"),
+        revokedAt: new Date("2026-04-01T00:00:00Z"),
+      },
+    ]);
+
+    const res = await request(app)
+      .get("/api/v1/me/api-keys")
+      .set(...auth(token));
+    expect(res.status).toBe(200);
+    expect(res.body.data.keys).toHaveLength(2);
+    expect(res.body.data.keys[0]).toMatchObject({
+      id: "key-a",
+      label: "ci",
+      key_prefix: "sgnl_live_TEST1",
+      revoked_at: null,
+    });
+    expect(res.body.data.keys[0]).not.toHaveProperty("key");
+    expect(res.body.data.keys[0]).not.toHaveProperty("key_hash");
+  });
+});
+
+describe("DELETE /api/v1/me/api-keys/:id", () => {
+  const userId = "user-3";
+  const email = "e@f.com";
+  let token: string;
+
+  beforeEach(() => {
+    mock.reset();
+    token = generateToken(userId, email);
+  });
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).delete("/api/v1/me/api-keys/11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 204 and issues a scoped update (by user_id + id + revoked_at IS NULL)", async () => {
+    const res = await request(app)
+      .delete("/api/v1/me/api-keys/11111111-1111-1111-1111-111111111111")
+      .set(...auth(token));
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+    expect(mock.state.updatedRows).toHaveLength(1);
+    expect(mock.state.updatedRows[0]).toMatchObject({ revokedAt: expect.any(Date) });
+  });
+
+  it("is idempotent: repeating DELETE still returns 204", async () => {
+    const res1 = await request(app)
+      .delete("/api/v1/me/api-keys/11111111-1111-1111-1111-111111111111")
+      .set(...auth(token));
+    expect(res1.status).toBe(204);
+
+    const res2 = await request(app)
+      .delete("/api/v1/me/api-keys/11111111-1111-1111-1111-111111111111")
+      .set(...auth(token));
+    expect(res2.status).toBe(204);
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/setup.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/setup.ts
@@ -8,3 +8,5 @@ process.env.NODE_ENV = "test";
 process.env.REDIS_URL = "";
 process.env.SENDGRID_API_KEY = "";
 process.env.DISABLE_EMAIL_SCHEDULER = "1";
+process.env.API_KEY_HASH_SECRET =
+  process.env.API_KEY_HASH_SECRET ?? "test-api-key-hmac-secret-at-least-32-chars";


### PR DESCRIPTION
Ships API keys infrastructure as the foundation for Phase 11 v2 endpoints.

## What's in scope
- Migration 0005: drops orphan Phase 0 `api_keys` placeholder, recreates with proper schema (user_id FK, HMAC-SHA256 hash, partial unique index on active labels)
- Service: `sgnl_live_<43-char base64url>` key generation, HMAC-SHA256 hashing with `API_KEY_HASH_SECRET`, timing-safe verify
- Middleware: `X-API-Key` header auth, O(1) hash lookup, fire-and-forget `last_used_at` bump (not yet mounted — reserved for 11c v2 routes)
- Controller: `/api/v1/me/api-keys` POST/GET/DELETE, full key returned exactly once on create, 10-active-key cap per user, idempotent 204 DELETE, 409 on duplicate active label

## What's deferred to later 11x sessions
- Rate limiting → 11b
- v2 intelligence endpoints → 11c
- Developer dashboard frontend → 11d
- API docs page → 11e
- Team-owned keys → future
- Pricing tiers / scopes → future

## Testing
- Backend: 281/281 (was 259, +22 new — 9 service unit, 3 middleware unit, 10 integration)
- Frontend: 37/37 unchanged (no frontend touched)
- Type-check + lint clean

## Prod DB verified safe for migration
- Existing orphan `api_keys` table from Phase 0 scaffold: 0 rows
- No FK references into `api_keys`
- No `customers` table (referenced by old orphan schema)
- Drop-and-recreate is safe