### PR TITLE
Phase 4.5: seed production stories table with curated content

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/package.json
+++ b/OneDrive/Desktop/signal-app/backend/package.json
@@ -16,6 +16,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:seed": "ts-node src/db/seed.ts",
+    "seed:stories": "ts-node src/scripts/seedStories.ts",
     "send-digest-now": "ts-node src/scripts/sendDigestNow.ts",
     "smoke": "ts-node src/scripts/smokeTest.ts"
   },

--- a/OneDrive/Desktop/signal-app/backend/seed-data/stories.json
+++ b/OneDrive/Desktop/signal-app/backend/seed-data/stories.json
@@ -1,0 +1,312 @@
+{
+  "writers_seed": [
+    {
+      "placeholder_id": "SIGNAL_EDITORIAL",
+      "name": "SIGNAL Editorial",
+      "slug": "signal-editorial",
+      "bio": "SIGNAL's editorial desk. Analysis and commentary for professionals in AI, Finance, and Semiconductors."
+    }
+  ],
+  "stories": [
+    {
+      "sector": "ai",
+      "headline": "OpenAI closes record $122B round at $852B valuation",
+      "context": "OpenAI closed its largest-ever funding round on March 31, raising $122B at an $852B post-money valuation. Amazon led with $50B (a $35B tranche contingent on IPO or AGI), with Nvidia and SoftBank each adding $30B. The round opened a $3B slice to retail investors through bank channels — the first time a frontier lab has extended pre-IPO access that way.",
+      "why_it_matters": "The raise cements OpenAI as the best-funded private company in history and sets the stage for a late-2026 IPO. The more consequential read is structural: AGI and public-listing milestones are now embedded as contractual triggers in the cap table, turning roadmap promises into enforceable deal terms.",
+      "why_it_matters_template": {
+        "ai": "The round isn't really about OpenAI — it's about who ends up owning the compute layer underneath every frontier lab. Amazon's $35B contingent tranche tied to AGI or IPO is the tell: this is strategic positioning dressed as financing, and it locks OpenAI into AWS-adjacent infrastructure in ways that will shape model economics for years. Anyone building on frontier APIs should assume pricing and availability decisions increasingly run through a three-way negotiation between OpenAI, its cloud partners, and its chip suppliers — not OpenAI alone.",
+        "finance": "$852B private, with a $3B retail tranche through bank channels and ARK ETF inclusion on the same day — this is IPO bookbuilding dressed as a late-stage round. The contingent Amazon tranche is the structure to watch: $35B that clears only on AGI or public listing functions as a soft deadline the market will price into comps for Anthropic, xAI, and every other private AI valuation through year-end. Expect the \"is this round real cash or circular financing\" debate to define AI diligence in Q2.",
+        "semiconductors": "Follow the compute commitments, not the headline. OpenAI just bought 2GW of AWS Trainium capacity, 3GW of Nvidia inference, and 2GW of Vera Rubin training — multi-gigawatt buckets that bind the next two node cycles at TSMC and the HBM roadmaps at SK Hynix and Samsung. If you're modeling advanced-node capacity through 2027, this round just removed whatever slack you were assuming in the allocation pool."
+      },
+      "source_url": "https://www.cnbc.com/2026/03/31/openai-funding-round-ipo.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-03-31T12:00:00Z"
+    },
+    {
+      "sector": "ai",
+      "headline": "Anthropic declines $800B-valuation term sheets — for now",
+      "context": "Bloomberg reported on April 14 that Anthropic has received multiple VC offers valuing the company at roughly $800B, more than double the $350B pre-money from its February round. Anthropic has so far declined. Annualized revenue reportedly crossed $30B in early April, up from $9B at the end of 2025, with an IPO in discussion for as early as October.",
+      "why_it_matters": "A private company turning down an $800B term sheet is a rare discipline signal — Anthropic has the leverage to wait and knows it. The larger story is revenue: $30B ARR with 80% from enterprise, doubling the $1M+ customer count in two months, is a growth profile that historically hasn't existed at this scale.",
+      "why_it_matters_template": {
+        "ai": "Anthropic's posture here is the product strategy in financial form: ignore the frothy consumer-valuation game, hold pricing power on enterprise code-gen, raise only when it's structurally necessary. The 1,000+ customers at $1M+ annual spend — doubled from 500 in February — is the metric that matters, because it implies genuine workflow embedding, not eval-chasing. If you're evaluating AI vendors, the read is that Anthropic has enough runway to not chase quarterly feature parity with OpenAI and can afford to underinvest in the categories (video, voice, consumer) where it's already decided not to compete.",
+        "finance": "$800B private with an October IPO in discussion would slot Anthropic behind only SpaceX in US pre-IPO valuation history. The math that makes it plausible rather than absurd: revenue went from $1B to $30B annualized in fifteen months, ~1,400% YoY, with 80% enterprise mix and positive cash flow projected for 2028 — vs. OpenAI's 2030. Watch the IPO underwriter slate (Goldman, JPM, Morgan Stanley all reportedly in) for read-through on which bank gets the lead, and expect secondary markets to keep running ahead of primary — Anthropic's Caplight mark is already near $688B.",
+        "semiconductors": "Don't let the valuation headline distract from the compute footprint. Anthropic has committed $50B to its own data centers, $30B to Microsoft cloud, and multiple billions annually to AWS — and revenue growing this fast means the infrastructure buildout isn't slowing down. For advanced-node and HBM allocation, the useful question isn't whether Anthropic raises at $800B; it's whether the frontier-lab duopoly (OpenAI + Anthropic) now absorbs enough of 2026-27 capacity that everyone else — hyperscaler custom silicon programs included — gets rationed."
+      },
+      "source_url": "https://www.bloomberg.com/news/articles/2026-04-14/anthropic-attracts-investor-offers-at-a-800-billion-valuation",
+      "source_name": "Bloomberg",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-14T13:00:00Z"
+    },
+    {
+      "sector": "ai",
+      "headline": "Meta ships Muse Spark, its first major model under Alexandr Wang",
+      "context": "Meta unveiled Muse Spark on April 8, its first frontier model since the $14.3B Scale AI acquisition that brought Alexandr Wang in as head of Meta Superintelligence Labs nine months ago. The model is proprietary — a departure from the Llama open-source track — with Meta saying it \"hopes to open-source future versions.\" 2026 AI capex is guided at $115–135B, nearly twice last year's.",
+      "why_it_matters": "The Wang acquisition was Meta's expensive admission that Llama's trajectory wasn't going to close the frontier gap. Muse Spark's proprietary license — a break from the open-source identity Zuckerberg spent two years building around Llama — is the more consequential signal than the model itself.",
+      "why_it_matters_template": {
+        "ai": "Muse Spark is Meta choosing proprietary over open-weight after years of the opposite positioning — and the \"hope to open-source future versions\" hedge tells you they haven't fully committed to the pivot either. The model itself will get judged on benchmarks, but the strategic bet is that Wang's team can re-tool the entire stack faster than frontier labs can keep pulling away. If Muse Spark lands as merely competitive with Claude Sonnet 4.6 and GPT-5.4 — not leading — then Meta's moat becomes distribution (WhatsApp, Instagram, Ray-Ban) rather than model quality, which is a different company than the one Zuckerberg has been pitching to investors.",
+        "finance": "Meta just told the Street it's spending $115–135B on AI in 2026 — roughly double 2025 capex — and Muse Spark is the first deliverable that justifies it. The capex-to-revenue ratio is now the central Meta question: if Muse Spark underperforms on enterprise adoption, the 2027 guidance call gets brutal. The Wang hire at $14.3B looks reasonable only if Meta Superintelligence Labs can turn custom silicon (MTIA) plus proprietary models into differentiated margin, not just expensive parity.",
+        "semiconductors": "Meta's $115–135B capex guide is largely a semiconductor story — MTIA custom silicon, Nvidia GB200/300 deployments, and the data-center buildout to house them. Muse Spark being proprietary rather than open-weight matters because it lets Meta optimize the model specifically for its own silicon without leaking architectural advantages to competitors. For the custom-ASIC ecosystem (Broadcom, Marvell), Meta is now the reference customer showing that vertical model-silicon integration can close the Nvidia gap enough to justify the investment."
+      },
+      "source_url": "https://www.cnbc.com/2026/04/08/meta-debuts-first-major-ai-model-since-14-billion-deal-to-bring-in-alexandr-wang.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-08T14:00:00Z"
+    },
+    {
+      "sector": "ai",
+      "headline": "PwC: AI's economic gains concentrating, with 20% of firms capturing 74%",
+      "context": "PwC released its 2026 AI Performance Study on April 13, based on a survey of 1,217 senior executives across 25 sectors. The top finding: 74% of AI's measurable economic value is captured by the top 20% of companies. Leaders are 2.8x more likely than peers to automate decisions without human review and 1.9x more likely to run AI in fully autonomous modes.",
+      "why_it_matters": "Most \"AI divide\" framing has been directional hand-waving; this is the first serious attempt to quantify it. The 2.8x gap in autonomous-decision deployment is the number to sit with — it suggests the leader-laggard spread is widening, not closing, even as tooling gets cheaper.",
+      "why_it_matters_template": {
+        "ai": "The interesting finding isn't the 74/20 concentration — that's the usual Pareto shape. It's that leaders are pursuing growth through industry-convergence opportunities, not just internal efficiency gains. That reframes the AI-ROI conversation away from \"how much cost did you take out\" toward \"what new revenue did the technology enable that didn't exist before.\" If your AI roadmap is still dominated by support-ticket deflection and meeting-summary tools, you're playing the laggard game.",
+        "finance": "The study is a useful dataset for anyone underwriting AI-exposure at the enterprise level: the gap between AI-leading companies and their industry medians is widening, which means public-equity AI beneficiaries should be increasingly easy to separate from AI poseurs. Watch for this framing to surface in Q2 earnings calls — expect CFOs at the \"leader\" cohort to start citing AI-attributable revenue as a KPI, while laggards will continue reporting cost savings that never quite show up in margins. For allocators, the concentration pattern suggests AI exposure should be stock-picked at the industry-leader level, not spread across sector ETFs.",
+        "semiconductors": "Enterprise AI demand is bifurcating faster than aggregate deployment numbers suggest. The 20% of companies capturing 74% of value are the ones running multi-agent, self-optimizing systems — which translates directly to token-per-query growth, context-window expansion, and sustained inference-compute demand. For chip and memory suppliers, this means aggregate enterprise AI spend understates the concentration of compute consumption; hyperscaler allocations to a handful of enterprise flagship customers may matter more than broad adoption curves."
+      },
+      "source_url": "https://www.pwc.com/gx/en/news-room/press-releases/2026/pwc-2026-ai-performance-study.html",
+      "source_name": "PwC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-13T08:00:00Z"
+    },
+    {
+      "sector": "ai",
+      "headline": "Claude Mythos Preview becomes HumanX centerpiece as Anthropic's focus bet pays off",
+      "context": "Anthropic's Claude Mythos Preview — a cybersecurity-focused model limited to ~50 enterprise customers — dominated discussion at the HumanX conference the week of April 7. Executives interviewed credited Anthropic's product discipline (no video, no voice, code-gen only) as the reason enterprise buyers are standardizing on Claude. The subplot: Chinese open-weight models (GLM-5.1, Kimi K2.5, Qwen 3.5) now dominate public benchmarks, with US builders including Cursor and Airbnb depending on them.",
+      "why_it_matters": "Two narratives are colliding. Anthropic is showing that narrow product focus wins enterprise contracts, while Chinese open-weight models are quietly winning the underlying benchmarks — meaning the \"who leads AI\" question increasingly has different answers depending on whether you measure revenue or capability.",
+      "why_it_matters_template": {
+        "ai": "Anthropic's \"solve code gen, ignore everything else\" is the most durable product strategy in frontier AI right now, and HumanX was the week it became consensus. The counter-signal worth sitting with: US builders are routing work to Chinese open-weight models because the benchmark gap matters operationally, not just academically. The practical takeaway for anyone choosing an AI stack is that \"best model\" and \"best vendor\" are diverging — and Anthropic is betting enterprise buyers care more about the second than the first.",
+        "finance": "The HumanX read-through is that enterprise AI spend is consolidating toward Anthropic faster than market-share data has caught up to — Ramp data already shows Anthropic at 30.6% enterprise spend in March, up 6.3 points in one month, while OpenAI dropped from 46% to 35.2%. If that trajectory holds into Q3, the Anthropic IPO will price against a different narrative than the \"OpenAI's smaller rival\" framing analysts are still using. The Chinese open-weight subplot is also an emerging geopolitical risk factor for any portfolio company running production workloads on Kimi or Qwen.",
+        "semiconductors": "Claude Mythos Preview's cybersecurity focus matters for chip demand less because of the model itself and more because of what it implies: Anthropic is moving toward specialized, high-value enterprise models rather than single-model-fits-all, which means per-customer inference compute stays high and sticky. The Chinese open-weight story is the real semi read — if Kimi, GLM, and Qwen continue winning benchmarks, demand for Chinese-accessible compute (including whatever H200 volumes clear export review) stays structurally strong regardless of US policy posture."
+      },
+      "source_url": "https://www.cnbc.com/2026/04/11/vibe-check-from-ai-industry-humanx-anthropic-is-talk-of-the-town.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-11T15:00:00Z"
+    },
+    {
+      "sector": "ai",
+      "headline": "Meta commits 1GW to Broadcom custom silicon, extends MTIA partnership through 2029",
+      "context": "Meta and Broadcom announced an expanded multi-year partnership on April 14, covering the next several generations of Meta's MTIA chips and Broadcom's Ethernet networking through 2029. The initial commitment is over 1GW of compute capacity. Broadcom CEO Hock Tan will leave Meta's board and shift to an advisory role on custom silicon — a governance move that signals how strategic the deal has become.",
+      "why_it_matters": "Meta is spending up to $135B on AI this year and has now announced chip commitments across Nvidia, AMD, Arm, and Broadcom — the Broadcom piece is the bet on proprietary silicon that Meta designs itself. Hock Tan stepping off the board removes a conflict-of-interest overhang and clears the way for Broadcom to sell the same architecture approach to other hyperscalers.",
+      "why_it_matters_template": {
+        "ai": "Meta is running a portfolio strategy across every tier of the AI stack — Nvidia for peak capability, AMD and Arm for alternatives, Broadcom for the custom silicon Meta owns end-to-end. The 1GW commitment is the floor, not the ceiling; Meta has already telegraphed MTIA 400, 450, and 500 generations through 2027. For anyone benchmarking model training economics, the read is that Meta believes it can close enough of the Nvidia performance gap on inference and recommendation workloads that the TCO math flips — and if Meta's right, every other hyperscaler's custom-silicon roadmap gets pulled forward.",
+        "finance": "Broadcom is up 10% YTD vs 2% for the S&P 500, and this deal is the reason — it cements AVGO as the default custom-silicon partner for hyperscalers who don't want to buy Nvidia's margin. Hock Tan leaving Meta's board isn't incidental; it removes the governance constraint that was limiting Broadcom's ability to pursue parallel deals with Google, Microsoft, and anyone else racing to custom ASICs. The Meta-Broadcom deal through 2029 also anchors AVGO's revenue visibility through the next two guidance cycles — expect Broadcom multiple expansion to continue outpacing Nvidia as the custom-silicon narrative matures.",
+        "semiconductors": "This is the deal that formalizes the custom-ASIC thesis for the AI era: hyperscalers moving inference and recommendation workloads to proprietary silicon, with Broadcom as the design and networking partner. The technical signal is the XPU platform plus Tomahawk 6 / Jericho 4 / 800G AI NIC stack — Meta isn't just buying chips, it's buying an entire rack-scale architecture. For the broader semi supply chain, this reinforces TSMC as the obvious winner (Broadcom manufactures there), Nvidia as still-dominant-but-squeezed on the margin, and the advanced-packaging bottleneck as the next constraint that matters more than raw wafer capacity."
+      },
+      "source_url": "https://www.cnbc.com/2026/04/14/meta-commits-to-one-gigawatt-of-custom-chips-with-broadcom-as-hock-tan-agrees-to-leave-board.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-14T16:00:00Z"
+    },
+    {
+      "sector": "ai",
+      "headline": "OpenAI's $3B retail tranche signals IPO on-ramp via bank channels",
+      "context": "$3B of OpenAI's $122B round came from individual investors routed through bank channels — the first time a frontier AI lab has extended pre-IPO access this way. OpenAI was simultaneously added to several ARK Invest ETFs, broadening public-market exposure to the company ahead of its expected IPO. The company also expanded its revolving credit facility to $4.7B with support from top global banks.",
+      "why_it_matters": "The retail tranche and ARK inclusion are IPO bookbuilding moves more than financing moves. When a company opens pre-IPO access through retail banks and lands in public-market ETFs on the same day, the public listing is weeks to months away, not quarters.",
+      "why_it_matters_template": {
+        "ai": "OpenAI is building its public-market narrative in real time, and the retail tranche is the tell. The practical consequence for builders is pricing power — once OpenAI trades as a public equity comp, every quarterly call will be evaluated on margin expansion, which constrains how aggressively OpenAI can cut API prices to compete with Anthropic, Gemini, or the open-weight pack. Expect API price floors to stabilize rather than race-to-zero through 2027, and plan vendor diversification accordingly.",
+        "finance": "This is late-stage financing engineered as an IPO warmup — ARK ETF inclusion plus retail bank-channel access plus a $4.7B revolver from global banks is the exact choreography you run when a Q4 public listing is the plan. The interesting consequence is precedent: if OpenAI's retail tranche clears without friction, expect Anthropic's rumored October IPO (and whatever SpaceX, Stripe, or Databricks do next) to use the same playbook. For allocators, the pre-IPO retail access game is about to become a structural feature of late-stage tech financing rather than a one-off experiment.",
+        "semiconductors": "The semi-adjacent signal is in the $4.7B revolver — OpenAI is stacking liquidity across equity, contingent tranches, credit facilities, and retail channels simultaneously because the compute bill requires it. The 3GW of Nvidia inference, 2GW of Vera Rubin training, and 2GW of AWS Trainium capacity that OpenAI committed in this round are already baked into the next two years of TSMC, SK Hynix, and Samsung order books. If you're modeling semi capex cycles, treat OpenAI's balance sheet as a binding input — the financing structure is what unlocks the allocation."
+      },
+      "source_url": "https://techcrunch.com/2026/03/31/openai-not-yet-public-raises-3b-from-retail-investors-in-monster-122b-fund-raise/",
+      "source_name": "TechCrunch",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-03-31T18:00:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "Fed holds rates, sees one cut in 2026 as Iran oil shock complicates the path",
+      "context": "The FOMC voted 11-1 on March 18 to hold the federal funds rate at 3.5–3.75%, with the median dot plot showing one cut in 2026 and another in 2027. Officials raised their 2026 inflation forecast to 2.7% on both headline and core PCE, citing the Iran-related oil shock. Powell's term as Fed Chair expires May 15, making the next few meetings the last of his tenure.",
+      "why_it_matters": "The Fed is threading a narrower needle than a single rate cut suggests — inflation above target, labor softening, and an oil shock complicating both sides of the dual mandate. The real question is Powell's successor; whoever takes over in May inherits this mess.",
+      "why_it_matters_template": {
+        "ai": "Rate-path uncertainty is now a direct input to AI capex math. Every frontier lab raising mega-rounds this year is implicitly borrowing against a lower-rate world that may not arrive as fast as bulls expect. If the Fed holds longer than one cut in 2026, Anthropic's and OpenAI's compute-financing deals — especially the contingent tranches tied to AGI or IPO milestones — get repriced. Any AI startup burning cash on training runs should sit with the possibility that late-2026 fundraising rounds come in flatter than the current momentum implies.",
+        "finance": "The 11-1 vote masks a wider dispersion than the Fed has seen in years — at least one FOMC member wants four cuts in 2026, while others are flat. That dispersion plus Powell's May 15 exit means the next three months of Fed communication will be unusually thin; markets should discount Fed-speak more than usual until the succession is resolved. The playable read: front-end Treasuries remain the expression for \"rates stay higher for longer\" scenarios, and any meaningful Iran-war de-escalation is the asymmetric catalyst that unlocks the September cut markets were pricing before the shock.",
+        "semiconductors": "The Fed's hold is background noise for most semi names — demand is structural, not rate-sensitive — but it matters for the data-center buildout cadence. $40B+ leveraged deals like Aligned Data Centers priced on a lower-rates assumption; if the Fed delivers only one 2026 cut, refinancing those deals in 2027-28 gets more expensive and the pace of new DC LBO announcements likely moderates. For semi capex timing, rate uncertainty matters less for TSMC or ASML than for the hyperscaler customers who ultimately fund the chips."
+      },
+      "source_url": "https://www.cnbc.com/2026/03/18/fed-interest-rate-decision-march-2026.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-03-18T18:00:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "Goldman Q1 sets equities-trading record, IB fees surge 48% — but stock falls on the tape",
+      "context": "Goldman Sachs reported Q1 2026 revenue of $17.23B and EPS of $17.55, beating consensus of $16.47. Equities trading hit a record $5.33B, up 27% YoY, while investment banking fees rose 48%. The stock fell on the day as the market absorbed news of a US naval blockade of Iranian ports.",
+      "why_it_matters": "This is a beat-and-lower quarter in reverse — record execution, forward uncertainty. The 48% IB fee surge validates the dealmaking rebound thesis that analysts have been pricing since late 2025; the stock reaction validates that the macro tape now matters more than any single print.",
+      "why_it_matters_template": {
+        "ai": "The Goldman quarter is a proxy for how the AI financing flywheel is showing up in bank P&Ls. Record equities trading + 48% IB fees reflects the mega-rounds (OpenAI, Anthropic, xAI), the IPO pipeline (Anthropic rumored Q4), and the PE-backed AI-infrastructure LBOs that bankers are now underwriting at scale. If the AI capital cycle slows in H2 — whether from a rate reset, a model-progress disappointment, or geopolitical escalation — Goldman's 2026 is the high watermark, not the run rate. Worth watching which banks win the Anthropic mandate.",
+        "finance": "Goldman's record quarter plus the negative stock reaction is the cleanest signal yet that Q1 2026 earnings season rewards forward guidance over backward execution. With Iran risk live and the Fed path uncertain, the 48% IB fee growth is being discounted faster than it was 18 months ago — which implies Q2 estimates need to come down across the banking cohort or multiples get re-rated. The sector-level read: long the advisory and capital-markets names with 2027 visibility (Goldman, Morgan Stanley), cautious on the NII-dependent commercial banks (JPM cut its 2026 NII guide by $1.5B the next day).",
+        "semiconductors": "Bank earnings matter for semi mainly as an indirect signal on the AI capital cycle funding chip buildouts. Goldman's 48% IB fee surge and record equities quarter confirm the mega-round and IPO activity that ultimately flows into TSMC, SK Hynix, and ASML order books — if bank dealmaking moderates in H2, expect a lagged effect on semi capex announcements six to nine months later."
+      },
+      "source_url": "https://www.sec.gov/Archives/edgar/data/886982/000088698226000096/a1q26gsearningsresults.htm",
+      "source_name": "Goldman Sachs (SEC 8-K)",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-13T11:30:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "JPMorgan beats Q1 on IB and trading, cuts full-year NII guidance",
+      "context": "JPMorgan reported Q1 2026 EPS of $5.94 on revenue of $50.54B, beating consensus of $5.45 and $49.17B respectively. Fixed income trading rose 21% to $7.08B and IB revenue climbed 28%. But the bank lowered 2026 net interest income guidance from $104.5B to $103B, citing slower loan growth and rate dynamics. Dimon's statement flagged an \"increasingly complex set of risks\" — geopolitical, fiscal, energy, trade.",
+      "why_it_matters": "JPMorgan's Q1 is the cleanest framing of the 2026 bank setup: trading and IB are carrying the quarter, but the NII engine that powered 2023-24 is throttling back. Dimon's risk language is the more durable signal — when JPM starts hedging guidance, the rest of the sector follows within two quarters.",
+      "why_it_matters_template": {
+        "ai": "JPMorgan's 28% IB revenue growth is partly AI-deal flow — OpenAI's $122B round, Anthropic's expected IPO, the Broadcom-Meta adjacent transactions all generate advisory fees. More consequentially, Dimon is one of the CEOs most actively positioning his bank as an AI-first institution; the bank's internal AI deployment data will increasingly become a competitive signal in its own right. If JPM Q2 earnings start breaking out AI-attributable productivity or revenue, expect every other money-center CFO to be forced into the same disclosure.",
+        "finance": "The NII guide cut is the Q1 story, not the beat. $1.5B off full-year NII at JPMorgan scale means loan demand is softer than the resilient-consumer narrative suggests, and rate-cut delays are starting to bite even at the largest commercial balance sheet in the world. The trading strength — fixed income +21%, IB +28% — is volatility-driven (Iran, Fed uncertainty, Middle East energy flows) and not obviously repeatable. Expect analyst Q2 models to compress NII estimates across the sector within two weeks and bring the regional-bank downgrades that have been waiting for a catalyst.",
+        "semiconductors": "The signal worth extracting from JPM's quarter is Dimon's risk framing — \"geopolitical tensions, energy price volatility, trade uncertainty, elevated asset prices\" — which is the same list every semi CEO is navigating. Expect semi guidance language to echo Dimon's caution tone in the next two weeks of chip earnings, even as underlying AI demand stays structurally strong. The gap between tone and fundamentals creates trading setups for names that guide conservatively but deliver on the backlog."
+      },
+      "source_url": "https://www.cnbc.com/2026/04/14/jpmorgan-chase-jpm-earnings-1q-2026.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-14T11:30:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "SpaceX absorbs xAI at $1.25T combined valuation, teeing up mid-2026 IPO",
+      "context": "SpaceX announced on February 2 that it was acquiring xAI in an all-stock transaction, with the combined entity valued at $1.25T (SpaceX at $1T, xAI at $250B). The share exchange converts each xAI share into 0.1433 SpaceX shares. The merger consolidates Musk's two cash-burning AI and aerospace plays ahead of a reported mid-2026 SpaceX IPO targeting a $1.75T valuation and up to $80B raised.",
+      "why_it_matters": "This isn't a PE exit — it's an internal Musk reorganization that converts xAI's $230B-range valuation into SpaceX stock. The real liquidity event is the SpaceX IPO, which would be the largest public listing in history if it prices anywhere near the $1.75T target.",
+      "why_it_matters_template": {
+        "ai": "The strategic logic is clean: xAI was burning ~$1B per month with no obvious path to close the gap with Anthropic or OpenAI, and SpaceX's Starlink cash flow plus the space-based-data-center narrative gives xAI room to keep spending. For the broader AI field, the merger signals that the frontier-lab race is now a capex contest rather than a model-quality contest — and that companies without hyperscaler-scale balance sheets or their own funding mechanisms (Starlink revenue, SpaceX IPO proceeds) can't sustain the training-run cadence. Grok's roadmap becomes an afterthought inside a $1T-plus aerospace-AI conglomerate.",
+        "finance": "The interesting read isn't the $1.25T valuation — it's the precedent for tax-free share-exchange mergers as AI-era liquidity strategy. xAI investors (Sequoia, a16z, Valor) didn't get cash; they got SpaceX stock that they can only convert at IPO, which makes the SpaceX listing more consequential than almost any other 2026 event. The SpaceX IPO at $1.75T with $40-80B raised would anchor AI-era public-market valuations for the entire cohort behind it (Anthropic, OpenAI, Databricks, Stripe). If the IPO prices soft, the private-market AI-adjacent valuation stack gets repriced within a quarter.",
+        "semiconductors": "xAI's Colossus 2 supercluster buildout and the \"space-based data centers\" narrative in Musk's announcement translate to sustained AI infrastructure demand from a counterparty that now has Starlink cash flow backing the capex. For Nvidia specifically, xAI was already a major GB200/GB300 customer; the merger doesn't change near-term chip orders but does stabilize the counterparty risk. The more speculative read is whether space-based data centers move from science fiction to procurement line item — if SpaceX starts ordering compute-specific satellite payloads, that's a new category of semi demand entirely."
+      },
+      "source_url": "https://www.cnbc.com/2026/02/03/musk-xai-spacex-biggest-merger-ever.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-02-02T22:00:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "S&P Global: PE fundraising confidence rising, but AI adoption still early",
+      "context": "S&P Global Market Intelligence published its 2026 PE/VC Outlook on April 13, based on a February survey of global GPs and LPs. 38% expect deal volumes to rise in 2026 and 40% expect them flat. 46% anticipate a mid-tier GP \"shakeout\" — managers unable to generate distributions struggle to raise. AI adoption in PE remains early: 64% rate AI as ineffective for deal sourcing, 75% ineffective for portfolio monitoring; due diligence is the one area where 31% report meaningful integration.",
+      "why_it_matters": "The survey data matches the experience of anyone on the fundraising trail: capital is returning but only to the top of the distribution. The AI adoption finding is the more surprising one — two years into the enterprise AI wave, the industry that most loudly pitches AI to its portfolio companies hasn't meaningfully deployed it internally.",
+      "why_it_matters_template": {
+        "ai": "The 64%-ineffective-for-sourcing stat is the inverse of the narrative every AI vendor is selling to PE firms right now. Three barriers surfaced: expertise (49%), data privacy (43%), and model accuracy (38%) — the same concerns every regulated-industry buyer lists. For AI companies targeting PE as a distribution channel (which is exactly what OpenAI and Anthropic's joint-venture pitches are trying to unlock), the survey is a useful calibration: adoption is going to take longer and require more customization than vendor roadmaps assume. Sell tools that solve the expertise-gap problem, not the model-capability problem.",
+        "finance": "The 46% \"mid-tier shakeout\" finding is the most actionable data in the survey. Expect a wave of GP consolidation and strategic-secondary activity over the next 12-18 months as managers who can't raise new funds seek liquidity for existing vintages. Allocators with dry powder should see 2026-27 as a buyer's market for LP positions and continuation vehicles. Separately, the 53% citing private credit as the biggest risk is worth pairing with the Fed's hold — if rates stay higher than the cut-cycle consensus, the private-credit default cycle that's been deferred for two years finally shows up in 2026 data.",
+        "semiconductors": "PE is a meaningful buyer at the AI-infrastructure layer (data centers, semiconductor capital equipment, energy) even while it's a laggard AI adopter operationally. The $40B Aligned Data Centers LBO from October is the archetype; S&P's finding that PE investment activity is stabilizing or growing means the infrastructure-layer demand signal for semis stays intact. The separate read worth watching: 47% of GPs expect worsening inflation — if that view translates to bid-ask gaps on semi-capex-heavy targets, expect deal activity at the chip-equipment and data-center-infrastructure layer to slow before it picks back up."
+      },
+      "source_url": "https://www.prnewswire.com/news-releases/sp-global-market-intelligences-2026-private-equity-survey-shows-fundraising-confidence-rising-as-managers-pivot-to-operational-value-302740423.html",
+      "source_name": "S&P Global Market Intelligence",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-13T09:00:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "OpenAI offers PE firms 17.5% guaranteed return to unlock enterprise distribution",
+      "context": "Reuters reported in March that OpenAI is in advanced talks with TPG, Advent, Bain Capital, and Brookfield on a joint venture valued at ~$10B pre-money, with PE firms committing roughly $4B in preferred equity with a 17.5% guaranteed minimum return plus early access to OpenAI's latest models. Anthropic is pursuing a similar $1B structure with Blackstone, Hellman & Friedman, and Permira — but without a guaranteed return floor. The goal on both sides is to convert PE portfolio companies into captive distribution for enterprise AI products.",
+      "why_it_matters": "The 17.5% floor is materially above standard preferred equity terms and reveals how badly OpenAI wants PE portfolio-company distribution. The strategic question is whether PE partnership actually translates to adoption across hundreds of portfolio companies or just creates the option for it.",
+      "why_it_matters_template": {
+        "ai": "This is the clearest signal yet that frontier labs are willing to pay meaningful financial concessions to compress enterprise sales cycles. Early access to new models is the other half of the sweetener and the more interesting one — it creates a tiering of AI customers where PE-backed enterprises get capability advantages over direct buyers. For anyone evaluating AI vendors, the practical consequence is that \"latest model access\" is becoming a contract term rather than a commodity, and the gap between frontier access and generally-available capabilities will likely widen through 2026-27.",
+        "finance": "17.5% guaranteed floors on preferred equity are not standard — they're a financial concession that implies OpenAI views enterprise distribution as more valuable than the cost of the guarantee. For PE firms, the deal reduces downside while preserving upside, which is a rare structure in this vintage. The more strategic read: if the joint-venture model works, expect Anthropic to re-enter the negotiation with improved terms, and expect every other frontier lab (xAI inside SpaceX, Gemini inside Google's enterprise push) to copy the playbook. The buyout industry's relationship to AI is shifting from \"invest in vendors\" to \"become the distribution channel.\"",
+        "semiconductors": "The indirect read is that frontier-lab distribution deals of this size — $4B from the PE side, roughly $10B pre-money — free up OpenAI capital to sustain compute commitments, which in turn keeps TSMC and HBM order books stable. For the semi supply chain, every financial structure that extends OpenAI's runway is effectively a confirmation of the previously-announced chip allocations rather than new demand."
+      },
+      "source_url": "https://finance.yahoo.com/markets/stocks/articles/openai-guarantees-17-5-minimum-165757294.html",
+      "source_name": "Reuters (via Yahoo Finance)",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-03-16T16:00:00Z"
+    },
+    {
+      "sector": "finance",
+      "headline": "ASML raises 2026 guide to €36–40B, says demand \"outpacing supply\"",
+      "context": "ASML reported Q1 2026 net sales of €8.8B and net income of €2.8B, beating consensus on April 15. Full-year 2026 revenue guidance was raised to €36–40B from the previous €34–39B range. CEO Christophe Fouquet said demand for chips is \"outpacing supply\" and customers are accelerating capacity expansion plans. ASML plans to ship 60 low-NA EUV tools in 2026 (25% more than 2025) and has capacity for 80 in 2027.",
+      "why_it_matters": "ASML is the sole EUV supplier, which makes its guidance the cleanest forward signal on global advanced-chip capacity. A raised guide on accelerating customer capex plans means TSMC, Samsung, and SK Hynix are expanding faster than the previous consensus implied — and the 2027 capacity ceiling at 80 tools is now the bottleneck that matters.",
+      "why_it_matters_template": {
+        "ai": "ASML is the canary for whether AI compute supply keeps pace with demand through 2027. The raised guide is bullish for near-term capacity, but the 80-EUV-tool ceiling for 2027 is the number to sit with — it defines the upper bound on advanced-node wafer starts at TSMC, Samsung, and SK Hynix. For anyone modeling AI infrastructure, this implies HBM and advanced-logic tightness extends through 2027 regardless of how much capex hyperscalers announce. Compute allocation becomes a relationship and contract question, not a money question.",
+        "finance": "ASML's raised guide is the cleanest single data point confirming the AI capex supercycle is real and accelerating rather than plateauing. The stock setup is complicated by China exposure (19% of net system sales in Q1, down from 36% in Q4 2025) and the MATCH Act legislation that could extend restrictions to DUV tools. Expect Q2-Q3 ASML commentary to drive the semi-capital-equipment comps (Applied Materials, Lam Research, KLA) in ways that have nothing to do with their own prints. Long ASML, watch for MATCH Act progress as the asymmetric downside risk.",
+        "semiconductors": "The 60-to-80 low-NA EUV shipment trajectory is the single most important capacity number in the industry right now. Every advanced-node roadmap — TSMC N2, Samsung SF2, Intel 18A and 14A, SK Hynix 1c DRAM — gates on EUV tool availability. ASML dropping order-number disclosures starting this quarter makes forward visibility harder, but Fouquet's \"order intake continues to be very strong\" language plus the raised guide means lead times are extending. Memory mix jumped to 51% of new-tool sales in Q1 (from 30% prior), which signals HBM4/HBM4E production capacity is getting built now for 2027 deliveries."
+      },
+      "source_url": "https://www.cnbc.com/amp/2026/04/15/asml-q1-2026-earnings-report.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-15T09:00:00Z"
+    },
+    {
+      "sector": "semiconductors",
+      "headline": "TSMC Q1 profit +58%, raises 2026 revenue growth guide above 30%",
+      "context": "TSMC reported Q1 2026 revenue up 35.1% YoY and net income up 58.3%. The company raised its full-year 2026 revenue growth guide above 30%, an upgrade from prior guidance below that number. Capital spending will trend toward the upper end of the existing $56B range. The Iran conflict and Middle East tensions failed to dent AI chip demand.",
+      "why_it_matters": "TSMC's print is the cleanest confirmation of the AI demand picture the industry has had in months — profit up 58% with capex heading to the top of the range means the multi-year AI infrastructure thesis is still accelerating, not peaking.",
+      "why_it_matters_template": {
+        "ai": "TSMC's read-through is that frontier-lab compute demand isn't slowing and isn't price-sensitive. The 35% revenue growth is almost entirely AI-driven (Nvidia, Broadcom custom silicon for Meta/Google/Amazon, Anthropic and OpenAI buildouts), and TSMC raising capex to $56B means 2027-28 capacity is getting built now. For builders, the implication is that model-serving costs at the infrastructure layer should stay roughly flat through 2027 rather than compress — every incremental inference demand gets absorbed by expanding capacity rather than falling per-token prices.",
+        "finance": "TSMC beating through an active Middle East conflict is the fact pattern worth sitting with. If geopolitical stress can't dent the earnings, what can? The raised 30%+ revenue guide plus $56B capex plus 58% EPS growth is the strongest possible signal that the semi supercycle is structural, not cyclical. For allocators, TSMC at this valuation is still the cleanest pure-play AI infrastructure exposure — the ETF proxy (SMH at 11.59% TSM weight) captures the bulk of the thesis without Nvidia-specific concentration risk. Pair trade worth thinking about: long TSM, short names that guide cautiously on Middle East or China exposure but don't have TSM's demand structure.",
+        "semiconductors": "TSMC raising capex to the upper end of the $56B range is the data point that matters. It confirms the Arizona fab buildout stays on schedule, validates ASML's raised EUV shipment guide, and implies the advanced-packaging capacity (CoWoS) expansion continues aggressively through 2027. The \"conviction in the multi-year AI megatrend\" language from C.C. Wei is consistent with Nvidia's positioning. For semi-cap equipment (Applied Materials, Lam, KLA), TSMC's capex at the high end of range is the cleanest positive signal for 2026-27 bookings. The overlooked subplot is that TSMC is now Nvidia's customer more than Apple's, completing the industry leadership shift we've been watching for 18 months."
+      },
+      "source_url": "https://www.bloomberg.com/news/articles/2026-04-16/tsmc-s-profit-beats-estimates-after-war-failed-to-dent-ai-demand",
+      "source_name": "Bloomberg",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-16T07:00:00Z"
+    },
+    {
+      "sector": "semiconductors",
+      "headline": "Nvidia locks majority of TSMC's CoWoS packaging capacity as bottleneck moves downstream",
+      "context": "Nvidia has reserved the majority of TSMC's leading CoWoS advanced packaging capacity, forcing TSMC to outsource simpler packaging steps to ASE and Amkor. Advanced packaging is emerging as the next AI supply chain bottleneck as wafer capacity expands. TSMC is ramping two new packaging facilities in Taiwan and building two more in Arizona; 100% of current packaging happens in Asia, including for wafers fabricated at TSMC's Phoenix plant.",
+      "why_it_matters": "Most supply chain attention tracks wafer starts and EUV tool shipments, but advanced packaging is the less-visible bottleneck that actually gates AI accelerator delivery. Nvidia locking up CoWoS capacity means every custom silicon program at Meta, Google, Amazon, and Microsoft competes for the leftover packaging slots.",
+      "why_it_matters_template": {
+        "ai": "If you're modeling GPU availability through 2027, CoWoS capacity is now the binding constraint — not TSMC N2 wafer starts, not HBM, not Nvidia chip yields. Nvidia reserving the majority of leading-edge packaging capacity means every competing AI silicon program (Meta's MTIA, Google's TPU, Amazon's Trainium) is effectively working around the gap Nvidia leaves behind. For cloud customers, this means Nvidia GPU allocations from hyperscalers stay tight and pricing power stays with AWS, Azure, and GCP rather than shifting to the AI labs.",
+        "finance": "The CoWoS bottleneck creates a second-order trade worth sitting with. ASE Technology Holdings (ASX) and Amkor (AMKR) — the two OSAT companies picking up TSMC's outsourced packaging work — are trading as leveraged plays on the advanced packaging squeeze. ASE expects advanced packaging sales to double in 2026. For portfolio construction, these names offer pure-play exposure to a structural AI supply chain constraint without the valuation premium attached to Nvidia or TSMC. Watch the CHIPS Act packaging subsidies and the Arizona plant ramp timelines as the catalysts that could compress or extend the bottleneck.",
+        "semiconductors": "Advanced packaging — CoWoS specifically — has now displaced wafer capacity as the tightest constraint in the AI supply chain, and Nvidia's reservation of majority capacity formalizes the competitive pressure on everyone else. The Arizona packaging build-out is strategically critical: right now, 100% of TSMC Phoenix wafers still ship to Taiwan for packaging, which means the \"US-made AI chips\" narrative is incomplete until packaging localizes. For anyone modeling the semi stack, CoWoS capacity is the fulcrum variable — it determines how much of the $56B TSMC capex and the 60-tool ASML shipment cadence actually converts to deliverable accelerators."
+      },
+      "source_url": "https://www.cnbc.com/2026/04/08/tsmc-nvidia-advanced-packaging-intel.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-08T12:00:00Z"
+    },
+    {
+      "sector": "semiconductors",
+      "headline": "Intel 18A enters HVM as Apple and Nvidia explore 2028 non-core production",
+      "context": "Intel entered high-volume manufacturing on its 18A node in late January 2026, completing the \"five nodes in four years\" roadmap. Reuters, DigiTimes, and others subsequently reported Apple and Nvidia are in exploratory discussions about using Intel foundry services starting in 2028. The scope is narrower than headlines suggest: Nvidia's Feynman GPU compute die stays at TSMC N2, with Intel potentially handling I/O die and up to 25% of final packaging via EMIB. Apple talks center on entry-level M-series on 18A-P or 14A — not flagship silicon.",
+      "why_it_matters": "Intel hitting HVM on 18A is a genuine manufacturing milestone that matters on its own. The Apple/Nvidia story is softer than headlines imply — both companies are exploring non-core production for 2028 and keeping flagship chips at TSMC. Treat it as validation that Intel's foundry pitch is real enough to get evaluated, not as the end of TSMC's dominance.",
+      "why_it_matters_template": {
+        "ai": "For AI compute planning, Intel's 18A entering HVM matters less than the shape of the Apple/Nvidia interest: both companies are hedging for geopolitical risk and US-manufacturing mandates rather than choosing Intel on technical merit. Nvidia's GPU compute die stays at TSMC N2 through Feynman — that's the capability call. For anyone modeling AI accelerator supply, Intel foundry becomes a second-source option for I/O and packaging by 2028-29, not a primary path. The more consequential read is that the AI compute layer remains concentrated at TSMC, which means the TSMC-specific bottlenecks (CoWoS, N2 yields, Arizona ramp) continue to define the industry's forward capacity.",
+        "finance": "Intel's 18A HVM milestone is the strongest positive data point on an INTC turnaround thesis in years, and the stock has responded accordingly (up 18% in January alone). But the investment case requires separating the manufacturing achievement from the customer story: 18A HVM is real and Microsoft Maia 3, Amazon, and DoD design wins are confirmed; the Apple/Nvidia piece is still exploratory and framed around \"non-core\" production. The asymmetric risk is 14A — the node Intel has explicitly positioned as its foundry-customer offering — where yields and customer commitments remain uncertain. For pairs trades, long INTC on 18A execution, short on 14A delivery timeline if guidance slips.",
+        "semiconductors": "Intel 18A in HVM is the first credible Western alternative to TSMC's leading-edge node in nearly a decade, and the implications for supply chain resilience are real. RibbonFET (Intel's GAA implementation) plus PowerVia backside power delivery are genuine architectural innovations ahead of TSMC N2 in backside power specifically. But the commercial story is secondary-workload only through 2028: Nvidia Feynman I/O dies, Apple entry-level M-series, DoD secure compute. TSMC N2 remains the frontier for AI compute. The real test for Intel is 14A in 2027-28 — if it delivers on timeline with competitive yields, Intel becomes a structural second source; if it slips, 18A becomes the peak of the Gelsinger-era turnaround."
+      },
+      "source_url": "https://finance.yahoo.com/news/intel-foundry-talks-nvidia-apple-171229595.html",
+      "source_name": "Yahoo Finance",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-02-01T17:00:00Z"
+    },
+    {
+      "sector": "semiconductors",
+      "headline": "SK Hynix, Samsung post record profits, warn memory shortages extend into 2027",
+      "context": "SK Hynix posted 2025 full-year operating profit of 47.2 trillion won ($33.3B) and Samsung 43.6 trillion won ($30.5B), both records. Both companies warned on Q4 earnings calls that memory supply shortages will persist into 2027 due to cleanroom-space constraints on capacity expansion, even as they reallocate wafer capacity toward HBM for AI. SK Hynix has said 2026 HBM capacity is \"essentially sold out.\" Consumer electronics will see the deepest shortages as capacity shifts to AI infrastructure.",
+      "why_it_matters": "The memory supercycle isn't a 2026 story — it extends into 2027 because cleanroom space, not wafer technology, is the binding constraint. Record profits at both Samsung and SK Hynix confirm pricing power has shifted decisively to memory suppliers.",
+      "why_it_matters_template": {
+        "ai": "HBM capacity being sold out for 2026 means that every AI training cluster being planned right now has a memory allocation problem, not a compute problem. Google's 7th-gen TPU (8 HBM3E stacks per chip), Amazon's Trainium3 (4 stacks), and Nvidia's H200/Rubin buildouts all compete for the same constrained HBM4/HBM4E supply. For AI infrastructure teams, this means training-cluster delivery timelines should be modeled against memory availability, not GPU allocation alone. The builders winning allocation are those with multi-year pre-commitments — latecomers get rationed.",
+        "finance": "The memory supercycle is now a multi-year thesis, not a cycle-peak-debate. Record profits plus sold-out 2026 capacity plus 2027 cleanroom constraints means earnings revisions at Samsung and SK Hynix continue higher through 2026-27 regardless of macro conditions. SK Hynix is reportedly exploring a US listing — if that happens, expect a valuation re-rate as US investors access the purest AI memory play in the market. Micron (MU) is the obvious US-listed proxy, though it exited consumer memory to focus on enterprise. The sector-level trade: long memory suppliers, short consumer-electronics OEMs who can't pass memory price increases to end customers without demand destruction.",
+        "semiconductors": "The HBM capacity being sold out through 2026 with shortages extending into 2027 is the structural fact that defines the entire AI supply chain. Samsung's P5 fab doesn't come online until 2028; SK Hynix's M15X until mid-2027. Until then, capacity constraints are absolute, not negotiable. The interesting subplot: HBM revenue mix is shifting from ~55% HBM4 / 45% HBM3E in 2026 toward \"custom HBM\" — memory stacks where the logic die is tailored to specific AI accelerators (Amazon, Google). That customization adds manufacturing complexity and reinforces allocation rationing. DRAM prices up 45-50% in Q1 and 20%+ more through 2026 confirms the pricing trajectory."
+      },
+      "source_url": "https://www.datacenterdynamics.com/en/news/samsung-and-sk-hynix-post-record-profits-but-warn-memory-chip-shortages-will-likely-persist-into-2027/",
+      "source_name": "Data Center Dynamics",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-04-02T10:00:00Z"
+    },
+    {
+      "sector": "semiconductors",
+      "headline": "Nvidia to overtake Apple as TSMC's largest customer, formalizing AI-era industry shift",
+      "context": "Analyst estimates and CEO Jensen Huang's own comments confirm Nvidia will become TSMC's largest customer in 2026, displacing Apple. Nvidia's fiscal 2026 revenue is expected to grow 66% to $213B; Apple's fiscal 2025 revenue grew 6.4%. Nvidia's AI chips are physically larger and more complex than Apple's, meaning they cost more per unit. TSMC holds roughly 70% of global chip manufacturing revenue.",
+      "why_it_matters": "The customer shift at TSMC is the cleanest expression of the AI-era industry reordering. For nearly two decades, Apple defined leading-edge node priorities — now Nvidia does, and that changes what TSMC optimizes its manufacturing roadmap around.",
+      "why_it_matters_template": {
+        "ai": "Nvidia becoming TSMC's largest customer means the global leading-edge semiconductor roadmap is now optimized for AI accelerators first, mobile SoCs second. Wafer allocation, process tuning, and packaging capacity all get designed around what Nvidia needs — which benefits every AI silicon customer at TSMC (Broadcom's custom Meta chips, Google TPUs manufactured at TSMC, AMD MI300/400) but creates pressure on consumer product cycles. The read for AI capacity planning is that the infrastructure layer is now the primary customer of the world's most advanced manufacturing, and that alignment of incentives will continue accelerating capacity dedicated to AI through 2027-28.",
+        "finance": "The Nvidia-overtakes-Apple-at-TSMC milestone formalizes what the stock market has been pricing for 18 months. For anyone comparing the two companies as investment theses, the revenue delta is the punchline: Nvidia growing 66% YoY on a ~$210B base vs Apple at 6.4% growth on a similar base. The more nuanced trade is around Apple's response — Apple is reportedly in exploratory talks with Intel for entry-level M-series production starting 2028, partly to hedge geopolitical risk and partly to avoid competing with Nvidia for TSMC's best capacity. Expect the \"Apple's AI strategy\" conversation to become increasingly about supply chain positioning rather than product launches.",
+        "semiconductors": "This is the definitional moment of the AI-era semi industry: the largest chip designer at the largest foundry is now an AI company, not a consumer electronics company. The practical consequences compound across the roadmap — TSMC N2, N1.4, and future nodes will be tuned for AI accelerator requirements (large die sizes, high power density, advanced packaging integration) rather than the mobile SoC optimization that drove 5nm and 3nm. For equipment suppliers, this means tool configurations, metrology requirements, and capacity planning shift toward the physics of AI silicon. For the broader industry, it means Apple is no longer the pace-setter for leading-edge manufacturing priorities."
+      },
+      "source_url": "https://www.cnbc.com/2026/01/26/nvidia-set-to-supplant-apple-as-tsmcs-largest-customer.html",
+      "source_name": "CNBC",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2026-01-26T12:00:00Z"
+    },
+    {
+      "sector": "semiconductors",
+      "headline": "Samsung and SK Hynix lift HBM3E prices ~20% for 2026 as ASIC demand surges",
+      "context": "Reuters-originated reporting in late December 2025 revealed Samsung and SK Hynix had hiked HBM3E supply prices by roughly 20% for 2026 deliveries. Demand drivers: Nvidia H200 export approval for China (each H200 uses six HBM3E stacks), Google's 7th-gen TPU (eight stacks), and Amazon's Trainium3 (four stacks) ramping in 2026. HBM content per accelerator is rising 20-30% per generation. Analysts expect 2026 HBM revenue mix at roughly 55% HBM4 / 45% HBM3E.",
+      "why_it_matters": "A 20% price hike on components that are already sold out tells you supply-demand imbalance has moved past \"tight\" into \"binding.\" Every major AI accelerator launched in 2026 — Nvidia, Google, Amazon — uses more HBM per chip than its predecessor, which means demand scales faster than capacity expansion can match.",
+      "why_it_matters_template": {
+        "ai": "HBM content per accelerator rising 20-30% per generation is the detail that matters more than the 20% price hike. Google's 7th-gen TPU with 8 HBM3E stacks per chip vs prior generations is a structural step-up in memory intensity; Amazon Trainium3 with 4 stacks shows the same pattern. For AI compute cost modeling, this means training and inference per-chip costs are being driven up by memory as much as by logic silicon — and since memory prices are rising while logic prices are roughly flat, HBM is the line item increasingly determining accelerator economics.",
+        "finance": "The 20% HBM3E price hike for sold-out capacity is a textbook case of pricing power, and it flows directly to Samsung and SK Hynix margins. With HBM revenue mix shifting to 55/45 HBM4/HBM3E in 2026, the ASP story gets even stronger — HBM4 carries higher margin than HBM3E. The read for the memory trade: long the Korean memory duopoly through 2027, with valuation upside contingent on the SK Hynix US listing rumored in secondary press. The risk factor worth monitoring is a potential slowdown in AI capex announcements — if OpenAI, Anthropic, or Meta dial back stated compute commitments, the HBM demand curve softens quickly at these price points.",
+        "semiconductors": "HBM3E supply remaining tight through 2026 — even as Samsung and SK Hynix prioritize HBM4 ramp — is the cleanest possible signal that memory allocation, not capacity expansion, defines the near-term AI supply chain. The 20% price hike is unusual in timing: HBM3E was expected to ease as HBM4 came online, but sustained H200 demand (including China exports) and the growing base of ASIC customers (Google, Amazon) absorbed the rollover. For anyone modeling memory supply, the practical implication is that HBM generations are no longer cleanly substitutable — customers with HBM3E designs in production can't simply migrate to HBM4 mid-cycle, which means HBM3E pricing stays elevated until at least late 2026."
+      },
+      "source_url": "https://www.trendforce.com/news/2025/12/24/news-samsung-sk-hynix-reportedly-plan-20-hbm3e-price-hike-for-2026-as-nvidia-h200-asic-demand-rises/",
+      "source_name": "TrendForce",
+      "author_id": "SIGNAL_EDITORIAL",
+      "published_at": "2025-12-24T08:00:00Z"
+    }
+  ]
+}

