### PR TITLE
Phase 11b — Redis-backed API key rate limiter

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/src/app.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/app.ts
@@ -83,6 +83,10 @@ export function createApp(): Express {
   app.use("/api/v1/teams", teamsRouter);
   app.use("/api/v1/emails", emailLimiter, emailsRouter);
 
+  // Phase 11b: apiKeyRateLimit middleware exists (src/middleware/apiKeyRateLimit.ts)
+  // but is NOT mounted here. 11c will apply it to the v2 Intelligence API
+  // routes via: router.use(apiKeyAuth, apiKeyRateLimit, ...).
+
   installSentryErrorHandler(app);
 
   app.use(notFoundHandler);

--- a/OneDrive/Desktop/signal-app/backend/src/middleware/apiKeyRateLimit.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/middleware/apiKeyRateLimit.ts
@@ -1,0 +1,121 @@
+import type { NextFunction, Request, Response } from "express";
+import * as Sentry from "@sentry/node";
+import { getRedis } from "../lib/redis";
+
+// Per-API-key rate limiter. Fixed 1-minute window, Redis-backed counter,
+// fails open on Redis errors.
+//
+// Must run AFTER apiKeyAuth so req.apiKey is populated. 11c will mount
+// this on v2 routes as: router.use(apiKeyAuth, apiKeyRateLimit, ...).
+// It is intentionally NOT mounted in app.ts yet.
+//
+// Default env var: API_KEY_RATE_LIMIT_PER_MINUTE (default 300).
+// Rationale for 300 vs. a tighter 100: a fresh integration doing paginated
+// catchup (e.g. 500 stories @ 100 per page) should not stall for minutes
+// on its first call. 300/min (5/sec) still catches runaway loops.
+
+const DEFAULT_LIMIT_PER_MINUTE = 300;
+const WINDOW_SECONDS = 60;
+
+function getLimit(): number {
+  const raw = process.env.API_KEY_RATE_LIMIT_PER_MINUTE?.trim();
+  if (raw && raw.length > 0) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_LIMIT_PER_MINUTE;
+}
+
+function setRateLimitHeaders(
+  res: Response,
+  limit: number,
+  remaining: number,
+  resetUnixSeconds: number,
+): void {
+  res.setHeader("X-RateLimit-Limit", String(limit));
+  res.setHeader("X-RateLimit-Remaining", String(Math.max(0, remaining)));
+  res.setHeader("X-RateLimit-Reset", String(resetUnixSeconds));
+}
+
+export async function apiKeyRateLimit(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const limit = getLimit();
+
+  // Defensive: if upstream routing forgot to mount apiKeyAuth first,
+  // fall through rather than 500. A silently-unlimited request is still
+  // preferable to a 500 on an otherwise-authenticated call. The warning
+  // surfaces the misconfiguration for ops.
+  const apiKeyId = req.apiKey?.id;
+  if (!apiKeyId) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[apiKeyRateLimit] req.apiKey missing — passing through without rate limiting. Check middleware order.",
+    );
+    next();
+    return;
+  }
+
+  const now = Date.now();
+  const minuteWindow = Math.floor(now / (WINDOW_SECONDS * 1000));
+  const windowEndMs = (minuteWindow + 1) * WINDOW_SECONDS * 1000;
+  const resetUnixSeconds = Math.ceil(windowEndMs / 1000);
+  const retryAfterSeconds = Math.max(1, Math.ceil((windowEndMs - now) / 1000));
+  const redisKey = `ratelimit:apikey:${apiKeyId}:${minuteWindow}`;
+
+  const redis = getRedis();
+  if (!redis) {
+    // No Redis configured (local dev, or intentional degraded config).
+    // Fail open without Sentry noise — this is deliberate, not an incident.
+    setRateLimitHeaders(res, limit, limit, resetUnixSeconds);
+    next();
+    return;
+  }
+
+  let count: number;
+  try {
+    count = await redis.incr(redisKey);
+    if (count === 1) {
+      // First hit of a new window. Use unconditional EXPIRE (not NX) so we
+      // stay portable to Redis < 7.0 — re-setting an expiry to the same
+      // value on a brand-new key is free, and the "on first hit only"
+      // guard already prevents resetting on subsequent hits in the window.
+      await redis.expire(redisKey, WINDOW_SECONDS);
+    }
+  } catch (err) {
+    // Rate limiting is throttling, not security. A Redis blip should not
+    // take down the API. Log structured, surface a Sentry *warning* (not
+    // error — error-level would eventually page on-call for a non-critical
+    // degradation), and allow the request through.
+    const message = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[apiKeyRateLimit] ratelimit_redis_unavailable apiKeyId=${apiKeyId} err=${message}`,
+    );
+    Sentry.captureMessage("Rate limiter fail-open: Redis unavailable", {
+      level: "warning",
+      extra: { apiKeyId, err: message },
+    });
+    setRateLimitHeaders(res, limit, limit, resetUnixSeconds);
+    next();
+    return;
+  }
+
+  const remaining = limit - count;
+  setRateLimitHeaders(res, limit, remaining, resetUnixSeconds);
+
+  if (count > limit) {
+    res.setHeader("Retry-After", String(retryAfterSeconds));
+    res.status(429).json({
+      error: {
+        code: "RATE_LIMIT_EXCEEDED",
+        message: `Rate limit of ${limit} requests per minute exceeded. Retry in ${retryAfterSeconds}s.`,
+      },
+    });
+    return;
+  }
+
+  next();
+}

--- a/OneDrive/Desktop/signal-app/backend/tests/apiKeyRateLimit.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/apiKeyRateLimit.test.ts
@@ -1,0 +1,269 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { NextFunction, Request, Response } from "express";
+
+const redisIncrMock = jest.fn();
+const redisExpireMock = jest.fn();
+let redisInstance: { incr: jest.Mock; expire: jest.Mock } | null = {
+  incr: redisIncrMock,
+  expire: redisExpireMock,
+};
+
+jest.mock("../src/lib/redis", () => ({
+  __esModule: true,
+  getRedis: () => redisInstance,
+  isRedisConfigured: () => redisInstance !== null,
+  getRedisUrl: () => (redisInstance ? "redis://stub" : null),
+  closeRedis: async () => undefined,
+}));
+
+const captureMessageMock = jest.fn();
+jest.mock("@sentry/node", () => ({
+  __esModule: true,
+  captureMessage: (...args: unknown[]) => captureMessageMock(...args),
+}));
+
+import { apiKeyRateLimit } from "../src/middleware/apiKeyRateLimit";
+
+function makeReq(apiKeyId: string): Request {
+  return {
+    apiKey: { id: apiKeyId, userId: "user-1", label: "ci" },
+  } as unknown as Request;
+}
+
+function makeReqWithoutApiKey(): Request {
+  return {} as unknown as Request;
+}
+
+interface MockRes {
+  res: Response;
+  status: jest.Mock;
+  json: jest.Mock;
+  setHeader: jest.Mock;
+  headers: Record<string, string>;
+}
+
+function makeRes(): MockRes {
+  const headers: Record<string, string> = {};
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const setHeader = jest.fn((name: string, value: string) => {
+    headers[name] = value;
+  });
+  const res = { status, json, setHeader } as unknown as Response;
+  return { res, status, json, setHeader, headers };
+}
+
+function resetMocks(): void {
+  redisIncrMock.mockReset();
+  redisExpireMock.mockReset();
+  captureMessageMock.mockReset();
+  redisInstance = { incr: redisIncrMock, expire: redisExpireMock };
+}
+
+describe("apiKeyRateLimit middleware", () => {
+  let consoleWarn: jest.SpyInstance;
+  let prevLimitEnv: string | undefined;
+
+  beforeEach(() => {
+    resetMocks();
+    consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    prevLimitEnv = process.env.API_KEY_RATE_LIMIT_PER_MINUTE;
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+    if (prevLimitEnv === undefined) {
+      delete process.env.API_KEY_RATE_LIMIT_PER_MINUTE;
+    } else {
+      process.env.API_KEY_RATE_LIMIT_PER_MINUTE = prevLimitEnv;
+    }
+  });
+
+  it("passes through under the limit, decrementing X-RateLimit-Remaining", async () => {
+    redisIncrMock.mockResolvedValueOnce(1);
+    redisExpireMock.mockResolvedValueOnce(1);
+    const { res, setHeader, headers } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(headers["X-RateLimit-Limit"]).toBe("300");
+    expect(headers["X-RateLimit-Remaining"]).toBe("299");
+    expect(headers["X-RateLimit-Reset"]).toMatch(/^\d+$/);
+    expect(setHeader).not.toHaveBeenCalledWith("Retry-After", expect.anything());
+  });
+
+  it("only calls EXPIRE on the first hit of a window (INCR=1), not subsequent hits", async () => {
+    redisIncrMock.mockResolvedValueOnce(2);
+    const { res } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(redisExpireMock).not.toHaveBeenCalled();
+  });
+
+  it("sets EXPIRE to WINDOW_SECONDS (60) on the first hit", async () => {
+    redisIncrMock.mockResolvedValueOnce(1);
+    redisExpireMock.mockResolvedValueOnce(1);
+    const { res } = makeRes();
+
+    await apiKeyRateLimit(makeReq("key-a"), res, jest.fn());
+
+    expect(redisExpireMock).toHaveBeenCalledWith(expect.any(String), 60);
+  });
+
+  it("allows the request at exactly the limit with remaining=0", async () => {
+    process.env.API_KEY_RATE_LIMIT_PER_MINUTE = "5";
+    redisIncrMock.mockResolvedValueOnce(5);
+    const { res, headers, status } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(status).not.toHaveBeenCalled();
+    expect(headers["X-RateLimit-Limit"]).toBe("5");
+    expect(headers["X-RateLimit-Remaining"]).toBe("0");
+  });
+
+  it("returns 429 RATE_LIMIT_EXCEEDED when the counter exceeds the limit", async () => {
+    process.env.API_KEY_RATE_LIMIT_PER_MINUTE = "5";
+    redisIncrMock.mockResolvedValueOnce(6);
+    const { res, status, json, headers } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(429);
+    expect(json).toHaveBeenCalledWith({
+      error: {
+        code: "RATE_LIMIT_EXCEEDED",
+        message: expect.stringMatching(/Rate limit of 5 requests per minute/),
+      },
+    });
+    expect(headers["Retry-After"]).toMatch(/^\d+$/);
+    expect(Number(headers["Retry-After"])).toBeGreaterThanOrEqual(1);
+    expect(Number(headers["Retry-After"])).toBeLessThanOrEqual(60);
+    expect(headers["X-RateLimit-Limit"]).toBe("5");
+    expect(headers["X-RateLimit-Remaining"]).toBe("0");
+    expect(headers["X-RateLimit-Reset"]).toMatch(/^\d+$/);
+  });
+
+  it("scopes counters by key — different apiKeyIds hit different Redis keys", async () => {
+    redisIncrMock.mockResolvedValue(1);
+    redisExpireMock.mockResolvedValue(1);
+
+    await apiKeyRateLimit(makeReq("key-a"), makeRes().res, jest.fn());
+    await apiKeyRateLimit(makeReq("key-b"), makeRes().res, jest.fn());
+
+    const keyA = redisIncrMock.mock.calls[0]?.[0] as string;
+    const keyB = redisIncrMock.mock.calls[1]?.[0] as string;
+    expect(keyA).toMatch(/^ratelimit:apikey:key-a:\d+$/);
+    expect(keyB).toMatch(/^ratelimit:apikey:key-b:\d+$/);
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it("fails open with warn + Sentry('warning') when INCR throws", async () => {
+    redisIncrMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const { res, headers, status } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(status).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("ratelimit_redis_unavailable"),
+    );
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      "Rate limiter fail-open: Redis unavailable",
+      expect.objectContaining({ level: "warning" }),
+    );
+    expect(headers["X-RateLimit-Limit"]).toBe("300");
+    expect(headers["X-RateLimit-Remaining"]).toBe("300");
+  });
+
+  it("fails open with Sentry('warning') when EXPIRE throws on first-hit path", async () => {
+    redisIncrMock.mockResolvedValueOnce(1);
+    redisExpireMock.mockRejectedValueOnce(new Error("redis blip"));
+    const { res } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      "Rate limiter fail-open: Redis unavailable",
+      expect.objectContaining({ level: "warning" }),
+    );
+  });
+
+  it("passes through without Sentry noise when Redis is not configured (getRedis returns null)", async () => {
+    redisInstance = null;
+    const { res, headers } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReq("key-a"), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(captureMessageMock).not.toHaveBeenCalled();
+    expect(headers["X-RateLimit-Limit"]).toBe("300");
+    expect(headers["X-RateLimit-Remaining"]).toBe("300");
+  });
+
+  it("passes through with a warning when req.apiKey is missing (defensive, no 500)", async () => {
+    const { res, status } = makeRes();
+    const next = jest.fn() as NextFunction;
+
+    await apiKeyRateLimit(makeReqWithoutApiKey(), res, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(status).not.toHaveBeenCalled();
+    expect(redisIncrMock).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("req.apiKey missing"),
+    );
+  });
+
+  it("honors API_KEY_RATE_LIMIT_PER_MINUTE env override", async () => {
+    process.env.API_KEY_RATE_LIMIT_PER_MINUTE = "42";
+    redisIncrMock.mockResolvedValueOnce(1);
+    redisExpireMock.mockResolvedValueOnce(1);
+    const { res, headers } = makeRes();
+
+    await apiKeyRateLimit(makeReq("key-a"), res, jest.fn());
+
+    expect(headers["X-RateLimit-Limit"]).toBe("42");
+    expect(headers["X-RateLimit-Remaining"]).toBe("41");
+  });
+
+  it("ignores non-numeric env overrides and falls back to the default", async () => {
+    process.env.API_KEY_RATE_LIMIT_PER_MINUTE = "not-a-number";
+    redisIncrMock.mockResolvedValueOnce(1);
+    redisExpireMock.mockResolvedValueOnce(1);
+    const { res, headers } = makeRes();
+
+    await apiKeyRateLimit(makeReq("key-a"), res, jest.fn());
+
+    expect(headers["X-RateLimit-Limit"]).toBe("300");
+  });
+
+  it("emits X-RateLimit-* headers as plain numeric strings (not NaN/undefined)", async () => {
+    redisIncrMock.mockResolvedValueOnce(1);
+    redisExpireMock.mockResolvedValueOnce(1);
+    const { res, headers } = makeRes();
+
+    await apiKeyRateLimit(makeReq("key-a"), res, jest.fn());
+
+    for (const header of ["X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"]) {
+      const value = headers[header];
+      expect(value).toBeDefined();
+      expect(value).toMatch(/^\d+$/);
+      expect(Number.isFinite(Number(value))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Adds a per-API-key rate limiter as Express middleware, Redis-backed with fixed-window counters. Not yet mounted to any route — 11c will wire it to v2 endpoints.

## What's in scope
- `apiKeyRateLimit` middleware reading `req.apiKey` (populated by Phase 11a's `apiKeyAuth`)
- Fixed-window counter: `ratelimit:apikey:{id}:{minute}` key format, 60s TTL via unconditional EXPIRE on first hit (Redis-version-portable — no EXPIRE NX)
- Default 300 req/min (configurable via `API_KEY_RATE_LIMIT_PER_MINUTE`), chosen so fresh-integration paginated catchups don't stall
- `X-RateLimit-Limit` / `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers on every response (success and 429)
- `Retry-After` header on 429 only (per HTTP spec — defer semantic)
- Fails OPEN on Redis errors: structured warn log + `Sentry.captureMessage(level='warning')`
- `getRedis() === null` path (dev/local with no Redis) passes through silently — no Sentry spam for deliberate config

## What's deferred
- Mounting the middleware to actual routes → 11c
- Usage-reading service (`getCurrentMinuteUsage`, etc) → 11d when it knows its read shape
- Per-tier limits, sliding windows, monthly quotas → future

## Testing
- Backend: 294/294 (was 281, +13 new)
- Frontend: 37/37 unchanged
- Type-check + lint clean
- Tests cover: under limit, at limit, over limit, window reset, INCR throw fail-open, EXPIRE throw fail-open, Redis null (dev), two-key isolation, missing `req.apiKey` defense, header numeric-string shape, Sentry severity

## Security note
Confirmed the existing Sentry `beforeSend` hook (from prior work) strips `x-api-key` headers before Sentry upload. No plaintext key can leak via fail-open error reporting.