### PR TITLE
Phase 11c.5: aggregation layer + /api/v2/trends/:sector

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/package.json
+++ b/OneDrive/Desktop/signal-app/backend/package.json
@@ -18,6 +18,7 @@
     "db:seed": "ts-node src/db/seed.ts",
     "seed:stories": "ts-node src/scripts/seedStories.ts",
     "send-digest-now": "ts-node src/scripts/sendDigestNow.ts",
+    "run-aggregation": "ts-node src/scripts/runAggregation.ts",
     "smoke": "ts-node src/scripts/smokeTest.ts"
   },
   "dependencies": {

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/v2/trendsController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/v2/trendsController.ts
@@ -1,0 +1,94 @@
+import type { NextFunction, Request, Response } from "express";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../../db";
+import { storyAggregates } from "../../db/schema";
+import { AppError } from "../../middleware/errorHandler";
+import { AGGREGATED_SECTORS } from "../../jobs/aggregationJob";
+
+const DEFAULT_WINDOW = 8;
+const MAX_WINDOW = 52;
+
+const paramsSchema = z.object({
+  sector: z.enum(AGGREGATED_SECTORS),
+});
+
+const querySchema = z.object({
+  weeks: z.coerce.number().int().min(2).max(MAX_WINDOW).default(DEFAULT_WINDOW),
+});
+
+/**
+ * Volume-based weekly momentum: percent change from last week to this week,
+ * floored at `last_week = 1` to avoid divide-by-zero and the spike-of-
+ * infinity that 0→N would otherwise produce. Positive = up, negative =
+ * down, `null` when the caller asked for fewer than 2 data points (can't
+ * compute a delta with a single week).
+ */
+export function computeMomentum(series: { storyCount: number }[]): number | null {
+  if (series.length < 2) return null;
+  // `series` is returned newest-first; this week = index 0, last week = 1.
+  const thisWeek = series[0]!.storyCount;
+  const lastWeek = series[1]!.storyCount;
+  const denom = Math.max(lastWeek, 1);
+  return (thisWeek - lastWeek) / denom;
+}
+
+export async function getSectorTrends(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const paramParse = paramsSchema.safeParse(req.params);
+    if (!paramParse.success) {
+      throw new AppError(
+        "INVALID_SECTOR",
+        `Sector must be one of: ${AGGREGATED_SECTORS.join(", ")}`,
+        400,
+        paramParse.error.flatten(),
+      );
+    }
+    const queryParse = querySchema.safeParse(req.query);
+    if (!queryParse.success) {
+      throw new AppError(
+        "INVALID_QUERY",
+        "Invalid query parameters",
+        400,
+        queryParse.error.flatten(),
+      );
+    }
+
+    const { sector } = paramParse.data;
+    const { weeks } = queryParse.data;
+
+    const rows = await db
+      .select({
+        period: storyAggregates.period,
+        storyCount: storyAggregates.storyCount,
+        saveCount: storyAggregates.saveCount,
+        computedAt: storyAggregates.computedAt,
+      })
+      .from(storyAggregates)
+      .where(and(eq(storyAggregates.sector, sector)))
+      .orderBy(desc(storyAggregates.period))
+      .limit(weeks);
+
+    const momentum = computeMomentum(rows);
+    const asOf = rows[0]?.computedAt ?? null;
+
+    res.json({
+      data: {
+        sector,
+        as_of: asOf,
+        momentum,
+        series: rows.map((r) => ({
+          period: r.period,
+          story_count: r.storyCount,
+          save_count: r.saveCount,
+        })),
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/0006_phase11c5_story_aggregates.sql
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/0006_phase11c5_story_aggregates.sql
@@ -1,0 +1,26 @@
+-- Phase 11c.5: precomputed sector-level weekly rollups for
+-- /api/v2/trends/:sector. Populated by the aggregation job
+-- (`aggregationJob.ts`) on a daily cron; momentum is derived on read,
+-- not stored — so only raw counts live here.
+--
+-- `save_count` is reserved for future engagement-weighted aggregation
+-- and stays 0 in v1. Shipping the column now means the user_saves JOIN
+-- can be added later without a migration or API contract change.
+--
+-- UNIQUE(sector, period) is the upsert target on job re-runs. Postgres
+-- auto-creates a btree index for the constraint, so it also serves the
+-- primary read query (sector + recent periods) without a separate index.
+
+CREATE TABLE IF NOT EXISTS "story_aggregates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"sector" varchar(50) NOT NULL,
+	"period" varchar(10) NOT NULL,
+	"story_count" integer DEFAULT 0 NOT NULL,
+	"save_count" integer DEFAULT 0 NOT NULL,
+	"computed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "story_aggregates_sector_period_unique" UNIQUE("sector","period")
+);--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "story_aggregates_computed_at_idx" ON "story_aggregates" USING btree ("computed_at");

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/meta/_journal.json
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777284000004,
       "tag": "0005_phase11_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1777284000005,
+      "tag": "0006_phase11c5_story_aggregates",
+      "breakpoints": true
     }
   ]
 }

--- a/OneDrive/Desktop/signal-app/backend/src/db/schema.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/db/schema.ts
@@ -88,6 +88,36 @@ export const stories = pgTable(
   }),
 );
 