--- a/OneDrive/Desktop/signal-app/backend/src/scripts/seedStories.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/scripts/seedStories.ts
@@ -1,0 +1,424 @@
+/* eslint-disable no-console */
+/**
+ * Seed the production `stories` table from a hand-curated JSON file.
+ *
+ * Usage:
+ *   npm run seed:stories --workspace=backend           # default path
+ *   npm run seed:stories --workspace=backend -- --dry-run
+ *   npm run seed:stories --workspace=backend -- --file=<path>
+ *   npm run seed:stories --workspace=backend -- --yes   # skip confirm (CI only)
+ *
+ * Default file: <backend>/seed-data/stories.json
+ *
+ * Behavior:
+ *   - Validates the whole file with Zod (per-item errors on failure).
+ *   - Resolves string `author_id` placeholders (e.g. "SIGNAL_EDITORIAL") to
+ *     real writer UUIDs by upserting each entry in `writers_seed`.
+ *   - Writer upsert strategy: SELECT-by-name, INSERT-if-absent. `writers` has
+ *     no unique column we can match against here (email is unique but seed
+ *     data has no email), so this races under concurrent writers — fine for
+ *     a manually-operated prod seeder with explicit confirmation.
+ *   - Story idempotency: pre-SELECT by `source_url` (no unique index exists
+ *     on that column), partition into insert/skip, then insert.
+ *   - Prints a dry-run-style summary with DATABASE_URL host/dbname and waits
+ *     for an explicit `y` before writing (unless --yes is passed).
+ *
+ * Exit codes: 0 on success or clean no-op re-run, non-zero on validation or
+ * DB failure.
+ */
+
+import "dotenv/config";
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import { eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { db, pool } from "../db";
+import * as schema from "../db/schema";
+
+const SECTORS = ["ai", "finance", "semiconductors"] as const;
+type Sector = (typeof SECTORS)[number];
+
+// ---------- Schemas ----------
+
+const WriterSeedSchema = z
+  .object({
+    placeholder_id: z.string().min(1),
+    name: z.string().min(1).max(255),
+    // `slug` is accepted but has no column in the current writers schema —
+    // silently dropped at insert time. See completion log for details.
+    slug: z.string().optional(),
+    bio: z.string().optional(),
+  })
+  .passthrough();
+
+const WhyItMattersTemplateSchema = z.object({
+  ai: z.string().min(1),
+  finance: z.string().min(1),
+  semiconductors: z.string().min(1),
+});
+
+const StorySeedSchema = z.object({
+  sector: z.enum(SECTORS),
+  headline: z.string().min(1).max(255),
+  context: z.string().min(1),
+  why_it_matters: z.string().min(1),
+  why_it_matters_template: WhyItMattersTemplateSchema,
+  source_url: z.string().url(),
+  source_name: z.string().min(1).max(255).optional(),
+  author_id: z.string().min(1),
+  published_at: z.string().datetime({ offset: true }),
+});
+
+const SeedFileSchema = z.object({
+  writers_seed: z.array(WriterSeedSchema).min(1),
+  stories: z.array(StorySeedSchema).min(1),
+});
+
+export type SeedFile = z.infer<typeof SeedFileSchema>;
+export type StorySeed = z.infer<typeof StorySeedSchema>;
+export type WriterSeed = z.infer<typeof WriterSeedSchema>;
+
+// ---------- Validation ----------
+
+export class SeedValidationError extends Error {
+  public readonly issues: string[];
+  constructor(issues: string[]) {
+    super(`Seed validation failed:\n- ${issues.join("\n- ")}`);
+    this.name = "SeedValidationError";
+    this.issues = issues;
+  }
+}
+
+interface RawShape {
+  stories?: Array<{ headline?: unknown } | undefined>;
+  writers_seed?: Array<{ placeholder_id?: unknown; name?: unknown } | undefined>;
+}
+
+function identifyIssue(raw: unknown, issuePath: Array<string | number>): string {
+  const first = issuePath[0];
+  const idx = issuePath[1];
+  if (typeof idx !== "number") return "";
+  const r = raw as RawShape | undefined;
+  if (first === "stories") {
+    const story = r?.stories?.[idx];
+    const headline = typeof story?.headline === "string" ? story.headline : "";
+    const snippet = headline ? ` headline: "${headline.slice(0, 60)}${headline.length > 60 ? "..." : ""}"` : "";
+    return ` (story ${idx + 1}${snippet ? "," : ""}${snippet})`;
+  }
+  if (first === "writers_seed") {
+    const w = r?.writers_seed?.[idx];
+    const pid = typeof w?.placeholder_id === "string" ? w.placeholder_id : "";
+    return ` (writers_seed ${idx + 1}${pid ? `, placeholder_id: ${pid}` : ""})`;
+  }
+  return "";
+}
+
+export function validateSeedFile(raw: unknown): SeedFile {
+  const result = SeedFileSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((iss) => {
+      const pathStr = iss.path.join(".");
+      const hint = identifyIssue(raw, iss.path as Array<string | number>);
+      return `${pathStr || "<root>"}${hint}: ${iss.message}`;
+    });
+    throw new SeedValidationError(issues);
+  }
+
+  // Cross-field: every author_id must resolve to a writers_seed placeholder.
+  const placeholders = new Set(result.data.writers_seed.map((w) => w.placeholder_id));
+  const crossIssues: string[] = [];
+  result.data.stories.forEach((s, i) => {
+    if (!placeholders.has(s.author_id)) {
+      crossIssues.push(
+        `stories.${i}.author_id (story ${i + 1}, headline: "${s.headline.slice(0, 60)}${s.headline.length > 60 ? "..." : ""}"): author_id "${s.author_id}" not found in writers_seed`,
+      );
+    }
+  });
+  if (crossIssues.length > 0) throw new SeedValidationError(crossIssues);
+
+  return result.data;
+}
+
+// ---------- Writer upsert ----------
+
+type Database = typeof db;
+
+export interface WriterUpsertResult {
+  id: string;
+  created: boolean;
+}
+
+export async function upsertWriter(
+  database: Database,
+  w: WriterSeed,
+): Promise<WriterUpsertResult> {
+  const existing = await database
+    .select({ id: schema.writers.id })
+    .from(schema.writers)
+    .where(eq(schema.writers.name, w.name))
+    .limit(1);
+  const first = existing[0];
+  if (first) {
+    return { id: first.id, created: false };
+  }
+  const inserted = await database
+    .insert(schema.writers)
+    .values({
+      name: w.name,
+      bio: w.bio,
+      // `slug` from the JSON is intentionally dropped — there's no matching
+      // column in the writers schema today.
+    })
+    .returning({ id: schema.writers.id });
+  const newRow = inserted[0];
+  if (!newRow) {
+    throw new Error(`Writer upsert returned no rows for "${w.name}"`);
+  }
+  return { id: newRow.id, created: true };
+}
+
+export interface WriterUpsertDetail {
+  placeholder: string;
+  name: string;
+  id: string;
+  created: boolean;
+}
+
+export interface PlaceholderMapResult {
+  map: Map<string, string>;
+  created: number;
+  matched: number;
+  details: WriterUpsertDetail[];
+}
+
+export async function buildPlaceholderMap(
+  database: Database,
+  writers: WriterSeed[],
+): Promise<PlaceholderMapResult> {
+  const map = new Map<string, string>();
+  const details: WriterUpsertDetail[] = [];
+  let created = 0;
+  let matched = 0;
+  for (const w of writers) {
+    const result = await upsertWriter(database, w);
+    map.set(w.placeholder_id, result.id);
+    if (result.created) created += 1;
+    else matched += 1;
+    details.push({ placeholder: w.placeholder_id, name: w.name, id: result.id, created: result.created });
+  }
+  return { map, created, matched, details };
+}
+
+// ---------- Story idempotency ----------
+
+export interface PartitionResult {
+  toInsert: StorySeed[];
+  toSkip: StorySeed[];
+}
+
+export async function partitionStoriesByExistence(
+  database: Database,
+  stories: StorySeed[],
+): Promise<PartitionResult> {
+  if (stories.length === 0) return { toInsert: [], toSkip: [] };
+  const urls = stories.map((s) => s.source_url);
+  const rows = await database
+    .select({ sourceUrl: schema.stories.sourceUrl })
+    .from(schema.stories)
+    .where(inArray(schema.stories.sourceUrl, urls));
+  const existing = new Set(rows.map((r) => r.sourceUrl));
+  const toInsert: StorySeed[] = [];
+  const toSkip: StorySeed[] = [];
+  for (const s of stories) {
+    if (existing.has(s.source_url)) toSkip.push(s);
+    else toInsert.push(s);
+  }
+  return { toInsert, toSkip };
+}
+
+export interface InsertOptions {
+  onProgress?: (inserted: number, total: number) => void;
+}
+
+export async function insertStoryBatch(
+  database: Database,
+  stories: StorySeed[],
+  authorMap: Map<string, string>,
+  opts: InsertOptions = {},
+): Promise<number> {
+  let inserted = 0;
+  for (const s of stories) {
+    const authorId = authorMap.get(s.author_id);
+    if (!authorId) {
+      throw new Error(
+        `Unknown author_id "${s.author_id}" (should have been caught in validation)`,
+      );
+    }
+    await database.insert(schema.stories).values({
+      sector: s.sector,
+      headline: s.headline,
+      context: s.context,
+      whyItMatters: s.why_it_matters,
+      // `why_it_matters_template` column is TEXT, not JSONB — stringify.
+      whyItMattersTemplate: JSON.stringify(s.why_it_matters_template),
+      sourceUrl: s.source_url,
+      sourceName: s.source_name,
+      authorId,
+      publishedAt: new Date(s.published_at),
+    });
+    inserted += 1;
+    if (opts.onProgress && inserted % 5 === 0) opts.onProgress(inserted, stories.length);
+  }
+  return inserted;
+}
+
+// ---------- CLI plumbing ----------
+
+function describeDbFromUrl(url: string | undefined): string {
+  if (!url) return "<DATABASE_URL unset>";
+  try {
+    const u = new URL(url);
+    const dbname = u.pathname.replace(/^\//, "") || "<no-db>";
+    return `${u.hostname}/${dbname}`;
+  } catch {
+    return "<unparsable DATABASE_URL>";
+  }
+}
+
+async function promptConfirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "y");
+    });
+  });
+}
+
+interface CliArgs {
+  dryRun: boolean;
+  yes: boolean;
+  file: string;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = {
+    dryRun: false,
+    yes: false,
+    file: path.resolve(process.cwd(), "seed-data/stories.json"),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    if (arg === "--dry-run") {
+      out.dryRun = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      out.yes = true;
+    } else if (arg.startsWith("--file=")) {
+      out.file = path.resolve(arg.slice("--file=".length));
+    } else if (arg === "--file") {
+      const next = argv[i + 1];
+      if (next) {
+        out.file = path.resolve(next);
+        i += 1;
+      }
+    }
+  }
+  return out;
+}
+
+function log(msg: string): void {
+  console.log(`[seed] ${msg}`);
+}
+
+export async function run(args: CliArgs): Promise<void> {
+  log(`starting${args.dryRun ? " (dry-run)" : ""}`);
+  log(`reading ${args.file}`);
+
+  const raw: unknown = JSON.parse(fs.readFileSync(args.file, "utf-8"));
+  log("validating...");
+  const data = validateSeedFile(raw);
+  log(`validated: ${data.writers_seed.length} writer(s), ${data.stories.length} stories`);
+
+  log("resolving writers...");
+  const { map, created, matched, details } = await buildPlaceholderMap(db, data.writers_seed);
+  for (const d of details) {
+    log(
+      `  writer ${d.created ? "inserted" : "matched "} placeholder=${d.placeholder} name="${d.name}" id=${d.id}`,
+    );
+  }
+
+  log("checking existing stories by source_url...");
+  const { toInsert, toSkip } = await partitionStoriesByExistence(db, data.stories);
+  log(`plan: ${toInsert.length} to insert, ${toSkip.length} already present (will skip)`);
+
+  if (args.dryRun) {
+    log("dry-run — no writes will be performed");
+    if (toInsert.length > 0) {
+      log("sample of stories that would be inserted (up to 3):");
+      toInsert.slice(0, 3).forEach((s, i) => {
+        log(`  ${i + 1}. [${s.sector}] ${s.headline}`);
+      });
+    }
+    log("done (dry-run)");
+    return;
+  }
+
+  const dbDesc = describeDbFromUrl(process.env.DATABASE_URL);
+  const summary =
+    `Will upsert ${data.writers_seed.length} writer(s) (created: ${created}, matched: ${matched}), ` +
+    `insert ${toInsert.length} stories (${toSkip.length} already exist and will be skipped). ` +
+    `Database: ${dbDesc}. Proceed? (y/n) `;
+
+  const confirmed = args.yes ? true : await promptConfirm(summary);
+  if (!confirmed) {
+    log("aborted by user");
+    return;
+  }
+
+  let insertedStories = 0;
+  if (toInsert.length > 0) {
+    log(`inserting ${toInsert.length} stories...`);
+    insertedStories = await insertStoryBatch(db, toInsert, map, {
+      onProgress: (n, total) => log(`  progress ${n}/${total}`),
+    });
+  }
+
+  log(
+    `done: writers (${created} created, ${matched} matched), ` +
+      `stories (${insertedStories} inserted, ${toSkip.length} skipped)`,
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  let exitCode = 0;
+  try {
+    await run(args);
+  } catch (err) {
+    exitCode = 1;
+    if (err instanceof SeedValidationError) {
+      console.error("[seed] validation failed:");
+      for (const issue of err.issues) console.error(`  - ${issue}`);
+    } else {
+      console.error("[seed] error:", err instanceof Error ? err.message : err);
+    }
+  } finally {
+    try {
+      await pool.end();
+    } catch {
+      /* ignore — may be a mocked pool in tests */
+    }
+  }
+  process.exit(exitCode);
+}
+
+// Only run when executed directly (not imported by tests).
+if (require.main === module) {
+  void main();
+}
+
+// Unused type export kept so downstream consumers/IDE can reference the
+// narrowed sector literal without re-deriving it.
+export type { Sector };

--- a/OneDrive/Desktop/signal-app/backend/tests/seedStories.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/seedStories.test.ts
@@ -1,0 +1,235 @@
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  pool: { end: async (): Promise<void> => undefined },
+}));
+
+import {
+  SeedValidationError,
+  buildPlaceholderMap,
+  insertStoryBatch,
+  partitionStoriesByExistence,
+  upsertWriter,
+  validateSeedFile,
+  type SeedFile,
+  type StorySeed,
+  type WriterSeed,
+} from "../src/scripts/seedStories";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { db } = require("../src/db") as { db: any };
+
+// ---------- Fixtures ----------
+
+function validWriter(overrides: Partial<WriterSeed> = {}): WriterSeed {
+  return {
+    placeholder_id: "SIGNAL_EDITORIAL",
+    name: "SIGNAL Editorial",
+    slug: "signal-editorial",
+    bio: "SIGNAL's editorial desk.",
+    ...overrides,
+  };
+}
+
+function validStory(overrides: Partial<StorySeed> = {}): StorySeed {
+  return {
+    sector: "ai",
+    headline: "OpenAI closes record $122B round",
+    context: "Context paragraph with real framing.",
+    why_it_matters: "Role-neutral fallback commentary.",
+    why_it_matters_template: {
+      ai: "AI-specific commentary.",
+      finance: "Finance-specific commentary.",
+      semiconductors: "Semiconductor-specific commentary.",
+    },
+    source_url: "https://example.com/article/openai-round",
+    source_name: "Example News",
+    author_id: "SIGNAL_EDITORIAL",
+    published_at: "2026-03-31T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function validFile(overrides: Partial<SeedFile> = {}): SeedFile {
+  return {
+    writers_seed: [validWriter()],
+    stories: [validStory()],
+    ...overrides,
+  };
+}
+
+// ---------- validateSeedFile ----------
+
+describe("validateSeedFile", () => {
+  it("accepts a well-formed file", () => {
+    const data = validateSeedFile(validFile());
+    expect(data.stories).toHaveLength(1);
+    expect(data.writers_seed[0]?.placeholder_id).toBe("SIGNAL_EDITORIAL");
+  });
+
+  it("rejects an invalid sector with a per-item error that names the story", () => {
+    const bad = validFile({
+      stories: [validStory({ sector: "crypto" as unknown as StorySeed["sector"] })],
+    });
+    let err: SeedValidationError | null = null;
+    try {
+      validateSeedFile(bad);
+    } catch (e) {
+      if (e instanceof SeedValidationError) err = e;
+    }
+    expect(err).not.toBeNull();
+    expect(err?.issues.length).toBeGreaterThan(0);
+    const joined = err?.issues.join("\n") ?? "";
+    expect(joined).toMatch(/stories\.0\.sector/);
+    expect(joined).toMatch(/story 1/);
+    expect(joined).toMatch(/OpenAI closes record/);
+  });
+
+  it("rejects a malformed source_url", () => {
+    const bad = validFile({
+      stories: [validStory({ source_url: "not-a-real-url" })],
+    });
+    expect(() => validateSeedFile(bad)).toThrow(SeedValidationError);
+    try {
+      validateSeedFile(bad);
+    } catch (e) {
+      if (e instanceof SeedValidationError) {
+        expect(e.issues.some((i) => i.includes("source_url"))).toBe(true);
+      }
+    }
+  });
+
+  it("rejects a non-ISO published_at", () => {
+    const bad = validFile({
+      stories: [validStory({ published_at: "yesterday" })],
+    });
+    try {
+      validateSeedFile(bad);
+      fail("expected SeedValidationError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(SeedValidationError);
+      if (e instanceof SeedValidationError) {
+        expect(e.issues.some((i) => i.includes("published_at"))).toBe(true);
+      }
+    }
+  });
+
+  it("rejects an author_id placeholder that is not in writers_seed", () => {
+    const bad = validFile({
+      stories: [validStory({ author_id: "UNKNOWN_DESK" })],
+    });
+    try {
+      validateSeedFile(bad);
+      fail("expected SeedValidationError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(SeedValidationError);
+      if (e instanceof SeedValidationError) {
+        const joined = e.issues.join("\n");
+        expect(joined).toMatch(/UNKNOWN_DESK/);
+        expect(joined).toMatch(/not found in writers_seed/);
+        expect(joined).toMatch(/headline:/);
+      }
+    }
+  });
+});
+
+// ---------- upsertWriter ----------
+
+describe("upsertWriter", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("inserts a new writer row when SELECT returns nothing", async () => {
+    mock.queueSelect([]);
+    mock.queueInsert([{ id: "new-writer-uuid" }]);
+
+    const result = await upsertWriter(db, validWriter());
+    expect(result).toEqual({ id: "new-writer-uuid", created: true });
+  });
+
+  it("returns existing id without inserting when SELECT returns a match", async () => {
+    mock.queueSelect([{ id: "existing-writer-uuid" }]);
+
+    const result = await upsertWriter(db, validWriter());
+    expect(result).toEqual({ id: "existing-writer-uuid", created: false });
+    // No insert was consumed.
+    expect(mock.state.insertResults.length).toBe(0);
+  });
+});
+
+// ---------- buildPlaceholderMap ----------
+
+describe("buildPlaceholderMap", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("maps SIGNAL_EDITORIAL to the resolved writer uuid", async () => {
+    mock.queueSelect([{ id: "resolved-uuid" }]);
+    const { map, created, matched } = await buildPlaceholderMap(db, [validWriter()]);
+    expect(map.get("SIGNAL_EDITORIAL")).toBe("resolved-uuid");
+    expect(created).toBe(0);
+    expect(matched).toBe(1);
+  });
+});
+
+// ---------- partitionStoriesByExistence ----------
+
+describe("partitionStoriesByExistence (idempotency)", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("second run with identical input inserts zero and skips all", async () => {
+    const s1 = validStory({ source_url: "https://example.com/a" });
+    const s2 = validStory({ source_url: "https://example.com/b" });
+    // Simulate both URLs already present in the DB.
+    mock.queueSelect([{ sourceUrl: s1.source_url }, { sourceUrl: s2.source_url }]);
+
+    const { toInsert, toSkip } = await partitionStoriesByExistence(db, [s1, s2]);
+    expect(toInsert).toHaveLength(0);
+    expect(toSkip).toHaveLength(2);
+  });
+
+  it("partitions mixed inputs correctly", async () => {
+    const existing = validStory({ source_url: "https://example.com/exists" });
+    const fresh = validStory({ source_url: "https://example.com/fresh" });
+    mock.queueSelect([{ sourceUrl: existing.source_url }]);
+
+    const { toInsert, toSkip } = await partitionStoriesByExistence(db, [existing, fresh]);
+    expect(toInsert).toEqual([fresh]);
+    expect(toSkip).toEqual([existing]);
+  });
+});
+
+// ---------- insertStoryBatch ----------
+
+describe("insertStoryBatch", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("resolves SIGNAL_EDITORIAL placeholder to the real uuid at insert time", async () => {
+    const story = validStory();
+    const authorMap = new Map<string, string>([["SIGNAL_EDITORIAL", "author-uuid-123"]]);
+    // No returning() is called inside insertStoryBatch, so no queued rows needed —
+    // the mock chain's .values() resolves via .then() with an empty array.
+    const inserted = await insertStoryBatch(db, [story], authorMap);
+    expect(inserted).toBe(1);
+  });
+
+  it("throws if author_id cannot be resolved (defense-in-depth)", async () => {
+    const orphan = validStory({ author_id: "ORPHAN_PLACEHOLDER" });
+    const emptyMap = new Map<string, string>();
+    await expect(insertStoryBatch(db, [orphan], emptyMap)).rejects.toThrow(
+      /Unknown author_id "ORPHAN_PLACEHOLDER"/,
+    );
+  });
+});

