### PR TITLE
Phase 11c — /api/v2/stories endpoint with cursor pagination

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/src/app.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/app.ts
@@ -13,6 +13,7 @@ import { emailsRouter } from "./routes/emails";
 import { storiesRouter } from "./routes/stories";
 import { teamsRouter } from "./routes/teams";
 import { usersRouter } from "./routes/users";
+import { v2Router } from "./routes/v2";
 
 function parseAllowedOrigins(): string[] {
   const raw =
@@ -83,9 +84,10 @@ export function createApp(): Express {
   app.use("/api/v1/teams", teamsRouter);
   app.use("/api/v1/emails", emailLimiter, emailsRouter);
 
-  // Phase 11b: apiKeyRateLimit middleware exists (src/middleware/apiKeyRateLimit.ts)
-  // but is NOT mounted here. 11c will apply it to the v2 Intelligence API
-  // routes via: router.use(apiKeyAuth, apiKeyRateLimit, ...).
+  // v2 Intelligence API: API-key authenticated, per-key rate limited.
+  // Middleware chain (apiKeyAuth → apiKeyRateLimit) is applied inside
+  // routes/v2/index.ts so it only affects v2 endpoints, not v1.
+  app.use("/api/v2", v2Router);
 
   installSentryErrorHandler(app);
 

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/v2/storiesController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/v2/storiesController.ts
@@ -1,0 +1,155 @@
+import type { NextFunction, Request, Response } from "express";
+import { and, desc, eq, gte, isNotNull, lte, lt, or } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../../db";
+import { stories } from "../../db/schema";
+import { AppError } from "../../middleware/errorHandler";
+
+// Sectors are validated at the API boundary. The schema column is a plain
+// varchar(50) with no DB-level enum constraint; codifying the list here
+// gives callers a fail-fast 400 on typos instead of a silently-empty feed,
+// and makes the enum part of the public API contract.
+export const VALID_SECTORS = ["ai", "finance", "semiconductors"] as const;
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+const querySchema = z.object({
+  sector: z.enum(VALID_SECTORS).optional(),
+  since: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .transform((v) => (v === undefined ? undefined : new Date(v))),
+  until: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .transform((v) => (v === undefined ? undefined : new Date(v))),
+  author: z.string().uuid().optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  cursor: z.string().min(1).optional(),
+});
+
+interface CursorPayload {
+  p: string; // published_at ISO
+  i: string; // story id
+}
+
+function encodeCursor(publishedAt: Date, id: string): string {
+  const json = JSON.stringify({ p: publishedAt.toISOString(), i: id });
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+function decodeCursor(raw: string): CursorPayload {
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf8");
+    const parsed: unknown = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as { p?: unknown }).p !== "string" ||
+      typeof (parsed as { i?: unknown }).i !== "string"
+    ) {
+      throw new Error("malformed");
+    }
+    const p = (parsed as { p: string }).p;
+    const i = (parsed as { i: string }).i;
+    if (Number.isNaN(Date.parse(p))) throw new Error("malformed date");
+    return { p, i };
+  } catch {
+    throw new AppError(
+      "INVALID_CURSOR",
+      "Cursor is invalid or expired. Start a new pagination from the beginning.",
+      400,
+    );
+  }
+}
+
+export async function listStoriesV2(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const parseResult = querySchema.safeParse(req.query);
+    if (!parseResult.success) {
+      throw new AppError(
+        "INVALID_QUERY",
+        "Invalid query parameters",
+        400,
+        parseResult.error.flatten(),
+      );
+    }
+    const params = parseResult.data;
+
+    const cursor = params.cursor === undefined ? undefined : decodeCursor(params.cursor);
+
+    // v2 stories API only surfaces published content. Drafts (published_at
+    // IS NULL) are excluded from every response regardless of caller filters.
+    const conditions = [isNotNull(stories.publishedAt)];
+    if (params.sector) conditions.push(eq(stories.sector, params.sector));
+    if (params.since) conditions.push(gte(stories.publishedAt, params.since));
+    if (params.until) conditions.push(lte(stories.publishedAt, params.until));
+    if (params.author) conditions.push(eq(stories.authorId, params.author));
+    if (cursor) {
+      // Keyset pagination tuple: (published_at, id) < (cursor.p, cursor.i),
+      // expanded to an explicit OR form for Drizzle/Postgres portability.
+      // Order DESC on both columns means "less than" = "after" in the feed.
+      const cursorDate = new Date(cursor.p);
+      conditions.push(
+        or(
+          lt(stories.publishedAt, cursorDate),
+          and(eq(stories.publishedAt, cursorDate), lt(stories.id, cursor.i)),
+        )!,
+      );
+    }
+
+    // Fetch one extra row to determine has_more without a separate COUNT.
+    const rows = await db
+      .select({
+        id: stories.id,
+        headline: stories.headline,
+        // v2 API exposes `context` as "summary" — the schema column is named
+        // "context" for historical reasons but semantically represents the
+        // story body/description. If a dedicated summary column is added
+        // later, swap the source without changing the public API shape.
+        summary: stories.context,
+        url: stories.sourceUrl,
+        publishedAt: stories.publishedAt,
+        sector: stories.sector,
+      })
+      .from(stories)
+      .where(and(...conditions))
+      .orderBy(desc(stories.publishedAt), desc(stories.id))
+      .limit(params.limit + 1);
+
+    const hasMore = rows.length > params.limit;
+    const pageRows = hasMore ? rows.slice(0, params.limit) : rows;
+
+    let nextCursor: string | null = null;
+    if (hasMore) {
+      const last = pageRows[pageRows.length - 1];
+      if (last && last.publishedAt) {
+        nextCursor = encodeCursor(last.publishedAt, last.id);
+      }
+    }
+
+    res.json({
+      data: pageRows.map((r) => ({
+        id: r.id,
+        headline: r.headline,
+        summary: r.summary,
+        url: r.url,
+        published_at: r.publishedAt,
+        sector: r.sector,
+      })),
+      pagination: {
+        next_cursor: nextCursor,
+        has_more: hasMore,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/routes/v2/index.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/routes/v2/index.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { apiKeyAuth } from "../../middleware/apiKeyAuth";
+import { apiKeyRateLimit } from "../../middleware/apiKeyRateLimit";
+import { storiesV2Router } from "./stories";
+
+export const v2Router: Router = Router();
+
+// All v2 routes require API key auth followed by per-key rate limiting.
+// Order matters: apiKeyAuth populates req.apiKey; apiKeyRateLimit reads it.
+v2Router.use(apiKeyAuth, apiKeyRateLimit);
+
+v2Router.use("/stories", storiesV2Router);

--- a/OneDrive/Desktop/signal-app/backend/src/routes/v2/stories.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/routes/v2/stories.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { listStoriesV2 } from "../../controllers/v2/storiesController";
+
+export const storiesV2Router: Router = Router();
+
+storiesV2Router.get("/", listStoriesV2);

--- a/OneDrive/Desktop/signal-app/backend/tests/storiesV2.integration.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/storiesV2.integration.test.ts
@@ -1,0 +1,276 @@
+import request from "supertest";
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import { createApp } from "../src/app";
+
+const app = createApp();
+
+const API_KEY = "sgnl_live_TEST_FIXTURE_NOT_A_REAL_KEY_abcde_xyz0";
+
+function apiKeyHeader(value: string = API_KEY): [string, string] {
+  return ["X-API-Key", value];
+}
+
+function queueAuthOk(apiKeyId: string = "key-1", userId: string = "user-1"): void {
+  // apiKeyAuth select — lookup by hash, filter revoked.
+  mock.queueSelect([{ id: apiKeyId, userId, label: "ci", revokedAt: null }]);
+}
+
+function queueAuthMiss(): void {
+  mock.queueSelect([]);
+}
+
+function makeStoryRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    headline: "New frontier model released",
+    summary: "Context text explaining the story.",
+    url: "https://example.com/post",
+    publishedAt: new Date("2026-04-10T12:00:00Z"),
+    sector: "ai",
+    ...overrides,
+  };
+}
+
+describe("GET /api/v2/stories", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  describe("auth chain", () => {
+    it("returns 401 when X-API-Key header is missing", async () => {
+      const res = await request(app).get("/api/v2/stories");
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 401 when the key is unknown or revoked", async () => {
+      queueAuthMiss();
+      const res = await request(app)
+        .get("/api/v2/stories")
+        .set(...apiKeyHeader("sgnl_live_TEST_FIXTURE_UNKNOWN_KEY_abcde_xyz000"));
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 200 with a valid key", async () => {
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow()]);
+
+      const res = await request(app)
+        .get("/api/v2/stories")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+    });
+  });
+
+  describe("response shape", () => {
+    it("returns exactly id/headline/summary/url/published_at/sector fields", async () => {
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow()]);
+
+      const res = await request(app)
+        .get("/api/v2/stories")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(Object.keys(res.body.data[0]).sort()).toEqual([
+        "headline",
+        "id",
+        "published_at",
+        "sector",
+        "summary",
+        "url",
+      ]);
+      expect(res.body.pagination).toMatchObject({
+        next_cursor: null,
+        has_more: false,
+      });
+    });
+  });
+
+  describe("filters", () => {
+    it("accepts a valid sector filter", async () => {
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow({ sector: "finance" })]);
+
+      const res = await request(app)
+        .get("/api/v2/stories?sector=finance")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data[0].sector).toBe("finance");
+    });
+
+    it("rejects an unknown sector with 400 INVALID_QUERY", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/stories?sector=biotech")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_QUERY");
+    });
+
+    it("accepts ISO-8601 since/until datetimes", async () => {
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow()]);
+
+      const res = await request(app)
+        .get(
+          "/api/v2/stories?since=2026-04-01T00:00:00Z&until=2026-04-30T00:00:00Z",
+        )
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects a non-ISO since value", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/stories?since=yesterday")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_QUERY");
+    });
+
+    it("accepts a UUID author filter", async () => {
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow()]);
+
+      const res = await request(app)
+        .get("/api/v2/stories?author=22222222-2222-2222-2222-222222222222")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects a non-UUID author", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/stories?author=not-a-uuid")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_QUERY");
+    });
+
+    it("rejects limit=0 (below min)", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/stories?limit=0")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_QUERY");
+    });
+
+    it("rejects limit above MAX_LIMIT (100)", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/stories?limit=500")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_QUERY");
+    });
+  });
+
+  describe("pagination", () => {
+    it("sets has_more=false and next_cursor=null when rows < limit", async () => {
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow(), makeStoryRow({ id: "22222222-2222-2222-2222-222222222222" })]);
+
+      const res = await request(app)
+        .get("/api/v2/stories?limit=50")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.pagination.has_more).toBe(false);
+      expect(res.body.pagination.next_cursor).toBeNull();
+    });
+
+    it("sets has_more=true and emits a cursor when rows > limit", async () => {
+      queueAuthOk();
+      // limit=2 → controller fetches 3; slice to 2, signal has_more=true.
+      mock.queueSelect([
+        makeStoryRow({ id: "11111111-1111-1111-1111-111111111111" }),
+        makeStoryRow({ id: "22222222-2222-2222-2222-222222222222" }),
+        makeStoryRow({ id: "33333333-3333-3333-3333-333333333333" }),
+      ]);
+
+      const res = await request(app)
+        .get("/api/v2/stories?limit=2")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.pagination.has_more).toBe(true);
+      expect(res.body.pagination.next_cursor).toEqual(expect.any(String));
+      expect(res.body.pagination.next_cursor.length).toBeGreaterThan(0);
+    });
+
+    it("accepts a valid cursor emitted from a previous page", async () => {
+      queueAuthOk();
+      mock.queueSelect([
+        makeStoryRow({ id: "11111111-1111-1111-1111-111111111111" }),
+        makeStoryRow({ id: "22222222-2222-2222-2222-222222222222" }),
+        makeStoryRow({ id: "33333333-3333-3333-3333-333333333333" }),
+      ]);
+
+      const first = await request(app)
+        .get("/api/v2/stories?limit=2")
+        .set(...apiKeyHeader());
+      expect(first.status).toBe(200);
+      const cursor = first.body.pagination.next_cursor as string;
+
+      queueAuthOk();
+      mock.queueSelect([makeStoryRow({ id: "33333333-3333-3333-3333-333333333333" })]);
+
+      const second = await request(app)
+        .get(`/api/v2/stories?limit=2&cursor=${encodeURIComponent(cursor)}`)
+        .set(...apiKeyHeader());
+
+      expect(second.status).toBe(200);
+      expect(second.body.data).toHaveLength(1);
+      expect(second.body.pagination.has_more).toBe(false);
+      expect(second.body.pagination.next_cursor).toBeNull();
+    });
+
+    it("rejects a malformed cursor with 400 INVALID_CURSOR", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/stories?cursor=not-a-real-cursor")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_CURSOR");
+    });
+
+    it("rejects a base64url-but-not-JSON cursor with 400 INVALID_CURSOR", async () => {
+      queueAuthOk();
+      const garbage = Buffer.from("not json at all", "utf8").toString("base64url");
+      const res = await request(app)
+        .get(`/api/v2/stories?cursor=${garbage}`)
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_CURSOR");
+    });
+  });
+});