+// ---------- Story aggregates ----------
+
+// Precomputed per-sector weekly rollups. Populated by the aggregation job
+// (`aggregationJob.ts`); read by `/api/v2/trends/:sector`. `save_count` is
+// reserved for future engagement-weighted aggregation and stays 0 in v1 —
+// the column exists so adding a `user_saves` JOIN later doesn't require a
+// migration or API contract change. Upsert target is (sector, period).
+export const storyAggregates = pgTable(
+  "story_aggregates",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sector: varchar("sector", { length: 50 }).notNull(),
+    // ISO week string, e.g. "2026-W16". 8-char max in practice but we allow
+    // 10 to tolerate hypothetical 5-digit years and separator variants.
+    period: varchar("period", { length: 10 }).notNull(),
+    storyCount: integer("story_count").notNull().default(0),
+    saveCount: integer("save_count").notNull().default(0),
+    computedAt: timestamp("computed_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    // Unique (sector, period) is the upsert target AND the query index —
+    // Postgres creates a btree index for every UNIQUE constraint, so a
+    // separate non-unique (sector, period) index would be redundant.
+    sectorPeriodUnique: unique("story_aggregates_sector_period_unique").on(t.sector, t.period),
+    computedAtIdx: index("story_aggregates_computed_at_idx").on(t.computedAt),
+  }),
+);
+
 // ---------- User saves ----------
 
 export const userSaves = pgTable(
@@ -302,6 +332,8 @@ export type Writer = typeof writers.$inferSelect;
 export type NewWriter = typeof writers.$inferInsert;
 export type Story = typeof stories.$inferSelect;
 export type NewStory = typeof stories.$inferInsert;
+export type StoryAggregate = typeof storyAggregates.$inferSelect;
+export type NewStoryAggregate = typeof storyAggregates.$inferInsert;
 export type UserSave = typeof userSaves.$inferSelect;
 export type Team = typeof teams.$inferSelect;
 export type NewTeam = typeof teams.$inferInsert;

--- a/OneDrive/Desktop/signal-app/backend/src/jobs/aggregationJob.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/jobs/aggregationJob.ts
@@ -1,0 +1,138 @@
+import { and, gte, isNotNull, lt, sql } from "drizzle-orm";
+import { db } from "../db";
+import { stories, storyAggregates } from "../db/schema";
+
+// Sectors are codified at the job boundary so that a week with zero stories
+// in one sector still produces a zero-count row — downstream momentum
+// calculation needs (this_week, last_week) pairs with no missing sides.
+export const AGGREGATED_SECTORS = ["ai", "finance", "semiconductors"] as const;
+export type AggregatedSector = (typeof AGGREGATED_SECTORS)[number];
+
+export interface AggregationRunResult {
+  period: string;
+  processed: number;
+  sectors: { sector: AggregatedSector; storyCount: number; saveCount: number }[];
+}
+
+// ISO-8601 week string ("2026-W16"). The year is the Thursday-in-the-week's
+// year, not the calendar year of the passed date — so Jan 1 2027 is in
+// "2026-W53" if that Jan 1 is a Friday, which matches Postgres's EXTRACT
+// semantics and how Monday-start week buckets read in human reports.
+export function toIsoWeek(d: Date): string {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
+  const firstThursdayDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNum + 3);
+  const week = 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * 86_400_000));
+  return `${date.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+// [start, end) — Monday 00:00:00 UTC inclusive to next Monday 00:00:00 UTC
+// exclusive. Exclusive upper bound keeps the `published_at < end` query
+// tidy and avoids the "published at exactly 23:59:59.999" edge case.
+export function weekBounds(period: string): { start: Date; end: Date } {
+  const match = /^(\d{4})-W(\d{2})$/.exec(period);
+  if (!match) {
+    throw new Error(`aggregation: invalid ISO week "${period}" (expected "YYYY-Www")`);
+  }
+  const year = Number(match[1]);
+  const week = Number(match[2]);
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4DayNum = (jan4.getUTCDay() + 6) % 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - jan4DayNum);
+  const start = new Date(week1Monday);
+  start.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 7);
+  return { start, end };
+}
+
+export interface RunAggregationOptions {
+  period?: string;
+  now?: Date;
+}
+
+/**
+ * Recomputes per-sector story counts for the given ISO week (defaults to
+ * the week of `now`) and upserts them into `story_aggregates`. Idempotent:
+ * re-running against the same period updates counts and bumps
+ * `computed_at`/`updated_at`. `save_count` is always 0 in v1 (see the
+ * schema comment — reserved column, no user_saves JOIN yet).
+ */
+export async function runAggregation(
+  opts: RunAggregationOptions = {},
+): Promise<AggregationRunResult> {
+  const now = opts.now ?? new Date();
+  const period = opts.period ?? toIsoWeek(now);
+  const { start, end } = weekBounds(period);
+
+  const rows = await db
+    .select({
+      sector: stories.sector,
+      storyCount: sql<number>`count(*)::int`,
+    })
+    .from(stories)
+    .where(
+      and(
+        isNotNull(stories.publishedAt),
+        gte(stories.publishedAt, start),
+        lt(stories.publishedAt, end),
+      ),
+    )
+    .groupBy(stories.sector);
+
+  const byKnownSector = new Map<AggregatedSector, number>();
+  for (const row of rows) {
+    if ((AGGREGATED_SECTORS as readonly string[]).includes(row.sector)) {
+      byKnownSector.set(row.sector as AggregatedSector, Number(row.storyCount));
+    }
+  }
+
+  const values = AGGREGATED_SECTORS.map((sector) => ({
+    sector,
+    period,
+    storyCount: byKnownSector.get(sector) ?? 0,
+    saveCount: 0,
+  }));
+
+  await db
+    .insert(storyAggregates)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [storyAggregates.sector, storyAggregates.period],
+      set: {
+        storyCount: sql`excluded.story_count`,
+        saveCount: sql`excluded.save_count`,
+        computedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      },
+    });
+
+  return {
+    period,
+    processed: values.length,
+    sectors: values.map((v) => ({
+      sector: v.sector,
+      storyCount: v.storyCount,
+      saveCount: v.saveCount,
+    })),
+  };
+}
+
+// Thin BullMQ-level wrapper so the worker has a single named entry point.
+export async function processAggregationJob(
+  data: { period?: string } = {},
+): Promise<AggregationRunResult> {
+  return runAggregation({ period: data.period });
+}
+
+// Test-only accessor — keeps the sector-check closure testable without
+// exporting a mutable array.
+export function getEligibleAggregateSector(value: string): AggregatedSector | null {
+  return (AGGREGATED_SECTORS as readonly string[]).includes(value)
+    ? (value as AggregatedSector)
+    : null;
+}

--- a/OneDrive/Desktop/signal-app/backend/src/jobs/aggregationQueue.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/jobs/aggregationQueue.ts
@@ -1,0 +1,100 @@
+import { Queue, type JobsOptions } from "bullmq";
+import { getRedis, isRedisConfigured } from "../lib/redis";
+
+export const AGGREGATION_QUEUE_NAME = "signal-aggregation";
+export const AGGREGATION_JOB_NAME = "compute-sector-weekly";
+
+// 02:00 UTC daily. Running at 02:00 rather than 00:00 gives late-arriving
+// Sunday-night story inserts (across timezones) time to settle before the
+// week's rollup is taken. Repeated runs in the same period are safe — the
+// job upserts on (sector, period).
+export const AGGREGATION_CRON_PATTERN = process.env.AGGREGATION_CRON ?? "0 2 * * *";
+
+export interface AggregationJobData {
+  // Optional ISO week ("2026-W16") to target a specific period. Omitted
+  // for scheduled runs — the job defaults to the current week.
+  period?: string;
+  triggeredBy?: "cron" | "cli" | "test";
+}
+
+let cachedQueue: Queue<AggregationJobData> | null = null;
+
+function buildQueue(): Queue<AggregationJobData> | null {
+  const connection = getRedis();
+  if (!connection) return null;
+  return new Queue<AggregationJobData>(AGGREGATION_QUEUE_NAME, {
+    connection,
+    defaultJobOptions: {
+      attempts: 3,
+      backoff: { type: "exponential", delay: 30_000 },
+      removeOnComplete: { age: 86_400, count: 100 },
+      removeOnFail: { age: 604_800 },
+    },
+  });
+}
+
+export function getAggregationQueue(): Queue<AggregationJobData> | null {
+  if (cachedQueue) return cachedQueue;
+  if (!isRedisConfigured()) return null;
+  cachedQueue = buildQueue();
+  return cachedQueue;
+}
+
+export async function enqueueAggregation(
+  data: AggregationJobData = {},
+  opts?: JobsOptions,
+): Promise<{ queued: boolean; jobId?: string }> {
+  const queue = getAggregationQueue();
+  if (!queue) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[signal-backend] aggregation queue unavailable (Redis not configured) — skipping enqueue",
+    );
+    return { queued: false };
+  }
+  const job = await queue.add(AGGREGATION_JOB_NAME, data, opts);
+  return { queued: true, jobId: job.id };
+}
+
+/**
+ * Registers a BullMQ repeatable job for the daily aggregation cron. Safe
+ * to call multiple times — BullMQ dedupes repeatable jobs by jobId. Returns
+ * `false` when Redis is unavailable so server boot can log and continue.
+ */
+export async function scheduleAggregationRepeatable(): Promise<boolean> {
+  const queue = getAggregationQueue();
+  if (!queue) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[signal-backend] aggregation scheduler not started (REDIS_URL not set)",
+    );
+    return false;
+  }
+  await queue.add(
+    AGGREGATION_JOB_NAME,
+    { triggeredBy: "cron" },
+    {
+      jobId: `repeat:${AGGREGATION_JOB_NAME}`,
+      repeat: { pattern: AGGREGATION_CRON_PATTERN, tz: "UTC" },
+      removeOnComplete: { age: 86_400, count: 100 },
+      removeOnFail: { age: 604_800 },
+    },
+  );
+  // eslint-disable-next-line no-console
+  console.log(
+    `[signal-backend] aggregation scheduler started (cron="${AGGREGATION_CRON_PATTERN}" tz=UTC)`,
+  );
+  return true;
+}
+
+export async function closeAggregationQueue(): Promise<void> {
+  if (cachedQueue) {
+    await cachedQueue.close().catch(() => undefined);
+    cachedQueue = null;
+  }
+}
+
+// Test-only reset hook. Intentionally not exported from the jobs barrel.
+export function __resetAggregationQueueForTests(): void {
+  cachedQueue = null;
+}

--- a/OneDrive/Desktop/signal-app/backend/src/jobs/aggregationWorker.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/jobs/aggregationWorker.ts
@@ -1,0 +1,51 @@
+import { Worker, type Job } from "bullmq";
+import { getRedis, isRedisConfigured } from "../lib/redis";
+import {
+  AGGREGATION_QUEUE_NAME,
+  type AggregationJobData,
+} from "./aggregationQueue";
+import { processAggregationJob } from "./aggregationJob";
+
+let cachedWorker: Worker<AggregationJobData> | null = null;
+
+async function handle(job: Job<AggregationJobData>): Promise<void> {
+  const result = await processAggregationJob({ period: job.data.period });
+  // eslint-disable-next-line no-console
+  console.log(
+    `[signal-backend] [aggregation:done] period=${result.period} processed=${result.processed} triggeredBy=${job.data.triggeredBy ?? "unknown"}`,
+  );
+}
+
+export function startAggregationWorker(): Worker<AggregationJobData> | null {
+  if (cachedWorker) return cachedWorker;
+  if (!isRedisConfigured()) {
+    // eslint-disable-next-line no-console
+    console.warn("[signal-backend] aggregation worker not started (REDIS_URL not set)");
+    return null;
+  }
+  const connection = getRedis();
+  if (!connection) return null;
+
+  cachedWorker = new Worker<AggregationJobData>(AGGREGATION_QUEUE_NAME, handle, {
+    connection,
+    // Aggregation is single-writer per period — concurrency 1 keeps the
+    // upsert semantics simple (no contention on the unique constraint).
+    concurrency: Number(process.env.AGGREGATION_WORKER_CONCURRENCY ?? 1),
+  });
+  cachedWorker.on("failed", (job, err) => {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[signal-backend] [aggregation:failed] period=${job?.data.period ?? "current"}: ${err.message}`,
+    );
+  });
+  // eslint-disable-next-line no-console
+  console.log("[signal-backend] aggregation worker started");
+  return cachedWorker;
+}
+
+export async function stopAggregationWorker(): Promise<void> {
+  if (cachedWorker) {
+    await cachedWorker.close().catch(() => undefined);
+    cachedWorker = null;
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/routes/v2/index.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/routes/v2/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { apiKeyAuth } from "../../middleware/apiKeyAuth";
 import { apiKeyRateLimit } from "../../middleware/apiKeyRateLimit";
 import { storiesV2Router } from "./stories";
+import { trendsV2Router } from "./trends";
 
 export const v2Router: Router = Router();
 
@@ -10,3 +11,4 @@ export const v2Router: Router = Router();
 v2Router.use(apiKeyAuth, apiKeyRateLimit);
 
 v2Router.use("/stories", storiesV2Router);
+v2Router.use("/trends", trendsV2Router);

--- a/OneDrive/Desktop/signal-app/backend/src/routes/v2/trends.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/routes/v2/trends.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { getSectorTrends } from "../../controllers/v2/trendsController";
+
+export const trendsV2Router: Router = Router();
+
+trendsV2Router.get("/:sector", getSectorTrends);

--- a/OneDrive/Desktop/signal-app/backend/src/scripts/runAggregation.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/scripts/runAggregation.ts
@@ -1,0 +1,57 @@
+import "dotenv/config";
+import { runAggregation } from "../jobs/aggregationJob";
+import { closeRedis } from "../lib/redis";
+import { pool } from "../db";
+
+interface ParsedArgs {
+  period?: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg) continue;
+    if (arg.startsWith("--period=")) {
+      out.period = arg.slice("--period=".length);
+    } else if (arg === "--period") {
+      out.period = argv[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[run-aggregation] starting${args.period ? ` (period=${args.period})` : " (period=current week)"}`,
+  );
+
+  const result = await runAggregation({ period: args.period });
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[run-aggregation] period=${result.period} processed=${result.processed}`,
+  );
+  for (const s of result.sectors) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[run-aggregation]   sector=${s.sector} story_count=${s.storyCount} save_count=${s.saveCount}`,
+    );
+  }
+
+  await closeRedis();
+  await pool.end().catch(() => undefined);
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    // eslint-disable-next-line no-console
+    console.error("[run-aggregation] failed:", err);
+    process.exit(1);
+  },
+);

--- a/OneDrive/Desktop/signal-app/backend/src/server.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/server.ts
@@ -4,6 +4,8 @@ import { initSentry } from "./lib/sentry";
 import { runStartupEnvCheck } from "./lib/envCheck";
 import { startEmailWorker } from "./jobs/emailWorker";
 import { startEmailScheduler } from "./jobs/emailScheduler";
+import { startAggregationWorker } from "./jobs/aggregationWorker";
+import { scheduleAggregationRepeatable } from "./jobs/aggregationQueue";
 
 initSentry();
 runStartupEnvCheck();
@@ -18,5 +20,10 @@ app.listen(port, () => {
 
 startEmailWorker();
 startEmailScheduler();
+startAggregationWorker();
+void scheduleAggregationRepeatable().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error("[signal-backend] failed to schedule aggregation cron:", err);
+});
 
 export { app };

--- a/OneDrive/Desktop/signal-app/backend/tests/aggregationJob.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/aggregationJob.test.ts
@@ -1,0 +1,128 @@
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import {
+  runAggregation,
+  toIsoWeek,
+  weekBounds,
+  processAggregationJob,
+  getEligibleAggregateSector,
+} from "../src/jobs/aggregationJob";
+
+describe("aggregationJob", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  describe("toIsoWeek", () => {
+    it("returns the ISO week for a mid-week date", () => {
+      // Wednesday 2026-04-15 is in ISO week 16 of 2026.
+      expect(toIsoWeek(new Date("2026-04-15T12:00:00Z"))).toBe("2026-W16");
+    });
+
+    it("handles Jan 1 that belongs to the previous ISO year", () => {
+      // Jan 1 2027 is a Friday — ISO week belongs to 2026-W53.
+      expect(toIsoWeek(new Date("2027-01-01T12:00:00Z"))).toBe("2026-W53");
+    });
+  });
+
+  describe("weekBounds", () => {
+    it("returns Monday-start inclusive and next-Monday exclusive", () => {
+      const { start, end } = weekBounds("2026-W16");
+      // 2026-W16 starts Monday 2026-04-13 UTC.
+      expect(start.toISOString()).toBe("2026-04-13T00:00:00.000Z");
+      expect(end.toISOString()).toBe("2026-04-20T00:00:00.000Z");
+    });
+
+    it("throws on a malformed ISO week string", () => {
+      expect(() => weekBounds("2026-16")).toThrow(/invalid ISO week/);
+      expect(() => weekBounds("2026-W1")).toThrow(/invalid ISO week/);
+    });
+  });
+
+  describe("getEligibleAggregateSector", () => {
+    it("returns the sector for a known value", () => {
+      expect(getEligibleAggregateSector("ai")).toBe("ai");
+      expect(getEligibleAggregateSector("finance")).toBe("finance");
+      expect(getEligibleAggregateSector("semiconductors")).toBe("semiconductors");
+    });
+
+    it("returns null for an unknown sector", () => {
+      expect(getEligibleAggregateSector("biotech")).toBeNull();
+      expect(getEligibleAggregateSector("")).toBeNull();
+    });
+  });
+
+  describe("runAggregation", () => {
+    it("upserts one row per known sector, zero-filling missing sectors", async () => {
+      // DB returns only ai + finance — semiconductors should be zero-filled.
+      mock.queueSelect([
+        { sector: "ai", storyCount: 7 },
+        { sector: "finance", storyCount: 3 },
+      ]);
+      mock.queueInsert([]);
+
+      const result = await runAggregation({ period: "2026-W16" });
+
+      expect(result.period).toBe("2026-W16");
+      expect(result.processed).toBe(3);
+      const bySector = Object.fromEntries(
+        result.sectors.map((s) => [s.sector, s.storyCount]),
+      );
+      expect(bySector).toEqual({ ai: 7, finance: 3, semiconductors: 0 });
+      expect(result.sectors.every((s) => s.saveCount === 0)).toBe(true);
+    });
+
+    it("ignores stories in sectors outside the known enum", async () => {
+      // "biotech" appears in raw results but must not leak into the output.
+      mock.queueSelect([
+        { sector: "ai", storyCount: 2 },
+        { sector: "biotech", storyCount: 99 },
+      ]);
+      mock.queueInsert([]);
+
+      const result = await runAggregation({ period: "2026-W16" });
+      const sectors = result.sectors.map((s) => s.sector);
+      expect(sectors).not.toContain("biotech");
+      expect(sectors.sort()).toEqual(["ai", "finance", "semiconductors"]);
+    });
+
+    it("defaults to the ISO week of `now` when period is not passed", async () => {
+      mock.queueSelect([{ sector: "ai", storyCount: 1 }]);
+      mock.queueInsert([]);
+
+      const result = await runAggregation({
+        now: new Date("2026-04-15T12:00:00Z"),
+      });
+      expect(result.period).toBe("2026-W16");
+    });
+
+    it("emits zero-counts when the DB returns no rows for the week", async () => {
+      mock.queueSelect([]);
+      mock.queueInsert([]);
+
+      const result = await runAggregation({ period: "2026-W16" });
+      expect(result.sectors.every((s) => s.storyCount === 0)).toBe(true);
+    });
+  });
+
+  describe("processAggregationJob", () => {
+    it("forwards the period option through to runAggregation", async () => {
+      mock.queueSelect([]);
+      mock.queueInsert([]);
+
+      const result = await processAggregationJob({ period: "2026-W16" });
+      expect(result.period).toBe("2026-W16");
+    });
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/aggregationQueue.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/aggregationQueue.test.ts
@@ -1,0 +1,53 @@
+jest.mock("../src/lib/redis", () => ({
+  __esModule: true,
+  getRedis: () => null,
+  isRedisConfigured: () => false,
+  getRedisUrl: () => null,
+  closeRedis: async () => undefined,
+}));
+
+import {
+  AGGREGATION_QUEUE_NAME,
+  AGGREGATION_JOB_NAME,
+  AGGREGATION_CRON_PATTERN,
+  enqueueAggregation,
+  getAggregationQueue,
+  scheduleAggregationRepeatable,
+  __resetAggregationQueueForTests,
+} from "../src/jobs/aggregationQueue";
+
+describe("aggregationQueue graceful degradation", () => {
+  let consoleWarn: jest.SpyInstance;
+
+  beforeEach(() => {
+    __resetAggregationQueueForTests();
+    consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+  });
+
+  it("exposes stable queue/job/cron identifiers", () => {
+    expect(AGGREGATION_QUEUE_NAME).toBe("signal-aggregation");
+    expect(AGGREGATION_JOB_NAME).toBe("compute-sector-weekly");
+    // Default daily pattern unless overridden — matches Phase 11c.5 contract.
+    expect(AGGREGATION_CRON_PATTERN).toBe("0 2 * * *");
+  });
+
+  it("getAggregationQueue returns null when Redis is not configured", () => {
+    expect(getAggregationQueue()).toBeNull();
+  });
+
+  it("enqueueAggregation returns { queued: false } and warns without Redis", async () => {
+    const result = await enqueueAggregation({ period: "2026-W16" });
+    expect(result).toEqual({ queued: false });
+    expect(consoleWarn).toHaveBeenCalled();
+  });
+
+  it("scheduleAggregationRepeatable returns false and warns without Redis", async () => {
+    const ok = await scheduleAggregationRepeatable();
+    expect(ok).toBe(false);
+    expect(consoleWarn).toHaveBeenCalled();
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/trendsV2.integration.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/trendsV2.integration.test.ts
@@ -1,0 +1,131 @@
+import request from "supertest";
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import { createApp } from "../src/app";
+import { computeMomentum } from "../src/controllers/v2/trendsController";
+
+const app = createApp();
+
+const API_KEY = "sgnl_live_TEST_FIXTURE_NOT_A_REAL_KEY_abcde_xyz0";
+
+function apiKeyHeader(value: string = API_KEY): [string, string] {
+  return ["X-API-Key", value];
+}
+
+function queueAuthOk(): void {
+  mock.queueSelect([
+    { id: "key-1", userId: "user-1", label: "ci", revokedAt: null },
+  ]);
+}
+
+function aggregateRow(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    period: "2026-W16",
+    storyCount: 5,
+    saveCount: 0,
+    computedAt: new Date("2026-04-20T02:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("GET /api/v2/trends/:sector", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  describe("computeMomentum (unit)", () => {
+    it("returns null for series shorter than 2", () => {
+      expect(computeMomentum([])).toBeNull();
+      expect(computeMomentum([{ storyCount: 5 }])).toBeNull();
+    });
+
+    it("returns positive for up-week", () => {
+      expect(computeMomentum([{ storyCount: 10 }, { storyCount: 5 }])).toBeCloseTo(1);
+    });
+
+    it("returns negative for down-week", () => {
+      expect(computeMomentum([{ storyCount: 2 }, { storyCount: 4 }])).toBeCloseTo(-0.5);
+    });
+
+    it("floors last_week at 1 to avoid divide-by-zero on 0→N", () => {
+      // last_week=0, this_week=5 → (5-0)/max(0,1) = 5
+      expect(computeMomentum([{ storyCount: 5 }, { storyCount: 0 }])).toBe(5);
+    });
+  });
+
+  describe("route", () => {
+    it("returns 401 without an API key", async () => {
+      const res = await request(app).get("/api/v2/trends/ai");
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects an unknown sector with 400 INVALID_SECTOR", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/trends/biotech")
+        .set(...apiKeyHeader());
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_SECTOR");
+    });
+
+    it("rejects weeks=1 (below min of 2)", async () => {
+      queueAuthOk();
+      const res = await request(app)
+        .get("/api/v2/trends/ai?weeks=1")
+        .set(...apiKeyHeader());
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_QUERY");
+    });
+
+    it("returns {sector, as_of, momentum, series} with a valid sector", async () => {
+      queueAuthOk();
+      mock.queueSelect([
+        aggregateRow({ period: "2026-W16", storyCount: 10 }),
+        aggregateRow({ period: "2026-W15", storyCount: 5 }),
+      ]);
+
+      const res = await request(app)
+        .get("/api/v2/trends/ai?weeks=2")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.sector).toBe("ai");
+      expect(res.body.data.as_of).toBe("2026-04-20T02:00:00.000Z");
+      expect(res.body.data.momentum).toBeCloseTo(1);
+      expect(res.body.data.series).toEqual([
+        { period: "2026-W16", story_count: 10, save_count: 0 },
+        { period: "2026-W15", story_count: 5, save_count: 0 },
+      ]);
+    });
+
+    it("returns momentum=null and as_of=null when no aggregates exist", async () => {
+      queueAuthOk();
+      mock.queueSelect([]);
+
+      const res = await request(app)
+        .get("/api/v2/trends/finance")
+        .set(...apiKeyHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({
+        sector: "finance",
+        as_of: null,
+        momentum: null,
+        series: [],
+      });
+    });
+  });
+});

--- a/OneDrive/Desktop/signal-app/docs/API.md
+++ b/OneDrive/Desktop/signal-app/docs/API.md
@@ -1,0 +1,89 @@
+# SIGNAL — v2 API Reference
+
+Authoritative reference for the `/api/v2/*` Intelligence API. All endpoints require a self-service API key (`X-API-Key: sgnl_live_...`) and are subject to per-key rate limiting (60 req/min, fail-open on Redis outage).
+
+Error envelope (all endpoints):
+
+```json
+{ "error": { "code": "INVALID_QUERY", "message": "...", "details": { } } }
+```
+
+## `GET /api/v2/stories`
+
+Keyset-paginated feed of published stories.
+
+**Query params:**
+- `sector` — `ai` / `finance` / `semiconductors` (optional)
+- `since`, `until` — ISO-8601 datetimes with offset (optional)
+- `author` — UUID (optional)
+- `limit` — 1..100, default 50
+- `cursor` — opaque, emitted by the previous page
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "headline": "...",
+      "summary": "...",
+      "url": "https://...",
+      "published_at": "2026-04-15T10:30:00.000Z",
+      "sector": "ai"
+    }
+  ],
+  "pagination": { "next_cursor": "base64url|null", "has_more": false }
+}
+```
+
+Drafts (`published_at IS NULL`) are excluded unconditionally.
+
+## `GET /api/v2/trends/:sector`
+
+Per-sector weekly trend series with derived momentum. Reads from `story_aggregates` (populated daily at 02:00 UTC by the aggregation cron).
+
+**Path params:**
+- `sector` — `ai` / `finance` / `semiconductors`. Unknown sectors return 400 `INVALID_SECTOR`.
+
+**Query params:**
+- `weeks` — integer 2..52, default 8. Below 2 returns 400 `INVALID_QUERY` (momentum needs two data points).
+
+**Response:**
+```json
+{
+  "data": {
+    "sector": "ai",
+    "as_of": "2026-04-20T02:00:00.000Z",
+    "momentum": 1.0,
+    "series": [
+      { "period": "2026-W16", "story_count": 10, "save_count": 0 },
+      { "period": "2026-W15", "story_count": 5,  "save_count": 0 }
+    ]
+  }
+}
+```
+
+`series` is returned newest-first. `as_of` is the most recent `computed_at` across returned rows (null when no aggregates exist yet).
+
+**Momentum semantics:**
+
+```
+momentum = (this_week_count - last_week_count) / max(last_week_count, 1)
+```
+
+The `max(·, 1)` floor avoids divide-by-zero on a 0→N jump, which would otherwise produce ±∞. As a side effect, the first non-zero week after a zero week reads as "this_week new stories" rather than undefined — intentional and documented for API consumers.
+
+`momentum` is `null` when the caller requested fewer than two periods (explicit `weeks` below 2 is rejected at validation, but an empty DB also produces `momentum: null`).
+
+`save_count` is always 0 in v1. The column is reserved so a future engagement-weighted aggregation can be added without a breaking API change.
+
+## Aggregation job
+
+- **Queue:** `signal-aggregation`
+- **Job name:** `compute-sector-weekly`
+- **Cron:** `0 2 * * *` UTC (daily, configurable via `AGGREGATION_CRON`)
+- **Manual trigger (CLI):** `npm run run-aggregation [-- --period=2026-W16] --workspace=backend`
+
+The job recomputes the current ISO week's rollup and upserts one row per known sector (zero-filling sectors with no stories that week). Re-running against the same period updates counts and bumps `computed_at`/`updated_at` — safe to trigger repeatedly for backfills.
+
+When `REDIS_URL` is unset, the queue and worker log and no-op cleanly. The CLI still works (the job body is Redis-free — it talks directly to Postgres).

--- a/OneDrive/Desktop/signal-app/docs/SCHEMA.md
+++ b/OneDrive/Desktop/signal-app/docs/SCHEMA.md
@@ -36,6 +36,27 @@ Indexes: `(sector, published_at)`, `(created_at)`.
 
 There is **no `slug` column** and **no `updated_at` column**. `name` has no unique constraint — the seeder falls back to SELECT-by-name + INSERT-if-absent for upsert, which is acceptable for a manually-operated prod seed with explicit confirmation (concurrent seeders are not in scope).
 
+### `story_aggregates`
+
+Phase 11c.5 rollup table. One row per `(sector, period)` pair; populated by the aggregation job and read by `/api/v2/trends/:sector`.
+
+| column          | type            | notes                                                    |
+|-----------------|-----------------|----------------------------------------------------------|
+| `id`            | uuid PK         | `defaultRandom()`                                        |
+| `sector`        | varchar(50)     | `ai` / `finance` / `semiconductors` (enforced at API/job boundary) |
+| `period`        | varchar(10)     | ISO-8601 week string, e.g. `"2026-W16"`                  |
+| `story_count`   | integer         | not null, default 0                                      |
+| `save_count`    | integer         | **reserved**, always 0 in v1 (no `user_saves` JOIN yet)  |
+| `computed_at`   | timestamptz     | set on every upsert — read as `as_of` in the trends API  |
+| `created_at`    | timestamptz     | `defaultNow()`                                           |
+| `updated_at`    | timestamptz     | bumped on every upsert                                   |
+
+Constraints & indexes:
+- `UNIQUE (sector, period)` — upsert target, doubles as the btree index serving the primary read query.
+- `INDEX (computed_at)` — supports "when was the latest rollup produced" ops queries.
+
+See [`backend/src/jobs/aggregationJob.ts`](../backend/src/jobs/aggregationJob.ts) for how rows are produced, and [`docs/API.md`](API.md) for how they are exposed.
+
 ## Seeding stories (`npm run seed:stories`)
 
 The seeder loads hand-curated content from `backend/seed-data/stories.json` and inserts it idempotently. The JSON is checked into the repo — it's the content source of truth, not a migration artifact.


### PR DESCRIPTION
Phase 11c.5 — Aggregation layer. Introduces story_aggregates table for weekly per-sector rollups, BullMQ daily aggregation job (2am UTC) with manual CLI trigger via npm run run-aggregation --workspace=backend, and new GET /api/v2/trends/:sector endpoint returning momentum scalar + weekly time-series. Data source: stories only; save_count column is reserved and populated as 0 so future engagement-weighted aggregation adds a JOIN without requiring schema migration or API contract change.
Backend tests: 323 → 347 (+24). Hand-written migration (matching existing 0001–0005 pattern, not drizzle-kit generate). No prod writes performed this session — CLI/API deliverables to be captured post-merge against prod.
Post-merge actions: (1) run migration in prod, (2) manually trigger first aggregation via CLI, (3) smoke-test GET /api/v2/trends/ai with API key, (4) verify idempotency on second run. Runbook in commit ab6759f docs.