--- a/OneDrive/Desktop/signal-app/docs/SCHEMA.md
+++ b/OneDrive/Desktop/signal-app/docs/SCHEMA.md
@@ -1,0 +1,129 @@
+# SIGNAL — Schema & Seeding Reference
+
+The authoritative schema lives in [`backend/src/db/schema.ts`](../backend/src/db/schema.ts). This doc focuses on the tables touched by content seeding and on the seeder itself.
+
+## Content tables
+
+### `stories`
+
+| column                      | type            | notes                                         |
+|-----------------------------|-----------------|-----------------------------------------------|
+| `id`                        | uuid PK         | `defaultRandom()`                             |
+| `sector`                    | varchar(50)     | one of `ai` / `finance` / `semiconductors`    |
+| `headline`                  | varchar(255)    | not null                                      |
+| `context`                   | text            | not null                                      |
+| `why_it_matters`            | text            | **not null** — role-neutral fallback          |
+| `why_it_matters_template`   | text            | JSON-stringified `{ai, finance, semiconductors}` |
+| `source_url`                | text            | not null, **no unique constraint**            |
+| `source_name`               | varchar(255)    | nullable                                      |
+| `author_id`                 | uuid FK         | → `writers.id`, `on delete set null`          |
+| `published_at`              | timestamptz     | must be set for v2 API to surface the story   |
+| `created_at`, `updated_at`  | timestamptz     | `defaultNow()`                                |
+
+Indexes: `(sector, published_at)`, `(created_at)`.
+
+### `writers`
+
+| column            | type         | notes                        |
+|-------------------|--------------|------------------------------|
+| `id`              | uuid PK      | `defaultRandom()`            |
+| `name`            | varchar(255) | not null, **not unique**     |
+| `email`           | varchar(255) | unique, nullable             |
+| `bio`             | text         | nullable                     |
+| `twitter_handle`  | varchar(100) | nullable                     |
+| `sectors`         | jsonb        | `string[]`, nullable         |
+| `created_at`      | timestamptz  | `defaultNow()`               |
+
+There is **no `slug` column** and **no `updated_at` column**. `name` has no unique constraint — the seeder falls back to SELECT-by-name + INSERT-if-absent for upsert, which is acceptable for a manually-operated prod seed with explicit confirmation (concurrent seeders are not in scope).
+
+## Seeding stories (`npm run seed:stories`)
+
+The seeder loads hand-curated content from `backend/seed-data/stories.json` and inserts it idempotently. The JSON is checked into the repo — it's the content source of truth, not a migration artifact.
+
+### JSON shape
+
+```json
+{
+  "writers_seed": [
+    {
+      "placeholder_id": "SIGNAL_EDITORIAL",
+      "name": "SIGNAL Editorial",
+      "slug": "signal-editorial",          // accepted but dropped (no column)
+      "bio": "..."
+    }
+  ],
+  "stories": [
+    {
+      "sector": "ai" | "finance" | "semiconductors",
+      "headline": "...",                    // max 255 chars
+      "context": "...",
+      "why_it_matters": "...",              // role-neutral fallback
+      "why_it_matters_template": {
+        "ai": "...",
+        "finance": "...",
+        "semiconductors": "..."
+      },
+      "source_url": "https://...",
+      "source_name": "Publication Name",
+      "author_id": "SIGNAL_EDITORIAL",     // string placeholder, resolved at insert
+      "published_at": "2026-04-15T10:30:00Z"  // ISO-8601 with offset
+    }
+  ]
+}
+```
+
+### Placeholder-based author resolution
+
+`author_id` in the JSON is a *string placeholder* (e.g. `"SIGNAL_EDITORIAL"`), not a UUID. The seeder:
+
+1. Upserts every `writers_seed` entry by matching on `name`.
+2. Captures the real `writers.id` UUID into a `placeholder_id → uuid` map.
+3. Resolves each story's `author_id` through the map before INSERT.
+
+This keeps the JSON file static and committable to git without hardcoded UUIDs, and lets production and staging share the same seed file even though their writer UUIDs differ.
+
+### Idempotency
+
+`stories.source_url` has no unique constraint in the DB, so the seeder takes a pre-SELECT approach:
+
+1. `SELECT source_url FROM stories WHERE source_url IN (...)` with all incoming URLs.
+2. Partition the batch into `toInsert` (new) and `toSkip` (already present).
+3. INSERT only the fresh rows.
+
+Re-running the seeder with the same JSON is therefore a no-op. Stories already in the table are **not** updated in place — this is an additive load, not a migration.
+
+### Running it
+
+```bash
+# From repo root
+cd backend
+
+# Dry-run (read-only: SELECTs to compute counts, no writes, prints a sample)
+npm run seed:stories -- --dry-run
+
+# Actual run (prompts for y/n confirmation, shows DATABASE_URL host/dbname)
+npm run seed:stories
+
+# Custom file path
+npm run seed:stories -- --file=/absolute/path/to/stories.json
+
+# CI: skip confirmation prompt (do NOT use against prod interactively)
+npm run seed:stories -- --yes
+```
+
+The confirmation prompt prints `Database: <host>/<dbname>` extracted from `DATABASE_URL`, so you can visually verify you're pointing at prod vs. staging before typing `y`.
+
+### Exit codes
+
+- `0` — success, or clean no-op re-run, or user declined at the prompt.
+- `1` — validation failure (per-item errors printed to stderr) or DB error.
+
+### Verifying the seed after it runs
+
+```bash
+# Hit v2 API
+curl https://<prod>/api/v2/stories?sector=ai \
+  -H "Authorization: Bearer $SIGNAL_API_KEY" | jq '.pagination.has_more'
+```
+
+If `data` is non-empty and pagination has the expected shape, the seed landed.


### PR DESCRIPTION
Phase 4.5 populates the production stories table with 20 real, hand-curated stories (7 AI / 7 Finance / 6 Semiconductors) — unblocking the v2 /api/v2/stories endpoint and every demo path that depends on real feed content. Adds an idempotent seeder (seedStories.ts) that reads from backend/seed-data/stories.json, validates with Zod, upserts a "SIGNAL Editorial" writer row, and inserts stories with a pre-SELECT-by-source_url idempotency check. Backend tests: 311 → 323 (+12). Schema reconciled with production: why_it_matters_template persisted as stringified JSON in the existing text column, headline validated at varchar(255), writer upsert falls back to SELECT-by-name since no unique constraint exists on writers. Confirmation prompt requires explicit y and displays the target DB host as a safety rail. No prod writes performed during this session — npm run seed:stories is invoked manually post-merge.