### PR DESCRIPTION
Ships the first user-facing v2 API endpoint. Mounts `apiKeyAuth` + `apiKeyRateLimit` to a real route for the first time — all of Phase 11's infrastructure (keys, auth, rate limiting) now has a working surface.

## What's in scope
- `GET /api/v2/stories` endpoint, cursor-paginated
- v2 router at `/api/v2` with `apiKeyAuth` → `apiKeyRateLimit` middleware chain
- Filters: `sector`, `since`, `until`, `author`, `limit`, `cursor`
- Response shape: `{ data: [6 fields per story], pagination: { next_cursor, has_more } }`
- Always excludes unpublished stories (`published_at IS NULL`)
- Sector enum validated at API boundary: `ai`, `finance`, `semiconductors`

## Schema reconciliation
Prompt assumed fields/types that didn't match the actual schema. Resolved during recon:
- `summary` (prompt) → `context` column aliased at response layer
- `sector` enum validated in code (DB column is `varchar(50)`, not enum)
- `url` (prompt) ← `source_url` column, renamed in projection
- `writer` (prompt) → `author` query param, to match v1's user-facing `author: {id, name, bio}` shape

## Testing
- Backend: 311/311 (was 294, +17 new)
- Frontend: 37/37 unchanged
- Type-check + lint clean
- 17 tests cover: auth chain, response shape, filter validation, cursor round-trip, malformed cursor handling