### PR TITLE
Phase 12c: Personalized Haiku-Generated Commentary

### DIFF
--- a/OneDrive/Desktop/signal-app/CLAUDE.md
+++ b/OneDrive/Desktop/signal-app/CLAUDE.md
@@ -588,7 +588,7 @@ Frontend gates are the same three with `--workspace=frontend`. There is no CI en
 - **External services**: mock at the SDK boundary. Anthropic SDK mock pattern is in `tests/regenerateDepthVariants.test.ts`; SendGrid mock is in `tests/emailService.test.ts`.
 - **Integration tests** live alongside unit tests in `backend/tests/` and share the mock-DB helper.
 
-Current count: **431 tests across 36 suites** (as of Phase 12c). Adding a feature without tests is a code-review hard-block.
+Current count: **435 tests across 37 suites** (as of Phase 12c). Adding a feature without tests is a code-review hard-block.
 
 ### Frontend tests
 

--- a/OneDrive/Desktop/signal-app/CLAUDE.md
+++ b/OneDrive/Desktop/signal-app/CLAUDE.md
@@ -78,7 +78,7 @@ Deviation requires an explicit decision recorded somewhere durable (commit messa
 - **BullMQ** for durable queues (emails, aggregation rollups).
 - **node-cron** for in-process scheduling (the weekly-digest trigger lives here).
 - **jsonwebtoken** + **bcryptjs** for user auth.
-- **@anthropic-ai/sdk** — Claude Haiku (`claude-haiku-4-5`) for depth-variant generation. Added in Phase 12a.
+- **@anthropic-ai/sdk** — Claude Haiku for commentary generation. Two call sites, two model pins: the Phase 12a offline depth-variant regeneration script uses the alias `claude-haiku-4-5` (via `DEPTH_VARIANT_MODEL` in `services/depthVariantGenerator.ts`); the Phase 12c per-user, per-story commentary path uses the **dated** string **`claude-haiku-4-5-20251001`** (via `COMMENTARY_MODEL` in `services/haikuCommentaryClient.ts`). The dated pin is deliberate — request-path behavior must not shift silently when Anthropic advances the alias.
 - **@sendgrid/mail** for transactional email.
 - **zod** for every external input (bodies, queries, headers, seed JSON, cursor payloads).
 - **helmet** + **express-rate-limit** + custom per-API-key limiter.
@@ -389,7 +389,8 @@ The pre-12a sector-variant shape (`{ai, finance, semiconductors}`) is dead. Zod'
   - `WhyItMattersTemplateSchema` — `.strict()`, `min(1)` per field
   - `parseWhyItMattersTemplate(raw)` — **lenient-on-read**, returns `null` on null / empty / invalid JSON / legacy shape (never throws). Used by the v2 stories controller so the endpoint stays live during the regeneration window.
   - `assertWhyItMattersTemplate(value)` — **strict**, throws. Used at the regeneration boundary where garbage must not be written.
-- `backend/src/services/depthVariantGenerator.ts` — Anthropic Haiku (`claude-haiku-4-5`) client. Deps are injectable so tests run offline.
+- `backend/src/services/depthVariantGenerator.ts` — Anthropic Haiku (`claude-haiku-4-5` alias, exported as `DEPTH_VARIANT_MODEL`) client for the offline regeneration path. Deps are injectable so tests run offline.
+- `backend/src/services/haikuCommentaryClient.ts` — Phase 12c per-user, per-story commentary client. Uses the dated model string **`claude-haiku-4-5-20251001`** (exported as `COMMENTARY_MODEL`), 10s `AbortController` timeout, zero retries, fail-fast to the template scrub path on any error. Deliberately separate from the 12a client — the request path must not inherit a silent model-alias advance.
 
 ### Storage
 
@@ -420,6 +421,40 @@ Requires `ANTHROPIC_API_KEY`. Per-story failures (rate limits, schema mismatches
 - `/api/v2/stories` returns `why_it_matters` (string, always present) **and** `why_it_matters_template` (object or `null`).
 - When the template is `null`, the client falls back to `why_it_matters`. This is the permanent contract, not a migration-window hack — some rows may never get a template.
 - Paywall gating of depth access (§1) is enforced at the API layer, not in the parser. Which keys a given caller is permitted to see is a 12-series decision.
+
+### Phase 12c — per-user, per-story commentary
+
+12a shipped three depth variants per story — role-neutral. 12c layers per-user personalization on top: the feed and story-detail surfaces call `GET /api/v1/stories/:id/commentary` at view time and get back a commentary string generated from (role, domain, seniority, sectors, goals, topics) × story depth-variant, cached for reuse. The prior-gen `why_it_matters_to_you` template text remains as the 12b rollout floor until 12d removes it.
+
+**Endpoint — `GET /api/v1/stories/:id/commentary?depth=`**
+- JWT-auth. No `requireProfile` gate — pre-onboarding direct-link users get a clean `400 PROFILE_NOT_FOUND` rather than a 403.
+- `depth` query param is optional and validated against `{accessible, standard, technical}`. Precedence: explicit query > stored `depthPreference` > `"standard"` floor.
+- 404 `STORY_NOT_FOUND` on unknown story id. Any service failure below is hidden behind the tiered fallback — the endpoint never 5xxs on a content path.
+
+**Storage — `commentary_cache` (migration 0009)**
+- Composite unique key: `(user_id, story_id, depth, profile_version)`. Writes use `onConflictDoNothing` so the second member of a race simply loses and re-reads the winner.
+- `profile_version` on `user_profiles` is a monotonic int, default 1, bumped by `updateMyProfile` when any commentary-relevant field (role, domain, seniority, sectors, goals, topics) changes. Depth and email toggles do NOT bump.
+- `last_accessed_at` is written on every cache hit in 12c (TODO 12c.1: consider opportunistic — see comment in `commentaryService.ts`).
+
+**Tiered fallback**
+- `tier1` — the cache itself. If fresh for `(user, story, depth, profile_version)`, return it.
+- `tier2` — Haiku call succeeds; persist + return.
+- `tier3` — Haiku throws / times out. Return a template scrub of the depth variant with synonym substitution for banned phrases; emit an anomaly log with `{reason: "timeout" | "error" | ...}` so ops can see the fail-fast rate.
+
+**Haiku client discipline (Decisions 4–6 from the 12c spec)**
+- Dated model pin: `claude-haiku-4-5-20251001`. Hard-coded, not env-driven — a rollout calendar is not a code change.
+- 10-second hard timeout via `AbortController`. Timeout logged as `reason: "timeout"` on the tier3 path.
+- Zero retries. One call, fail fast. Revisit in 12d if the observed error rate warrants.
+
+**Banned-phrase three-layer enforcement**
+- Layer 1: system prompt instructs the model to avoid a named list of phrases (e.g. "in today's fast-paced world").
+- Layer 2: post-generation trip-wire scans the output for the banned set; a hit demotes the response to tier3.
+- Layer 3: the template scrub path substitutes synonyms for any banned phrase present in the source depth variant before returning.
+
+**Frontend wiring**
+- `GET /api/v2/stories` and `GET /api/v1/stories/:id` emit `commentary: null` + `commentary_source: null` on the Story shape — the feed hydrates lazily.
+- `useStoryCommentary(storyId, {enabled})` is the React hook; `frontend/src/lib/commentaryQueue.ts` holds an 8-slot FIFO semaphore (`COMMENTARY_MAX_CONCURRENT`) that caps parallel fetches.
+- `StoryCard` gates `enabled` on an `IntersectionObserver` with `rootMargin: "1200px 0px"` (~5-card lookahead); `StoryDetail` fires immediately. `shouldLoad` latches true once set — scrolling away never cancels an in-flight request.
 
 ---
 
@@ -553,7 +588,7 @@ Frontend gates are the same three with `--workspace=frontend`. There is no CI en
 - **External services**: mock at the SDK boundary. Anthropic SDK mock pattern is in `tests/regenerateDepthVariants.test.ts`; SendGrid mock is in `tests/emailService.test.ts`.
 - **Integration tests** live alongside unit tests in `backend/tests/` and share the mock-DB helper.
 
-Current count: **369 tests across 31 suites** (as of Phase 12a). Adding a feature without tests is a code-review hard-block.
+Current count: **431 tests across 36 suites** (as of Phase 12c). Adding a feature without tests is a code-review hard-block.
 
 ### Frontend tests
 
@@ -574,7 +609,7 @@ vitest; not much coverage yet. Add tests with every new component that has meani
 
 ## 16. PHASE STATUS
 
-### Shipped (0 through 11c.5)
+### Shipped (0 through 12c)
 
 | phase | ships                                                                      |
 |-------|----------------------------------------------------------------------------|
@@ -592,7 +627,9 @@ vitest; not much coverage yet. Add tests with every new component that has meani
 | 11    | public v2 API scaffolding + self-service API keys                          |
 | 11c   | `GET /api/v2/stories` with cursor pagination                               |
 | 11c.5 | `story_aggregates` table + aggregation job + `GET /api/v2/trends/:sector`  |
-| 12a   | **depth-variant commentary** — schema, parser, regeneration script, v2 projection fix |
+| 12a   | depth-variant commentary — schema, parser, regeneration script, v2 projection fix |
+| 12b   | rewritten onboarding questionnaire (7 screens) + `why_it_matters_to_you` rollout-floor template personalization |
+| 12c   | **per-user, per-story commentary** — dated-model Haiku client, `commentary_cache` with `profile_version` invalidation, tiered fallback + banned-phrase enforcement, Settings-side bump on commentary-relevant edits, feed/detail lazy hydration with 8-slot semaphore |
 
 Phase 10 (learning paths) was abandoned. Do not resurrect.
 
@@ -603,15 +640,19 @@ The 12-series is the push to public launch — every sub-phase is load-bearing f
 | sub-phase | scope                                                                                   |
 |-----------|-----------------------------------------------------------------------------------------|
 | **12a** (shipped) | depth-variant schema + offline regeneration                                     |
-| 12b       | personalization service — role-aware prose layered on top of depth variants             |
-| 12c       | profile questionnaire — capture role/goals at onboarding to drive 12b                   |
-| 12d       | depth-selector UI on story detail + feed                                                |
+| **12b** (shipped) | 7-screen onboarding questionnaire + `why_it_matters_to_you` template floor      |
+| **12c** (shipped) | per-user, per-story commentary — Haiku request path, cache with `profile_version`, Settings bump, feed/detail hydration (see §9 "Phase 12c") |
+| 12d       | depth-selector UI on story detail + feed (pick depth per-view, backed by the 12c cache entry for that (user, story, depth, profile_version)) |
 | **12e**   | **ingestion pipeline — raw-source crawl → editorial-review queue → published stories.** Replaces `seed-data/stories.json` as the sole content source. Launch blocker. |
 | 12f–12i   | paywall enforcement, Stripe/billing, depth-aware digest, launch polish (marketing/pricing pages, onboarding redesign, support inbox). Interior ordering not yet pinned — decide at the start of each session. |
 
 Ordering 12a→12e is fixed. Do not pull 12f–12i work ahead of 12e; the ingestion pipeline is the dependency that makes the paywall economics real.
 
-`docs/ROADMAP.md` is stale (last updated during Phase 11c kickoff) — update it alongside the first 12b commit, don't treat it as authoritative for 12-series today.
+Known 12c follow-ups (tracked inline as TODO comments, not blockers):
+- **12c.1** — `last_accessed_at` on `commentary_cache` is written on every cache hit; consider opportunistic/throttled writes if the row-update rate becomes a hot spot (comment in `commentaryService.ts`).
+- **12d** — ship the depth-selector UI; the endpoint already honors an explicit `?depth=` query and maintains separate cache entries per depth via the composite key.
+
+`docs/ROADMAP.md` is stale (last updated during Phase 11c kickoff) — refresh it in a dedicated cleanup pass; treat CLAUDE.md as authoritative for 12-series state today.
 
 ### Future (post-launch)
 

--- a/OneDrive/Desktop/signal-app/backend/src/constants/domainOptions.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/constants/domainOptions.ts
@@ -1,0 +1,96 @@
+// CONTENT DECISION — REVIEW BEFORE MERGE.
+// These domain lists will be seen by every new user during onboarding.
+// 15–20 options per sector, plus the "General / Not sure" sentinel.
+// Sensible defaults proposed by Claude Code; Omar to validate pre-merge.
+//
+// Phase 12c — Screen 2 "what field do you work in?" dropdown. Backend
+// validation source of truth. Mirrored in
+// `frontend/src/lib/onboarding/domainOptions.ts` for labels + the
+// filtered-by-selected-sector display logic. Keep the two files in
+// sync on value strings; frontend adds human-readable labels.
+//
+// The `general_not_sure` sentinel is always an explicit option,
+// regardless of which sectors the user selected. It lives OUTSIDE the
+// per-sector map so adding/removing a sector never changes whether
+// "General / Not sure" is offered.
+
+import { SECTORS, type Sector } from "./onboardingTopics";
+
+export const GENERAL_DOMAIN = "general_not_sure" as const;
+
+export const DOMAIN_OPTIONS_BY_SECTOR = {
+  ai: [
+    "foundation_model_research",
+    "model_training_infra",
+    "inference_infra",
+    "ai_product_engineering",
+    "ai_application_development",
+    "ml_engineering",
+    "ai_safety_alignment",
+    "ai_policy_governance",
+    "ai_developer_tools",
+    "computer_vision",
+    "nlp_conversational_ai",
+    "robotics_embodied_ai",
+    "ai_healthcare_biotech",
+    "ai_enterprise_productivity",
+    "ai_investing_vc",
+    "ai_journalism_analyst",
+    "data_engineering_ml",
+    "generative_ai_applications",
+  ],
+  finance: [
+    "equity_research",
+    "equity_sales_trading",
+    "fixed_income_credit",
+    "macro_rates_strategy",
+    "quantitative_research",
+    "quantitative_trading",
+    "risk_management",
+    "investment_banking_ma",
+    "private_equity",
+    "venture_capital",
+    "hedge_fund_fundamental",
+    "hedge_fund_systematic",
+    "wealth_management",
+    "corporate_strategy",
+    "financial_regulation_compliance",
+    "financial_journalism_analyst",
+    "crypto_digital_assets",
+    "fintech_product_engineering",
+  ],
+  semiconductors: [
+    "chip_design_architecture",
+    "verification_validation",
+    "physical_design_layout",
+    "eda_design_automation",
+    "foundry_operations",
+    "advanced_packaging",
+    "memory_dram_nand",
+    "gpu_accelerator_engineering",
+    "networking_silicon",
+    "automotive_embedded",
+    "analog_mixed_signal",
+    "rf_wireless_silicon",
+    "power_management_ic",
+    "semiconductor_supply_chain",
+    "semiconductor_equipment_oem",
+    "export_controls_trade_policy",
+    "semiconductor_investing_vc",
+    "semiconductor_journalism_analyst",
+  ],
+} as const satisfies Record<Sector, readonly string[]>;
+
+// Flat set of every accepted domain value. Used by Zod validators to
+// prove membership without having to reconstruct the union on every
+// request.
+export const VALID_DOMAIN_VALUES: ReadonlySet<string> = new Set<string>([
+  GENERAL_DOMAIN,
+  ...SECTORS.flatMap((s) => DOMAIN_OPTIONS_BY_SECTOR[s]),
+]);
+
+export function isValidDomain(value: string): boolean {
+  return VALID_DOMAIN_VALUES.has(value);
+}
+
+export type Domain = typeof GENERAL_DOMAIN | (typeof DOMAIN_OPTIONS_BY_SECTOR)[Sector][number];

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/commentaryController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/commentaryController.ts
@@ -1,0 +1,121 @@
+// Phase 12c — per-story commentary endpoint.
+//
+// Shape is deliberately thin: the controller validates input, loads
+// the user's current profileVersion + depthPreference, delegates to
+// getOrGenerateCommentary, and projects the service result onto a
+// stable JSON envelope. All of the cache-first / Haiku / fallback
+// logic lives in services/commentaryService.ts.
+//
+// Route: GET /api/v1/stories/:id/commentary(?depth=...)
+// Auth:  requireAuth (same as the rest of /stories)
+// Notes: depth gating (who can request which depth) is a 12f paywall
+// concern. In 12c the override is accepted unconditionally so
+// Premium's depth selector on story detail can exercise the full
+// surface before the paywall lands.
+
+import type { NextFunction, Request, Response } from "express";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { userProfiles, DEPTH_LEVELS, type DepthLevel } from "../db/schema";
+import { AppError } from "../middleware/errorHandler";
+import { getOrGenerateCommentary } from "../services/commentaryService";
+
+const idParamSchema = z.object({ id: z.string().uuid() });
+
+const querySchema = z.object({
+  depth: z.enum(DEPTH_LEVELS).optional(),
+});
+
+function requireUserId(req: Request): string {
+  if (!req.user) {
+    throw new AppError("UNAUTHORIZED", "Not authenticated", 401);
+  }
+  return req.user.userId;
+}
+
+/**
+ * GET /api/v1/stories/:id/commentary
+ * Response: { data: { commentary, depth, profile_version, source } }
+ *
+ * `source` mirrors CommentaryResult.source from commentaryService:
+ *   "cache" | "haiku" | "fallback_tier1" | "fallback_tier2" | "fallback_tier3"
+ * The client uses it for display affordances (e.g. "generating…" vs
+ * "from your signal") and for retry semantics on fallback rows.
+ */
+export async function getCommentary(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = requireUserId(req);
+    const { id: storyId } = idParamSchema.parse(req.params);
+    const { depth: depthOverride } = querySchema.parse(req.query);
+
+    // Load the user's depth_preference + profile_version in a single
+    // read. profileVersion is the cache-key input — reading it in the
+    // same tick the request is handled means a concurrent Settings
+    // write (which bumps the version) lands on a different cache row,
+    // not a stale one.
+    const [profile] = await db
+      .select({
+        depthPreference: userProfiles.depthPreference,
+        profileVersion: userProfiles.profileVersion,
+      })
+      .from(userProfiles)
+      .where(eq(userProfiles.userId, userId))
+      .limit(1);
+
+    if (!profile) {
+      // Pre-onboarding users shouldn't hit the feed endpoint (requireProfile
+      // gates that surface), but direct story-detail links can land them
+      // here. Surface a deterministic 400 — the client's onboarding redirect
+      // will kick in on the next navigation.
+      throw new AppError(
+        "PROFILE_NOT_FOUND",
+        "Complete onboarding to see personalized commentary",
+        400,
+      );
+    }
+
+    // Depth precedence: explicit query override > stored preference >
+    // "standard" as the last-resort default. The default exists because
+    // early-onboarding users may not have saved a depth yet; the
+    // onboarding flow makes it mandatory but a direct API caller
+    // could bypass. See §9 of CLAUDE.md — "standard" is the free-tier
+    // default and the right floor here.
+    const depth: DepthLevel =
+      depthOverride ?? profile.depthPreference ?? "standard";
+
+    const result = await getOrGenerateCommentary(
+      {
+        userId,
+        storyId,
+        depth,
+        profileVersion: profile.profileVersion,
+      },
+      { db },
+    );
+
+    res.json({
+      data: {
+        commentary: result.commentary,
+        depth: result.depth,
+        profile_version: result.profileVersion,
+        source: result.source,
+      },
+    });
+  } catch (error) {
+    // The service layer throws a plain Error with "story not found:
+    // <id>" when the storyId doesn't resolve. Map it to a proper 404
+    // so the client can distinguish "missing story" from "we failed
+    // to generate commentary for a real story" (the latter never
+    // throws — it falls through to the deterministic template).
+    if (error instanceof Error && error.message.startsWith("story not found:")) {
+      next(new AppError("STORY_NOT_FOUND", "Story not found", 404));
+      return;
+    }
+    next(error);
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/onboardingController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/onboardingController.ts
@@ -16,6 +16,7 @@ import {
   SENIORITIES,
   isValidTopicForSector,
 } from "../constants/onboardingTopics";
+import { isValidDomain } from "../constants/domainOptions";
 
 // Keep these in sync with the CHECK constraints in migration 0008. If
 // a literal is added/removed here, update the migration AND the
@@ -47,11 +48,19 @@ const completeSchema = z.object({
     .array(z.enum(SECTORS))
     .min(1, "Select at least one sector")
     .max(SECTORS.length),
-  // Screen 2
+  // Screen 2 — role + domain (Phase 12c expanded Screen 2 to include
+  // domain). Domain validated via a refine() rather than z.enum so the
+  // error message is stable across sector-specific option lists.
   role: z.enum(ROLES),
+  domain: z
+    .string()
+    .min(1)
+    .refine(isValidDomain, { message: "Domain is not a recognized value" }),
   // Screen 3
   seniority: z.enum(SENIORITIES),
-  // Screen 4
+  // Screen 4 (Phase 12c: depth now shows *after* goals — the step
+  // number changed in the UI. The wire shape is unchanged — both
+  // depth_preference and goals travel together on this request.)
   depth_preference: z.enum(DEPTH_PREFERENCE_VALUES),
   // Screen 5 — may be empty if the user skipped; the server fills it
   // with "all topics across selected sectors" when empty.
@@ -194,6 +203,11 @@ export async function postOnboardingComplete(
       const patch = {
         sectors: input.sectors,
         role: input.role,
+        // Phase 12c — domain joins the completion payload. profile_version
+        // is deliberately NOT touched here; it defaults to 1 on insert
+        // and completion shouldn't bump it (bumps happen on post-
+        // onboarding Settings mutations per Decision 7 of the 12c spec).
+        domain: input.domain,
         seniority: input.seniority,
         depthPreference: input.depth_preference,
         goals: input.goals,

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/storyController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/storyController.ts
@@ -61,11 +61,25 @@ function shapeStory(row: StoryRow, role: string | null): Record<string, unknown>
     headline: row.headline,
     context: row.context,
     why_it_matters: row.whyItMatters,
+    // Phase 12b personalization output — kept on the payload for
+    // backward compatibility through the 12c rollout. The 12c client
+    // prefers `commentary` once it arrives; the 12b field will be
+    // removed in the 12d cleanup commit.
     why_it_matters_to_you: personalizeStory({
       whyItMatters: row.whyItMatters,
       whyItMattersTemplate: row.whyItMattersTemplate,
       role,
     }),
+    // Phase 12c contract: feed-list responses never carry the
+    // per-user commentary inline. The client hydrates it via
+    // GET /stories/:id/commentary after the feed lands. Returning
+    // nulls here (rather than omitting the keys) makes the "not yet
+    // loaded" state explicit on the wire and lets TypeScript consumers
+    // treat the field as `string | null` rather than `string | undefined`.
+    // The `commentary_source` field is the null-mirror of
+    // CommentaryResult.source — populated only by the dedicated endpoint.
+    commentary: null,
+    commentary_source: null,
     source_url: row.sourceUrl,
     source_name: row.sourceName,
     published_at: row.publishedAt,

--- a/OneDrive/Desktop/signal-app/backend/src/controllers/userController.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/controllers/userController.ts
@@ -4,12 +4,18 @@ import { z } from "zod";
 import { db } from "../db";
 import { userProfiles, userTopicInterests, users } from "../db/schema";
 import { AppError } from "../middleware/errorHandler";
+import {
+  ROLES,
+  SECTORS,
+  SENIORITIES,
+  isValidTopicForSector,
+} from "../constants/onboardingTopics";
+import { isValidDomain } from "../constants/domainOptions";
 
-const SECTOR_MAX_LENGTH = 64;
 const GOAL_MAX_LENGTH = 64;
-const ROLE_MAX_LENGTH = 50;
 const NAME_MAX_LENGTH = 255;
 const URL_MAX_LENGTH = 2048;
+const TOPIC_MAX_LENGTH = 64;
 
 // Phase 12b: depth_preference is optional in this endpoint because the
 // settings UI is the only first-party caller that currently sends it;
@@ -18,13 +24,42 @@ const URL_MAX_LENGTH = 2048;
 // three-value set.
 const DEPTH_PREFERENCE_VALUES = ["accessible", "standard", "technical"] as const;
 
+// Phase 12c — the Settings UI now edits the full commentary-input set
+// (role/domain/seniority/sectors/goals/topics). All three new fields
+// (`domain`, `seniority`, `topic_interests`) are OPTIONAL on the wire:
+// older third-party callers and the "email-only" unsubscribe shim that
+// predates 12c keep working unchanged. When a field is present in the
+// body we diff it against the stored value and bump `profile_version`
+// if anything commentary-relevant changed.
+//
+// Fields that BUMP profile_version: role, domain, seniority, sectors,
+// goals, topics. Fields that do NOT: depth_preference (independent
+// cache-key dimension already), email_frequency / email_unsubscribed
+// (nothing to do with commentary).
+//
+// Roles/sectors/seniority use z.enum so the Zod error message identifies
+// the exact invalid value; topic pairs are validated via a refine after
+// basic shape because the sector↔topic relation is cross-field.
+const topicSelectionSchema = z.object({
+  sector: z.enum(SECTORS),
+  topic: z.string().min(1).max(TOPIC_MAX_LENGTH),
+});
+
 const updateProfileSchema = z.object({
-  sectors: z.array(z.string().min(1).max(SECTOR_MAX_LENGTH)).min(1).max(20),
-  role: z.string().min(1).max(ROLE_MAX_LENGTH),
+  sectors: z.array(z.enum(SECTORS)).min(1).max(SECTORS.length),
+  role: z.enum(ROLES),
   goals: z.array(z.string().min(1).max(GOAL_MAX_LENGTH)).min(1).max(20),
   email_frequency: z.enum(["daily", "weekly", "never"]),
   email_unsubscribed: z.boolean().optional(),
   depth_preference: z.enum(DEPTH_PREFERENCE_VALUES).optional(),
+  // Phase 12c additions — all optional for backward compat.
+  domain: z
+    .string()
+    .min(1)
+    .refine(isValidDomain, { message: "Domain is not a recognized value" })
+    .optional(),
+  seniority: z.enum(SENIORITIES).optional(),
+  topic_interests: z.array(topicSelectionSchema).max(200).optional(),
 });
 
 const updateUserSchema = z
@@ -101,6 +136,43 @@ export async function getMyProfile(
   }
 }
 
+// Set equality on string arrays — used to detect commentary-relevant
+// changes to the set-shaped fields (sectors, goals, topics). Order
+// and duplicates are ignored; what matters for commentary is "which
+// values were chosen."
+function sameSet(a: readonly string[] | null, b: readonly string[] | null): boolean {
+  const aSet = new Set(a ?? []);
+  const bSet = new Set(b ?? []);
+  if (aSet.size !== bSet.size) return false;
+  for (const v of aSet) {
+    if (!bSet.has(v)) return false;
+  }
+  return true;
+}
+
+// Re-enforce the (sector, topic) pairing after Zod has validated each
+// piece in isolation. Mirrors the onboarding controller's helper —
+// duplicated rather than shared because the cross-field validation is
+// cheap and keeping each controller self-contained avoids an import
+// cycle between the two boundary surfaces.
+function validateTopicPairs(
+  topics: { sector: string; topic: string }[],
+): { sector: string; topic: string }[] {
+  const invalid = topics.filter((t) => !isValidTopicForSector(t.sector, t.topic));
+  if (invalid.length > 0) {
+    throw new AppError("INVALID_INPUT", "One or more topics are not valid for their sector", 400, {
+      invalid,
+    });
+  }
+  const seen = new Set<string>();
+  return topics.filter((t) => {
+    const key = `${t.sector}:${t.topic}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export async function updateMyProfile(
   req: Request,
   res: Response,
@@ -110,41 +182,142 @@ export async function updateMyProfile(
     const userId = requireUserId(req);
     const input = updateProfileSchema.parse(req.body);
 
-    const patch = {
-      sectors: input.sectors,
-      role: input.role,
-      goals: input.goals,
-      emailFrequency: input.email_frequency,
-      updatedAt: new Date(),
-      ...(input.email_unsubscribed !== undefined
-        ? { emailUnsubscribed: input.email_unsubscribed }
-        : {}),
-      ...(input.depth_preference !== undefined
-        ? { depthPreference: input.depth_preference }
-        : {}),
-    };
+    // Validate + dedupe topics OUTSIDE the transaction so a 400 on an
+    // invalid pair doesn't spin up a tx we'd just roll back.
+    const validatedTopics =
+      input.topic_interests !== undefined
+        ? validateTopicPairs(input.topic_interests)
+        : null;
 
+    // Phase 12c — the full write runs inside a transaction so the
+    // profile patch, profile_version bump, and (optional) topic-set
+    // replacement land atomically. A partial write would leave the
+    // commentary cache keyed on a stale profile_version.
     const profile = await db.transaction(async (tx) => {
+      // Pull the fields we need to diff against — role, domain,
+      // seniority, sectors, goals, profileVersion. We also select
+      // userId so the existence check works for the insert path.
       const [existing] = await tx
-        .select({ userId: userProfiles.userId })
+        .select({
+          userId: userProfiles.userId,
+          role: userProfiles.role,
+          domain: userProfiles.domain,
+          seniority: userProfiles.seniority,
+          sectors: userProfiles.sectors,
+          goals: userProfiles.goals,
+          profileVersion: userProfiles.profileVersion,
+        })
         .from(userProfiles)
         .where(eq(userProfiles.userId, userId))
         .limit(1);
 
+      // Read current topic interests only when the caller is supplying
+      // a new topic set — otherwise the diff is skipped anyway.
+      const existingTopics =
+        existing && validatedTopics !== null
+          ? await tx
+              .select({
+                sector: userTopicInterests.sector,
+                topic: userTopicInterests.topic,
+              })
+              .from(userTopicInterests)
+              .where(eq(userTopicInterests.userId, userId))
+          : [];
+
+      // Compute whether anything commentary-relevant changed. A fresh
+      // insert (no `existing` row) is treated as "no bump needed" —
+      // the column defaults to 1 and an upsert-from-settings for a
+      // user with no profile row is an unusual-but-not-bump case
+      // (profile_version=1 is the right starting point).
+      let commentaryRelevantChanged = false;
+      if (existing) {
+        if (input.role !== existing.role) commentaryRelevantChanged = true;
+        if (
+          input.domain !== undefined &&
+          input.domain !== (existing.domain ?? undefined)
+        ) {
+          commentaryRelevantChanged = true;
+        }
+        if (
+          input.seniority !== undefined &&
+          input.seniority !== (existing.seniority ?? undefined)
+        ) {
+          commentaryRelevantChanged = true;
+        }
+        if (!sameSet(existing.sectors, input.sectors)) {
+          commentaryRelevantChanged = true;
+        }
+        if (!sameSet(existing.goals, input.goals)) {
+          commentaryRelevantChanged = true;
+        }
+        if (validatedTopics !== null) {
+          const existingKeys = existingTopics.map((t) => `${t.sector}:${t.topic}`);
+          const newKeys = validatedTopics.map((t) => `${t.sector}:${t.topic}`);
+          if (!sameSet(existingKeys, newKeys)) {
+            commentaryRelevantChanged = true;
+          }
+        }
+      }
+
+      const patch: Record<string, unknown> = {
+        sectors: input.sectors,
+        role: input.role,
+        goals: input.goals,
+        emailFrequency: input.email_frequency,
+        updatedAt: new Date(),
+      };
+      if (input.email_unsubscribed !== undefined) {
+        patch.emailUnsubscribed = input.email_unsubscribed;
+      }
+      if (input.depth_preference !== undefined) {
+        patch.depthPreference = input.depth_preference;
+      }
+      if (input.domain !== undefined) {
+        patch.domain = input.domain;
+      }
+      if (input.seniority !== undefined) {
+        patch.seniority = input.seniority;
+      }
+      if (existing && commentaryRelevantChanged) {
+        patch.profileVersion = existing.profileVersion + 1;
+      }
+
+      let row;
       if (existing) {
         const [updated] = await tx
           .update(userProfiles)
           .set(patch)
           .where(eq(userProfiles.userId, userId))
           .returning();
-        return updated;
+        row = updated;
+      } else {
+        const [inserted] = await tx
+          .insert(userProfiles)
+          .values({ userId, ...patch })
+          .returning();
+        row = inserted;
       }
 
-      const [inserted] = await tx
-        .insert(userProfiles)
-        .values({ userId, ...patch })
-        .returning();
-      return inserted;
+      // Replace the topic-interest set wholesale when supplied. Same
+      // "delete-then-insert inside the same tx" pattern as the
+      // onboarding completion path — safer than diffing and cheap at
+      // the row counts we allow (max 200).
+      if (validatedTopics !== null) {
+        await tx
+          .delete(userTopicInterests)
+          .where(eq(userTopicInterests.userId, userId));
+        if (validatedTopics.length > 0) {
+          await tx.insert(userTopicInterests).values(
+            validatedTopics.map((t) => ({
+              userId,
+              sector: t.sector,
+              topic: t.topic,
+            })),
+          );
+        }
+      }
+
+      return row;
     });
 
     if (!profile) {

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/0009_phase12c_commentary_cache.sql
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/0009_phase12c_commentary_cache.sql
@@ -1,0 +1,70 @@
+-- Phase 12c: per-user, per-story Haiku-generated commentary.
+--
+-- Two user_profiles additions + one new cache table. The v2 prompt
+-- originally named `users` as the target table; we put these on
+-- `user_profiles` to match the 12b pattern (every onboarding-captured
+-- field — seniority, depth_preference, digest_preference, timezone —
+-- lives there) and to avoid a cross-table JOIN on every commentary
+-- lookup.
+--
+-- `domain` is nullable at the DB boundary, same shape as the other
+-- onboarding-captured fields. `user_profiles` rows can exist pre-
+-- onboarding (created by the unsubscribe flow — see 0008's comment
+-- block); the authoritative "is this user onboarded" predicate is
+-- `completed_at IS NOT NULL`, and Zod at the /onboarding/complete
+-- endpoint enforces `domain` is a non-empty string. A CHECK constraint
+-- rejects empty strings at the DB so a partial write can't smuggle
+-- an empty value past the zod guard.
+--
+-- `profile_version` starts at 1 and increments on any post-onboarding
+-- mutation to role / domain / seniority / sectors / topics / goals
+-- (via Settings). Onboarding completion inserts with the default 1 —
+-- it does not bump. NOT NULL DEFAULT 1 is safe because the DEFAULT
+-- fills any existing rows during the ALTER, and every insert path
+-- will either rely on the default or set it explicitly.
+--
+-- commentary_cache is append-only. Key: (user_id, story_id, depth,
+-- profile_version). A cache hit short-circuits the Haiku call; a
+-- miss triggers regeneration. Depth and profile_version are part of
+-- the key so changing either invalidates prior rows without an
+-- explicit delete — stale rows are reaped by a stub GC function
+-- (documented but unscheduled in 12c; actual scheduling in 12c.1).
+-- Depth is enforced via CHECK rather than a new pgEnum, matching the
+-- depth_preference pattern from 0008.
+
+-- ---------- user_profiles alterations ----------
+
+ALTER TABLE "user_profiles" ADD COLUMN IF NOT EXISTS "domain" text;--> statement-breakpoint
+
+ALTER TABLE "user_profiles"
+	ADD CONSTRAINT "user_profiles_domain_check"
+	CHECK ("domain" IS NULL OR length("domain") > 0);--> statement-breakpoint
+
+ALTER TABLE "user_profiles" ADD COLUMN IF NOT EXISTS "profile_version" integer NOT NULL DEFAULT 1;--> statement-breakpoint
+
+-- ---------- commentary_cache ----------
+
+CREATE TABLE IF NOT EXISTS "commentary_cache" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"story_id" uuid NOT NULL,
+	"depth" text NOT NULL,
+	"profile_version" integer NOT NULL,
+	"commentary" text NOT NULL,
+	"generated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_accessed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "commentary_cache_depth_check"
+		CHECK ("depth" IN ('accessible', 'standard', 'technical')),
+	CONSTRAINT "commentary_cache_user_id_fk"
+		FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE,
+	CONSTRAINT "commentary_cache_story_id_fk"
+		FOREIGN KEY ("story_id") REFERENCES "stories"("id") ON DELETE CASCADE,
+	CONSTRAINT "commentary_cache_key_unique"
+		UNIQUE ("user_id", "story_id", "depth", "profile_version")
+);--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "commentary_cache_user_idx"
+	ON "commentary_cache" USING btree ("user_id");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "commentary_cache_user_story_idx"
+	ON "commentary_cache" USING btree ("user_id", "story_id");

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/meta/_journal.json
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777284000007,
       "tag": "0008_phase12b_onboarding",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777284000008,
+      "tag": "0009_phase12c_commentary_cache",
+      "breakpoints": true
     }
   ]
 }

--- a/OneDrive/Desktop/signal-app/backend/src/db/schema.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/db/schema.ts
@@ -59,18 +59,31 @@ export type DepthPreference = (typeof DEPTH_PREFERENCES)[number];
 export const DIGEST_PREFERENCES = ["morning", "evening", "none"] as const;
 export type DigestPreference = (typeof DIGEST_PREFERENCES)[number];
 
+// Phase 12c added `domain` (free-text from a curated list, selected on
+// Screen 2) and `profile_version` (monotonic int, bumps on any post-
+// onboarding mutation to commentary-affecting fields). Both are on
+// user_profiles rather than users — every onboarding-captured field
+// already lives here, and keeping them co-located avoids a cross-
+// table JOIN on every commentary lookup. `domain` is nullable at the
+// DB layer (same pattern as seniority/depth_preference — pre-
+// onboarding rows from the unsubscribe flow need to exist without
+// it) plus a CHECK rejecting empty strings. `profile_version` is
+// NOT NULL DEFAULT 1; the default fills existing rows during the
+// ALTER and the completion path leaves it at 1.
 export const userProfiles = pgTable("user_profiles", {
   userId: uuid("user_id")
     .primaryKey()
     .references(() => users.id, { onDelete: "cascade" }),
   sectors: text("sectors").array(),
   role: varchar("role", { length: 50 }),
+  domain: text("domain"),
   seniority: text("seniority"),
   depthPreference: text("depth_preference").$type<DepthPreference>(),
   goals: text("goals").array(),
   digestPreference: text("digest_preference").$type<DigestPreference>(),
   timezone: text("timezone"),
   completedAt: timestamp("completed_at", { withTimezone: true }),
+  profileVersion: integer("profile_version").notNull().default(1),
   emailFrequency: emailFrequencyEnum("email_frequency").notNull().default("weekly"),
   emailUnsubscribed: boolean("email_unsubscribed").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -409,6 +422,45 @@ export const apiKeys = pgTable(
   }),
 );
 
+// ---------- Commentary cache ----------
+//
+// Phase 12c. Append-only cache for per-user, per-story Haiku-generated
+// commentary. Key is (user_id, story_id, depth, profile_version) —
+// changing depth or any commentary-affecting profile field bumps
+// profile_version and causes subsequent lookups to miss, triggering
+// regeneration on next view. Failed Haiku calls fall back to the
+// tiered template and are deliberately NOT cached; only successful
+// model output lands here. GC of orphaned rows is a stub in 12c and
+// gets scheduled in 12c.1.
+
+export const commentaryCache = pgTable(
+  "commentary_cache",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    storyId: uuid("story_id")
+      .notNull()
+      .references(() => stories.id, { onDelete: "cascade" }),
+    depth: text("depth").$type<DepthLevel>().notNull(),
+    profileVersion: integer("profile_version").notNull(),
+    commentary: text("commentary").notNull(),
+    generatedAt: timestamp("generated_at", { withTimezone: true }).notNull().defaultNow(),
+    lastAccessedAt: timestamp("last_accessed_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    keyUnique: unique("commentary_cache_key_unique").on(
+      t.userId,
+      t.storyId,
+      t.depth,
+      t.profileVersion,
+    ),
+    userIdx: index("commentary_cache_user_idx").on(t.userId),
+    userStoryIdx: index("commentary_cache_user_story_idx").on(t.userId, t.storyId),
+  }),
+);
+
 // ---------- Exported row types ----------
 
 export type User = typeof users.$inferSelect;
@@ -440,3 +492,5 @@ export type LearningPathStory = typeof learningPathStories.$inferSelect;
 export type UserLearningProgress = typeof userLearningProgress.$inferSelect;
 export type ApiKey = typeof apiKeys.$inferSelect;
 export type NewApiKey = typeof apiKeys.$inferInsert;
+export type CommentaryCacheRow = typeof commentaryCache.$inferSelect;
+export type NewCommentaryCacheRow = typeof commentaryCache.$inferInsert;

--- a/OneDrive/Desktop/signal-app/backend/src/routes/stories.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/routes/stories.ts
@@ -7,6 +7,7 @@ import {
   searchStories,
   unsaveStory,
 } from "../controllers/storyController";
+import { getCommentary } from "../controllers/commentaryController";
 import {
   createComment,
   listStoryComments,
@@ -33,4 +34,8 @@ storiesRouter.post("/:id/save", saveStory);
 storiesRouter.delete("/:id/save", unsaveStory);
 storiesRouter.get("/:story_id/comments", listStoryComments);
 storiesRouter.post("/:story_id/comments", createComment);
+// Commentary (Phase 12c) is intentionally ungated by requireProfile —
+// story detail direct-links can land half-onboarded users here, and
+// the controller itself returns a clean 400 if the profile is missing.
+storiesRouter.get("/:id/commentary", getCommentary);
 storiesRouter.get("/:id", getStoryById);

--- a/OneDrive/Desktop/signal-app/backend/src/services/commentaryFallback.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/commentaryFallback.ts
@@ -1,0 +1,308 @@
+// Phase 12c — deterministic fallback commentary.
+//
+// When Haiku is unreachable, times out, returns empty, or emits banned
+// clichés, we fall back to a locally-constructed template so the feed
+// is never left with a null "why this matters". The template is tiered
+// by how much personalization context is available:
+//
+//   Tier 1 — role + sector match + at least one matched topic.
+//            Named profile anchor + concrete topic callout.
+//   Tier 2 — role + sector match but no matched topics
+//            (user picked Skip on topics, or no overlap in-sector).
+//            Named profile anchor, sector-level framing only.
+//   Tier 3 — profile is incomplete OR the story is off-sector for the
+//            user. Generic framing + anomaly log: in a normal post-
+//            onboarding flow every user has role/domain/seniority, so
+//            landing in Tier 3 usually means a data problem worth
+//            looking at (unsubscribe-only rows, dev seed data, etc.).
+//
+// Banned-phrase enforcement: we reject a short list of well-known
+// commentary clichés ("game-changing", "revolutionary", etc.) both in
+// Haiku output (reroute → fallback with reason="banned_phrase") and in
+// the fallback templates themselves (defense-in-depth; a template that
+// trips this is a code bug and logs an anomaly).
+//
+// Pure module — no DB, no I/O. Structured-log emission is done through
+// a caller-supplied logger so tests don't need to monkeypatch console.
+
+import type { MatchedInterests } from "../utils/matchedInterests";
+
+// Word-boundary regexes — we reject "revolutionary" as a cliché but
+// tolerate "evolutionary" (no false positive for the shared stem).
+// Matched case-insensitively; tested via .test(text.toLowerCase()).
+//
+// CONTENT DECISION — REVIEW BEFORE MERGE. This list was assembled from
+// the most frequent offenders in the Phase 12a regeneration script
+// output, plus canonical trade-press clichés. Tune in 12c.1 against a
+// real-world sample; the list is intentionally small and conservative
+// so we don't over-reject legitimate Haiku output.
+export const BANNED_PHRASES: readonly string[] = [
+  "game-changing",
+  "game changing",
+  "game-changer",
+  "revolutionary",
+  "revolutionize",
+  "groundbreaking",
+  "cutting-edge",
+  "paradigm shift",
+  "unprecedented",
+  "rapidly changing landscape",
+  "seismic shift",
+  "transformative breakthrough",
+] as const;
+
+const BANNED_PATTERNS: readonly RegExp[] = BANNED_PHRASES.map(
+  (p) => new RegExp(`\\b${p.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}\\b`, "i"),
+);
+
+export interface BannedPhraseResult {
+  clean: boolean;
+  offenders: string[];
+}
+
+/**
+ * Check `text` against the banned-phrase list. Returns `clean: true`
+ * and `offenders: []` for acceptable output; `clean: false` plus the
+ * list of matched phrases (lowercased, as declared in BANNED_PHRASES)
+ * when any hit. The caller decides what to do with the result — Haiku
+ * hits reroute to fallback; template hits log an anomaly and we strip
+ * the offender by replacing with a neutral synonym at build time.
+ */
+export function checkBannedPhrases(text: string): BannedPhraseResult {
+  const offenders: string[] = [];
+  for (let i = 0; i < BANNED_PATTERNS.length; i++) {
+    const pat = BANNED_PATTERNS[i]!;
+    if (pat.test(text)) offenders.push(BANNED_PHRASES[i]!);
+  }
+  return { clean: offenders.length === 0, offenders };
+}
+
+export type FallbackTier = "tier1" | "tier2" | "tier3";
+
+export type Tier3Reason =
+  | "haiku_timeout"
+  | "haiku_empty"
+  | "haiku_api_error"
+  | "haiku_no_api_key"
+  | "haiku_banned_phrase"
+  | "missing_profile_fields"
+  | "off_sector"
+  | "template_banned_phrase";
+
+export interface FallbackInput {
+  storyHeadline: string;
+  storySector: string;
+  storyWhyItMatters: string; // role-neutral editorial baseline (stories.why_it_matters)
+  profile: {
+    role: string | null;
+    domain: string | null;
+    seniority: string | null;
+  };
+  matched: MatchedInterests;
+  // When the caller landed in fallback because of a Haiku-side issue,
+  // propagate the reason so the Tier 3 anomaly log captures it
+  // verbatim. Omitted for cache-miss-without-key / cache-hit paths.
+  haikuFailureReason?: Tier3Reason;
+}
+
+export interface FallbackResult {
+  text: string;
+  tier: FallbackTier;
+  // Populated when tier === "tier3". The service consumer emits this
+  // via its structured logger exactly once per fallback invocation.
+  anomaly?: Tier3Anomaly;
+}
+
+export interface Tier3Anomaly {
+  event: "commentary_tier3_fallback";
+  reason: Tier3Reason;
+  missingProfileFields?: readonly ("role" | "domain" | "seniority")[];
+  // Populated when a template string itself trips banned-phrase check
+  // — this is a code bug, not a user-data issue.
+  templateOffenders?: readonly string[];
+}
+
+// Human-readable fragments used in templates. Kept separate from the
+// template assembly so the same phrase can be reused across tiers.
+const SECTOR_LABEL: Record<string, string> = {
+  ai: "the AI industry",
+  finance: "global finance",
+  semiconductors: "the semiconductor industry",
+};
+
+function sectorLabel(sector: string): string {
+  return SECTOR_LABEL[sector] ?? sector;
+}
+
+function roleFragment(role: string): string {
+  // Intentionally generic — the Tier 1/2 framing is "as an X working
+  // in…" and the Haiku prompt handles the real personalization. This
+  // is the failure-mode copy.
+  switch (role) {
+    case "engineer":
+      return "As an engineer";
+    case "researcher":
+      return "As a researcher";
+    case "manager":
+      return "As a manager";
+    case "vc":
+      return "As an investor";
+    case "analyst":
+      return "As an analyst";
+    case "founder":
+      return "As a founder";
+    case "executive":
+      return "As an executive";
+    case "student":
+      return "As a student";
+    default:
+      return "For anyone tracking this space";
+  }
+}
+
+function topicFragment(topics: string[]): string {
+  if (topics.length === 0) return "";
+  // Strip the snake_case values ("foundation_models" → "foundation
+  // models"). Labels live in the frontend catalog and are not worth
+  // duplicating backend-side for a fallback path.
+  const display = topics.map((t) => t.replace(/_/g, " "));
+  if (display.length === 1) return display[0]!;
+  if (display.length === 2) return `${display[0]} and ${display[1]}`;
+  return `${display.slice(0, -1).join(", ")}, and ${display[display.length - 1]}`;
+}
+
+function buildTier1(i: FallbackInput): string {
+  const role = roleFragment(i.profile.role!);
+  const sector = sectorLabel(i.storySector);
+  const topics = topicFragment(i.matched.matchedTopics);
+  // Short, concrete, no superlatives. The cliché list above would
+  // catch us if we strayed.
+  return `${role} tracking ${sector}, this touches ${topics} — the area you flagged as most relevant. ${i.storyWhyItMatters}`;
+}
+
+function buildTier2(i: FallbackInput): string {
+  const role = roleFragment(i.profile.role!);
+  const sector = sectorLabel(i.storySector);
+  return `${role} following ${sector}, this is worth your attention: ${i.storyWhyItMatters}`;
+}
+
+function buildTier3(i: FallbackInput): string {
+  // Deliberately free of profile anchors — we don't have enough to
+  // pretend otherwise. Leans on the editorial why_it_matters baseline.
+  const sector = sectorLabel(i.storySector);
+  return `Worth knowing if you follow ${sector}: ${i.storyWhyItMatters}`;
+}
+
+/** Fields the Tier 1/2 templates need from a profile. */
+function missingProfileFields(
+  profile: FallbackInput["profile"],
+): ("role" | "domain" | "seniority")[] {
+  const missing: ("role" | "domain" | "seniority")[] = [];
+  if (!profile.role) missing.push("role");
+  if (!profile.domain) missing.push("domain");
+  if (!profile.seniority) missing.push("seniority");
+  return missing;
+}
+
+/**
+ * Build a fallback commentary string plus tier metadata. The result is
+ * always safe to serve — the function sanitizes its own output against
+ * the banned-phrase list, swapping matches for neutral synonyms so the
+ * user never sees placeholder text or a blank card.
+ *
+ * Tier selection:
+ *   - profile missing role/domain/seniority → tier3 (anomaly)
+ *   - or Haiku failure reason supplied       → tier3 (anomaly)
+ *   - or story sector not in user's sectors  → tier3 (anomaly, "off_sector")
+ *   - else matched topics > 0                → tier1
+ *   - else                                   → tier2
+ */
+export function buildFallbackCommentary(input: FallbackInput): FallbackResult {
+  const missing = missingProfileFields(input.profile);
+  let tier: FallbackTier;
+  let anomaly: Tier3Anomaly | undefined;
+
+  if (input.haikuFailureReason) {
+    tier = "tier3";
+    anomaly = {
+      event: "commentary_tier3_fallback",
+      reason: input.haikuFailureReason,
+    };
+  } else if (missing.length > 0) {
+    tier = "tier3";
+    anomaly = {
+      event: "commentary_tier3_fallback",
+      reason: "missing_profile_fields",
+      missingProfileFields: missing,
+    };
+  } else if (!input.matched.matchedSector) {
+    tier = "tier3";
+    anomaly = {
+      event: "commentary_tier3_fallback",
+      reason: "off_sector",
+    };
+  } else if (input.matched.matchedTopics.length > 0) {
+    tier = "tier1";
+  } else {
+    tier = "tier2";
+  }
+
+  let text =
+    tier === "tier1"
+      ? buildTier1(input)
+      : tier === "tier2"
+        ? buildTier2(input)
+        : buildTier3(input);
+
+  // Defense-in-depth: the template strings above are human-reviewed,
+  // but a future edit could slip in a banned phrase. We check and
+  // surgically replace — the output is still useful, and the anomaly
+  // log tells an operator to fix the template.
+  const banCheck = checkBannedPhrases(text);
+  if (!banCheck.clean) {
+    text = scrubBannedPhrases(text);
+    const existing = anomaly ?? {
+      event: "commentary_tier3_fallback" as const,
+      reason: "template_banned_phrase" as const,
+    };
+    anomaly = {
+      ...existing,
+      // If we were already tier3 for a different reason, keep the
+      // original reason but flag the scrub via templateOffenders.
+      templateOffenders: banCheck.offenders,
+    };
+    // Upgrade tier to tier3 if the scrubbing-required case wasn't
+    // already tier3 — we want anomaly emission to be the signal.
+    tier = "tier3";
+  }
+
+  return { text, tier, anomaly };
+}
+
+// Neutral substitutions used by the defense-in-depth scrubber. Keys
+// match BANNED_PHRASES entries (lowercased) exactly.
+const NEUTRAL_SWAPS: Record<string, string> = {
+  "game-changing": "significant",
+  "game changing": "significant",
+  "game-changer": "notable development",
+  revolutionary: "substantial",
+  revolutionize: "reshape",
+  groundbreaking: "notable",
+  "cutting-edge": "current",
+  "paradigm shift": "structural change",
+  unprecedented: "unusual",
+  "rapidly changing landscape": "shifting environment",
+  "seismic shift": "major change",
+  "transformative breakthrough": "important development",
+};
+
+function scrubBannedPhrases(text: string): string {
+  let out = text;
+  for (const phrase of BANNED_PHRASES) {
+    const pat = new RegExp(`\\b${phrase.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}\\b`, "gi");
+    out = out.replace(pat, NEUTRAL_SWAPS[phrase] ?? "");
+  }
+  // Collapse any double spaces left by empty-string swaps (future-proof
+  // if NEUTRAL_SWAPS gains a "" entry).
+  return out.replace(/\s{2,}/g, " ").trim();
+}

--- a/OneDrive/Desktop/signal-app/backend/src/services/commentaryFallback.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/commentaryFallback.ts
@@ -85,6 +85,13 @@ export type Tier3Reason =
   | "haiku_api_error"
   | "haiku_no_api_key"
   | "haiku_banned_phrase"
+  // Post-insert re-read came up empty — no row from onConflictDoNothing
+  // and no row from the follow-up select. Unreachable under the current
+  // write path (the insert either returns our row or loses to a racer
+  // whose row the re-read sees); the constant exists so an anomaly log
+  // on this branch reports the true cause rather than being mislabeled
+  // as a banned-phrase reject.
+  | "cache_race_unexpected"
   | "missing_profile_fields"
   | "off_sector"
   | "template_banned_phrase";

--- a/OneDrive/Desktop/signal-app/backend/src/services/commentaryPrompt.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/commentaryPrompt.ts
@@ -1,0 +1,128 @@
+// Phase 12c — Haiku prompt construction for per-user, per-story
+// commentary.
+//
+// Single source of truth for the prompt shape. Kept pure so unit tests
+// can assert verbatim substrings without spinning up a mock Anthropic
+// client. The prompt layers (in this order):
+//
+//   1. Role framing — who the model is writing for (the product copy
+//      asks for commentary, not a recap).
+//   2. Audience profile — role / domain / seniority / sectors / goals
+//      / matched-topic callouts.
+//   3. Story block — headline + editorial context + the role-neutral
+//      why_it_matters baseline (so the model has the facts without us
+//      guessing them from the headline alone).
+//   4. Depth guidance — same tone ladder as depthVariantGenerator, so
+//      the three depths remain directly comparable.
+//   5. Output contract — banned-phrase list + "no preamble" reminder.
+//
+// The banned-phrase list is hardcoded into the prompt so the model
+// self-filters; the post-generation `checkBannedPhrases` pass
+// (commentaryFallback.ts) is a defense-in-depth trip-wire, not the
+// primary enforcement.
+
+import { BANNED_PHRASES } from "./commentaryFallback";
+import type { DepthLevel } from "../db/schema";
+
+// Matches depthVariantGenerator's guidance so the two prompt paths stay
+// comparable. Word counts intentionally match.
+const DEPTH_GUIDANCE: Record<DepthLevel, string> = {
+  accessible:
+    "Plain language, no domain jargon. A smart non-specialist reader. " +
+    "Prioritize the one thing the reader should walk away knowing. ~80–120 words.",
+  standard:
+    "Working-professional framing; light domain terminology allowed. " +
+    "Implications and second-order effects over narrative recap. ~120–160 words.",
+  technical:
+    "Domain insider. Precise terminology; cite specific numbers, " +
+    "mechanisms, or people when they change the interpretation. Skip " +
+    "introductory framing. ~160–220 words.",
+};
+
+export interface CommentaryPromptInputs {
+  depth: DepthLevel;
+  // Profile pieces. `role`, `domain`, and `seniority` are required by
+  // Tier 1/2 fallback but may be null when landing here — the prompt
+  // still reads coherently, just with blanker framing.
+  profile: {
+    role: string | null;
+    domain: string | null;
+    seniority: string | null;
+    sectors: string[] | null;
+    goals: string[] | null;
+  };
+  matchedTopics: string[]; // Topics declared against this story's sector.
+  story: {
+    sector: string;
+    headline: string;
+    context: string;
+    whyItMatters: string;
+  };
+}
+
+// Human-readable fragment helpers. Match commentaryFallback's output
+// where possible so the tiered paths don't feel jarringly different.
+const SECTOR_LABEL: Record<string, string> = {
+  ai: "AI",
+  finance: "finance",
+  semiconductors: "semiconductors",
+};
+
+function humanList(values: string[]): string {
+  const items = values.map((v) => v.replace(/_/g, " "));
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0]!;
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function audienceBlock(inputs: CommentaryPromptInputs): string {
+  const { profile, matchedTopics, story } = inputs;
+  const lines: string[] = [];
+  if (profile.role) lines.push(`Role: ${profile.role}`);
+  if (profile.domain) lines.push(`Field / domain: ${profile.domain.replace(/_/g, " ")}`);
+  if (profile.seniority) lines.push(`Seniority: ${profile.seniority.replace(/_/g, " ")}`);
+  if (profile.sectors && profile.sectors.length > 0) {
+    const labeled = profile.sectors.map((s) => SECTOR_LABEL[s] ?? s);
+    lines.push(`Tracks sectors: ${humanList(labeled)}`);
+  }
+  if (profile.goals && profile.goals.length > 0) {
+    lines.push(`Goals on this product: ${humanList(profile.goals)}`);
+  }
+  // Topics block — only include the ones matched for THIS story's
+  // sector (cross-sector picks are noise for this story). Omit the
+  // line entirely if nothing matched so the model doesn't try to
+  // invent a connection.
+  if (matchedTopics.length > 0) {
+    lines.push(
+      `Topics they flagged in ${SECTOR_LABEL[story.sector] ?? story.sector}: ${humanList(matchedTopics)}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+export function buildCommentaryPrompt(inputs: CommentaryPromptInputs): string {
+  const { depth, story } = inputs;
+  const sectorLabel = SECTOR_LABEL[story.sector] ?? story.sector;
+
+  return [
+    `You are writing a short, personalized "why this matters" paragraph for a single reader of SIGNAL — a ranked-feed intelligence product covering ${sectorLabel}, finance, and semiconductors. The reader has already chosen to read this story; commentary must explain why it matters to THEM specifically, not recap what it is.`,
+    "",
+    "Reader profile:",
+    audienceBlock(inputs),
+    "",
+    `Story sector: ${sectorLabel}`,
+    `Headline: ${story.headline}`,
+    "",
+    `Context (editorial, facts only — do not paraphrase wholesale): ${story.context}`,
+    "",
+    `Role-neutral editorial baseline on why it matters (reference, do not copy): ${story.whyItMatters}`,
+    "",
+    `Audience depth: ${depth}. ${DEPTH_GUIDANCE[depth]}`,
+    "",
+    "Banned phrases — do not use any of these or close variants. They mark the commentary as low-effort trade-press copy and defeat the whole point of personalization:",
+    BANNED_PHRASES.map((p) => `- ${p}`).join("\n"),
+    "",
+    "Output ONLY the commentary paragraph. No preamble, no headers, no bullet lists, no quotes around the output. Address the reader in second person where natural.",
+  ].join("\n");
+}

--- a/OneDrive/Desktop/signal-app/backend/src/services/commentaryService.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/commentaryService.ts
@@ -265,8 +265,21 @@ export async function getOrGenerateCommentary(
           source: "cache",
         };
       }
-      // Truly unexpected — fall through to the fallback path rather
-      // than throw; the user gets deterministic commentary.
+      // Truly unexpected — the insert returned no row AND the re-read
+      // came up empty. Route through the fallback so the user still
+      // gets deterministic commentary, but use a dedicated Tier 3
+      // reason: stamping this as "haiku_banned_phrase" (the old
+      // fall-through destination) would mislead operators investigating
+      // the anomaly log. Unreachable in normal operation.
+      return buildAndLogFallback(
+        input,
+        story,
+        profileShape,
+        matched,
+        "cache_race_unexpected",
+        logger,
+        undefined,
+      );
     }
     // Haiku text tripped the banned-phrase gate. Reroute to fallback
     // with an explicit reason so the Tier 3 anomaly log says why.

--- a/OneDrive/Desktop/signal-app/backend/src/services/commentaryService.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/commentaryService.ts
@@ -1,0 +1,346 @@
+// Phase 12c — per-user, per-story commentary orchestrator.
+//
+// Cache-miss path:
+//   1. Load user_profiles + user_topic_interests for this user.
+//   2. Compute matched_interests (sector overlap + in-sector topics).
+//   3. Build the Haiku prompt.
+//   4. Call Haiku. Success → check banned phrases → on pass, insert
+//      into commentary_cache and return. Any failure → tiered
+//      fallback (not cached).
+//   5. Anomaly log when Tier 3 fires, whatever the cause.
+//
+// Cache-hit path:
+//   1. Update last_accessed_at to now(). See LAST_ACCESSED_UPDATE_MODE
+//      below — in 12c we do this on every hit; 12c.1 may batch.
+//   2. Return the cached commentary.
+//
+// Cache key is (userId, storyId, depth, profileVersion). `depth`
+// comes in as the user's declared depth_preference or an explicit
+// override on the /commentary route (e.g. a Premium user toggling the
+// depth selector on story detail).
+
+import { and, eq } from "drizzle-orm";
+import type { db as DbType } from "../db";
+import {
+  commentaryCache,
+  stories,
+  userProfiles,
+  userTopicInterests,
+  type DepthLevel,
+} from "../db/schema";
+import {
+  buildFallbackCommentary,
+  checkBannedPhrases,
+  type FallbackResult,
+  type Tier3Reason,
+} from "./commentaryFallback";
+import { buildCommentaryPrompt } from "./commentaryPrompt";
+import {
+  callHaikuForCommentary,
+  type HaikuClientDeps,
+  type HaikuFailureReason,
+} from "./haikuCommentaryClient";
+import { computeMatchedInterests } from "../utils/matchedInterests";
+
+// 12c decision: update last_accessed_at on every cache hit. This lets
+// a future LRU-style GC job (12c.1) prune cold rows using real access
+// recency, not just generated_at. It's one extra UPDATE per feed row
+// — cheap, unindexed write, but if it shows up in load testing we'll
+// batch into a per-request deduped write-through in 12c.1. TODO: see
+// 12c.1 opportunistic-update proposal.
+const LAST_ACCESSED_UPDATE_MODE = "every_hit" as const;
+
+export interface CommentaryServiceDeps {
+  db: typeof DbType;
+  haiku?: HaikuClientDeps;
+  // Structured logger. Tests substitute a jest.fn(); production wiring
+  // uses a console.log-based shim until we formalize a pino/Sentry
+  // pipe for commentary events.
+  logger?: Pick<Console, "info" | "warn" | "error">;
+  // Clock injection for deterministic generated_at / last_accessed_at
+  // in tests. Defaults to Date.now().
+  now?: () => Date;
+}
+
+export interface GetOrGenerateInput {
+  userId: string;
+  storyId: string;
+  depth: DepthLevel;
+  // Snapshot of the user's profile_version at request time. The
+  // caller (controller) reads it off user_profiles in the same
+  // transaction that issued the request so a concurrent Settings
+  // update can't cause a stale-cache read.
+  profileVersion: number;
+}
+
+export interface CommentaryResult {
+  commentary: string;
+  depth: DepthLevel;
+  profileVersion: number;
+  // Source identifies which path produced the text. "haiku" is the
+  // happy path; "cache" is a hit; the three "fallback_*" variants
+  // tell the feed route this commentary is deterministic and
+  // should not be cached (it already wasn't — only successful Haiku
+  // output is inserted into commentary_cache — but the client may
+  // want to retry-on-next-view with different semantics).
+  source:
+    | "cache"
+    | "haiku"
+    | "fallback_tier1"
+    | "fallback_tier2"
+    | "fallback_tier3";
+}
+
+// Map the low-level Haiku failure reason into the Tier 3 anomaly
+// vocabulary. Kept in this layer because the fallback module doesn't
+// know about the Haiku client and shouldn't.
+function haikuReasonToTier3(reason: HaikuFailureReason): Tier3Reason {
+  switch (reason) {
+    case "timeout":
+      return "haiku_timeout";
+    case "empty":
+      return "haiku_empty";
+    case "api_error":
+      return "haiku_api_error";
+    case "no_api_key":
+      return "haiku_no_api_key";
+  }
+}
+
+/**
+ * Orchestrator. Cache-first, Haiku on miss, tiered fallback on any
+ * Haiku-side failure. Returns a structured result so the controller
+ * can project `source` into telemetry without re-deriving it.
+ */
+export async function getOrGenerateCommentary(
+  input: GetOrGenerateInput,
+  deps: CommentaryServiceDeps,
+): Promise<CommentaryResult> {
+  const logger = deps.logger ?? console;
+  const now = deps.now ?? ((): Date => new Date());
+
+  // ---- 1. Cache lookup ----
+  const [hit] = await deps.db
+    .select()
+    .from(commentaryCache)
+    .where(
+      and(
+        eq(commentaryCache.userId, input.userId),
+        eq(commentaryCache.storyId, input.storyId),
+        eq(commentaryCache.depth, input.depth),
+        eq(commentaryCache.profileVersion, input.profileVersion),
+      ),
+    )
+    .limit(1);
+
+  if (hit) {
+    // 12c: update last_accessed_at on every hit. See
+    // LAST_ACCESSED_UPDATE_MODE comment.
+    if (LAST_ACCESSED_UPDATE_MODE === "every_hit") {
+      await deps.db
+        .update(commentaryCache)
+        .set({ lastAccessedAt: now() })
+        .where(eq(commentaryCache.id, hit.id));
+    }
+    return {
+      commentary: hit.commentary,
+      depth: input.depth,
+      profileVersion: input.profileVersion,
+      source: "cache",
+    };
+  }
+
+  // ---- 2. Gather story + profile context for the prompt ----
+  const [story] = await deps.db
+    .select({
+      id: stories.id,
+      sector: stories.sector,
+      headline: stories.headline,
+      context: stories.context,
+      whyItMatters: stories.whyItMatters,
+    })
+    .from(stories)
+    .where(eq(stories.id, input.storyId))
+    .limit(1);
+  if (!story) {
+    // Caller should have validated this, but surface a deterministic
+    // error rather than letting Haiku hallucinate against an unknown
+    // headline. Controller maps this to 404.
+    throw new Error(`story not found: ${input.storyId}`);
+  }
+
+  const [profile] = await deps.db
+    .select({
+      role: userProfiles.role,
+      domain: userProfiles.domain,
+      seniority: userProfiles.seniority,
+      sectors: userProfiles.sectors,
+      goals: userProfiles.goals,
+    })
+    .from(userProfiles)
+    .where(eq(userProfiles.userId, input.userId))
+    .limit(1);
+
+  const topicRows = await deps.db
+    .select({ sector: userTopicInterests.sector, topic: userTopicInterests.topic })
+    .from(userTopicInterests)
+    .where(eq(userTopicInterests.userId, input.userId));
+
+  const matched = computeMatchedInterests({
+    storySector: story.sector,
+    userSectors: profile?.sectors ?? null,
+    userTopicsForSector: topicRows,
+  });
+
+  const profileShape = {
+    role: profile?.role ?? null,
+    domain: profile?.domain ?? null,
+    seniority: profile?.seniority ?? null,
+    sectors: profile?.sectors ?? null,
+    goals: profile?.goals ?? null,
+  };
+
+  // ---- 3. Call Haiku ----
+  const prompt = buildCommentaryPrompt({
+    depth: input.depth,
+    profile: profileShape,
+    matchedTopics: matched.matchedTopics,
+    story,
+  });
+
+  const result = await callHaikuForCommentary(prompt, deps.haiku);
+
+  // ---- 4a. Haiku succeeded — banned-phrase gate, then insert ----
+  if (result.ok) {
+    const banCheck = checkBannedPhrases(result.text);
+    if (banCheck.clean) {
+      const [row] = await deps.db
+        .insert(commentaryCache)
+        .values({
+          userId: input.userId,
+          storyId: input.storyId,
+          depth: input.depth,
+          profileVersion: input.profileVersion,
+          commentary: result.text,
+          generatedAt: now(),
+          lastAccessedAt: now(),
+        })
+        // onConflictDoNothing handles the narrow race where two
+        // concurrent cache-miss requests for the same key try to
+        // insert simultaneously. The bare form suffices — there's
+        // only one unique constraint on the table beyond the PK, so
+        // "any conflict" and "conflict on (userId, storyId, depth,
+        // profileVersion)" are equivalent here. The second insert is
+        // a no-op; the second caller falls through to the next read
+        // below (which will hit the now-populated row).
+        .onConflictDoNothing()
+        .returning();
+      // If the insert was pre-empted by another request, the returning
+      // clause is empty — re-read to get the canonical row.
+      if (row) {
+        return {
+          commentary: row.commentary,
+          depth: input.depth,
+          profileVersion: input.profileVersion,
+          source: "haiku",
+        };
+      }
+      const [raced] = await deps.db
+        .select()
+        .from(commentaryCache)
+        .where(
+          and(
+            eq(commentaryCache.userId, input.userId),
+            eq(commentaryCache.storyId, input.storyId),
+            eq(commentaryCache.depth, input.depth),
+            eq(commentaryCache.profileVersion, input.profileVersion),
+          ),
+        )
+        .limit(1);
+      if (raced) {
+        return {
+          commentary: raced.commentary,
+          depth: input.depth,
+          profileVersion: input.profileVersion,
+          source: "cache",
+        };
+      }
+      // Truly unexpected — fall through to the fallback path rather
+      // than throw; the user gets deterministic commentary.
+    }
+    // Haiku text tripped the banned-phrase gate. Reroute to fallback
+    // with an explicit reason so the Tier 3 anomaly log says why.
+    return buildAndLogFallback(
+      input,
+      story,
+      profileShape,
+      matched,
+      "haiku_banned_phrase",
+      logger,
+      { offenders: banCheck.offenders },
+    );
+  }
+
+  // ---- 4b. Haiku failed — fall through to fallback ----
+  return buildAndLogFallback(
+    input,
+    story,
+    profileShape,
+    matched,
+    haikuReasonToTier3(result.reason),
+    logger,
+    result.reason === "api_error" && result.detail
+      ? { detail: result.detail }
+      : undefined,
+  );
+}
+
+// Shared fallback-path emitter. Builds the fallback text, projects the
+// tier into the source string, and emits the Tier 3 anomaly log
+// exactly once per invocation.
+function buildAndLogFallback(
+  input: GetOrGenerateInput,
+  story: { sector: string; headline: string; whyItMatters: string },
+  profile: { role: string | null; domain: string | null; seniority: string | null },
+  matched: { matchedSector: boolean; matchedTopics: string[] },
+  haikuFailureReason: Tier3Reason | undefined,
+  logger: Pick<Console, "info" | "warn" | "error">,
+  extra: { offenders?: string[]; detail?: string } | undefined,
+): CommentaryResult {
+  const fb: FallbackResult = buildFallbackCommentary({
+    storyHeadline: story.headline,
+    storySector: story.sector,
+    storyWhyItMatters: story.whyItMatters,
+    profile,
+    matched: { matchedSector: matched.matchedSector, matchedTopics: matched.matchedTopics },
+    haikuFailureReason,
+  });
+
+  if (fb.anomaly) {
+    // One structured warn per fallback invocation. `event` field is
+    // stable so dashboards / log filters key off it directly.
+    logger.warn({
+      ...fb.anomaly,
+      userId: input.userId,
+      storyId: input.storyId,
+      depth: input.depth,
+      profileVersion: input.profileVersion,
+      ...(extra?.offenders ? { haikuOffenders: extra.offenders } : {}),
+      ...(extra?.detail ? { haikuErrorDetail: extra.detail } : {}),
+    });
+  }
+
+  const source =
+    fb.tier === "tier1"
+      ? ("fallback_tier1" as const)
+      : fb.tier === "tier2"
+        ? ("fallback_tier2" as const)
+        : ("fallback_tier3" as const);
+
+  return {
+    commentary: fb.text,
+    depth: input.depth,
+    profileVersion: input.profileVersion,
+    source,
+  };
+}

--- a/OneDrive/Desktop/signal-app/backend/src/services/haikuCommentaryClient.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/haikuCommentaryClient.ts
@@ -1,0 +1,111 @@
+// Phase 12c — thin Anthropic Haiku client for commentary generation.
+//
+// Intentionally minimal:
+//   - Dated model string: `claude-haiku-4-5-20251001` (locked per the
+//     12c ground rules; the generic "claude-haiku-4-5" alias used in
+//     12a remains only in the regeneration script path).
+//   - 10-second hard timeout per call. Wrapped with AbortController so
+//     a stalled Anthropic endpoint can't stall a feed render.
+//   - No retries in 12c. One call; on any failure, we fall back to the
+//     tiered template. Revisit in 12d if observability says the
+//     failure rate is high enough to warrant a single retry on 5xx.
+//   - Never throws. Returns a discriminated-union result so the caller
+//     can route by reason without catch blocks.
+//
+// Module-level Anthropic instance is lazy so tests can inject their
+// own client via `callHaikuForCommentary`'s deps arg without
+// stumbling over a missing ANTHROPIC_API_KEY.
+
+import Anthropic from "@anthropic-ai/sdk";
+
+// Pinned dated model. Do not replace with the alias — keeping the date
+// in-repo means "which model served this commentary" is answerable
+// from a commit SHA without consulting rollout calendars.
+export const COMMENTARY_MODEL = "claude-haiku-4-5-20251001";
+
+// 10,000 ms hard timeout. Chosen to be short enough that a single
+// stalled request can't hold a feed row's commentary spinner open long
+// enough for the user to notice, long enough that normal P99 latency
+// (~3–5 s at Haiku prices) passes comfortably. Raise only with an
+// explicit product decision.
+export const HAIKU_TIMEOUT_MS = 10_000;
+
+export type HaikuFailureReason =
+  | "timeout"
+  | "empty"
+  | "api_error"
+  | "no_api_key";
+
+export type HaikuResult =
+  | { ok: true; text: string }
+  | { ok: false; reason: HaikuFailureReason; detail?: string };
+
+export interface HaikuClientDeps {
+  client?: Pick<Anthropic["messages"], "create">;
+  model?: string;
+  timeoutMs?: number;
+}
+
+let cachedClient: Anthropic | null = null;
+function defaultClient(): Pick<Anthropic["messages"], "create"> | null {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+  if (!cachedClient) cachedClient = new Anthropic({ apiKey });
+  return cachedClient.messages;
+}
+
+// Exported for tests — resets the cached client after an env mutation.
+export function __resetHaikuClientForTests(): void {
+  cachedClient = null;
+}
+
+/**
+ * Call Haiku once with the given prompt. Returns a discriminated-union
+ * result. Never throws; any SDK error becomes `{ ok: false,
+ * reason: "api_error" }` with the raw message in `detail`.
+ */
+export async function callHaikuForCommentary(
+  prompt: string,
+  deps: HaikuClientDeps = {},
+): Promise<HaikuResult> {
+  const client = deps.client ?? defaultClient();
+  if (!client) return { ok: false, reason: "no_api_key" };
+
+  const model = deps.model ?? COMMENTARY_MODEL;
+  const timeoutMs = deps.timeoutMs ?? HAIKU_TIMEOUT_MS;
+
+  // AbortController drives both the SDK's `signal` and our own race
+  // so we emit a deterministic "timeout" reason rather than letting
+  // the SDK surface a less specific AbortError downstream.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await client.create(
+      {
+        model,
+        max_tokens: 600,
+        messages: [{ role: "user", content: prompt }],
+      },
+      { signal: controller.signal },
+    );
+    const text = res.content
+      .flatMap((block) => (block.type === "text" ? [block.text] : []))
+      .join("\n")
+      .trim();
+    if (!text) return { ok: false, reason: "empty" };
+    return { ok: true, text };
+  } catch (err) {
+    // AbortError surfaces as a DOMException on modern Node; shape-check
+    // rather than instanceof to avoid cross-realm pitfalls under test.
+    const name = (err as { name?: string } | null)?.name;
+    if (name === "AbortError" || controller.signal.aborted) {
+      return { ok: false, reason: "timeout" };
+    }
+    const message =
+      err instanceof Error ? err.message : String(err ?? "unknown error");
+    return { ok: false, reason: "api_error", detail: message };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/OneDrive/Desktop/signal-app/backend/src/utils/matchedInterests.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/utils/matchedInterests.ts
@@ -1,0 +1,54 @@
+// Phase 12c — matched_interests computation.
+//
+// Given the story's sector and the user's declared sectors + topic
+// selections, returns which of the user's profile signals "match" the
+// story. Fed into the Haiku prompt so commentary can lean on concrete
+// overlaps (e.g. "as a mid-career engineer interested in foundation
+// models..."). Also fed into the tiered fallback so Tier 2 vs Tier 3
+// selection is observable without re-querying the DB.
+//
+// Pure — no DB access, no I/O. The caller loads the pieces it needs
+// (from user_profiles + user_topic_interests) and hands them in.
+
+export interface MatchedInterestsInput {
+  storySector: string;
+  userSectors: string[] | null | undefined;
+  userTopicsForSector: ReadonlyArray<{ sector: string; topic: string }> | null | undefined;
+}
+
+export interface MatchedInterests {
+  // True iff the story's sector appears in the user's onboarded sectors.
+  // False here is the strongest "this story is off-sector for this user"
+  // signal — rare in practice because the feed filters by sector, but
+  // possible on direct story-detail reads.
+  matchedSector: boolean;
+  // User's topic picks *within the story's sector* only. We don't count
+  // cross-sector topics — a "foundation_models" pick against an AI user
+  // reading a finance story is not a relevant match. Widened to string
+  // (not the Topic union) because values come out of
+  // user_topic_interests as text; membership has already been enforced
+  // at insert time by the onboarding controller's Zod schema.
+  matchedTopics: string[];
+}
+
+export function computeMatchedInterests(input: MatchedInterestsInput): MatchedInterests {
+  const userSectors = input.userSectors ?? [];
+  const userTopics = input.userTopicsForSector ?? [];
+
+  const matchedSector = userSectors.includes(input.storySector);
+
+  // Filter topic picks to those declared against the story's sector.
+  // Dedupe defensively — the composite PK on user_topic_interests
+  // already prevents dupes in the DB, but callers may pass arrays
+  // assembled from multiple queries.
+  const seen = new Set<string>();
+  const matchedTopics: string[] = [];
+  for (const t of userTopics) {
+    if (t.sector !== input.storySector) continue;
+    if (seen.has(t.topic)) continue;
+    seen.add(t.topic);
+    matchedTopics.push(t.topic);
+  }
+
+  return { matchedSector, matchedTopics };
+}

--- a/OneDrive/Desktop/signal-app/backend/tests/commentaryEndpoint.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/commentaryEndpoint.test.ts
@@ -1,0 +1,182 @@
+// Phase 12c — GET /api/v1/stories/:id/commentary integration test.
+//
+// This stubs getOrGenerateCommentary at the service module boundary
+// (rather than wiring a full mock DB through every cache-hit / Haiku /
+// fallback codepath) because the service itself is covered end-to-end
+// by commentaryFallback / commentaryPrompt / matchedInterests unit
+// suites. What we're guarding here is the controller contract:
+//   - auth gate
+//   - uuid validation
+//   - depth override precedence (explicit query > stored preference)
+//   - pre-onboarding 400
+//   - story-not-found 404 mapping
+//   - JSON envelope shape matches the client's expectation
+
+import request from "supertest";
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+const getOrGenerateCommentaryMock = jest.fn();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+jest.mock("../src/services/commentaryService", () => ({
+  __esModule: true,
+  getOrGenerateCommentary: (...args: unknown[]) =>
+    getOrGenerateCommentaryMock(...args),
+}));
+
+import { createApp } from "../src/app";
+import { generateToken } from "../src/services/authService";
+
+const app = createApp();
+
+function auth(token: string): [string, string] {
+  return ["Authorization", `Bearer ${token}`];
+}
+
+const userId = "user-1";
+const email = "reader@example.com";
+const storyId = "11111111-1111-1111-1111-111111111111";
+
+describe("GET /api/v1/stories/:id/commentary", () => {
+  let token: string;
+
+  beforeEach(() => {
+    mock.reset();
+    getOrGenerateCommentaryMock.mockReset();
+    token = generateToken(userId, email);
+  });
+
+  it("returns 401 without a token", async () => {
+    const res = await request(app).get(`/api/v1/stories/${storyId}/commentary`);
+    expect(res.status).toBe(401);
+    expect(getOrGenerateCommentaryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on a non-uuid id param", async () => {
+    const res = await request(app)
+      .get("/api/v1/stories/not-a-uuid/commentary")
+      .set(...auth(token));
+    expect(res.status).toBe(400);
+    expect(getOrGenerateCommentaryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the user has no profile row (pre-onboarding direct link)", async () => {
+    mock.queueSelect([]); // empty profile lookup
+
+    const res = await request(app)
+      .get(`/api/v1/stories/${storyId}/commentary`)
+      .set(...auth(token));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("PROFILE_NOT_FOUND");
+    expect(getOrGenerateCommentaryMock).not.toHaveBeenCalled();
+  });
+
+  it("happy path: passes stored depth_preference + profileVersion to the service and returns the JSON envelope", async () => {
+    mock.queueSelect([
+      { depthPreference: "technical", profileVersion: 4 },
+    ]);
+    getOrGenerateCommentaryMock.mockResolvedValueOnce({
+      commentary: "A deep-insider take on the release.",
+      depth: "technical",
+      profileVersion: 4,
+      source: "haiku",
+    });
+
+    const res = await request(app)
+      .get(`/api/v1/stories/${storyId}/commentary`)
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      commentary: "A deep-insider take on the release.",
+      depth: "technical",
+      profile_version: 4,
+      source: "haiku",
+    });
+    expect(getOrGenerateCommentaryMock).toHaveBeenCalledTimes(1);
+    const [callInput] = getOrGenerateCommentaryMock.mock.calls[0];
+    expect(callInput).toMatchObject({
+      userId,
+      storyId,
+      depth: "technical",
+      profileVersion: 4,
+    });
+  });
+
+  it("explicit ?depth= query override beats the stored preference", async () => {
+    // User's stored preference is "accessible" but they're asking for
+    // "technical" (e.g. Premium depth selector on story detail).
+    mock.queueSelect([
+      { depthPreference: "accessible", profileVersion: 1 },
+    ]);
+    getOrGenerateCommentaryMock.mockResolvedValueOnce({
+      commentary: "…",
+      depth: "technical",
+      profileVersion: 1,
+      source: "cache",
+    });
+
+    const res = await request(app)
+      .get(`/api/v1/stories/${storyId}/commentary?depth=technical`)
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(getOrGenerateCommentaryMock.mock.calls[0][0].depth).toBe("technical");
+  });
+
+  it("falls back to 'standard' when the user has no depth preference stored", async () => {
+    mock.queueSelect([
+      { depthPreference: null, profileVersion: 1 },
+    ]);
+    getOrGenerateCommentaryMock.mockResolvedValueOnce({
+      commentary: "…",
+      depth: "standard",
+      profileVersion: 1,
+      source: "fallback_tier2",
+    });
+
+    const res = await request(app)
+      .get(`/api/v1/stories/${storyId}/commentary`)
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(getOrGenerateCommentaryMock.mock.calls[0][0].depth).toBe("standard");
+    expect(res.body.data.source).toBe("fallback_tier2");
+  });
+
+  it("rejects an invalid depth query value at the validator, not the service", async () => {
+    const res = await request(app)
+      .get(`/api/v1/stories/${storyId}/commentary?depth=wizard`)
+      .set(...auth(token));
+
+    expect(res.status).toBe(400);
+    expect(getOrGenerateCommentaryMock).not.toHaveBeenCalled();
+  });
+
+  it("maps 'story not found' from the service layer to a proper 404", async () => {
+    mock.queueSelect([
+      { depthPreference: "standard", profileVersion: 1 },
+    ]);
+    getOrGenerateCommentaryMock.mockRejectedValueOnce(
+      new Error(`story not found: ${storyId}`),
+    );
+
+    const res = await request(app)
+      .get(`/api/v1/stories/${storyId}/commentary`)
+      .set(...auth(token));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("STORY_NOT_FOUND");
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/commentaryFallback.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/commentaryFallback.test.ts
@@ -1,0 +1,162 @@
+import {
+  BANNED_PHRASES,
+  buildFallbackCommentary,
+  checkBannedPhrases,
+} from "../src/services/commentaryFallback";
+
+function baseInput(overrides: Partial<Parameters<typeof buildFallbackCommentary>[0]> = {}) {
+  return {
+    storyHeadline: "OpenAI announces GPT-5 with frontier-grade reasoning",
+    storySector: "ai",
+    storyWhyItMatters: "The new model resets the top of the capability frontier.",
+    profile: {
+      role: "engineer",
+      domain: "climate_weather_forecasting",
+      seniority: "mid",
+    },
+    matched: {
+      matchedSector: true,
+      matchedTopics: ["foundation_models"],
+    },
+    ...overrides,
+  };
+}
+
+describe("checkBannedPhrases", () => {
+  it("returns clean=true for neutral copy", () => {
+    const r = checkBannedPhrases("A modest improvement in inference throughput.");
+    expect(r.clean).toBe(true);
+    expect(r.offenders).toEqual([]);
+  });
+
+  it("flags offenders case-insensitively and lists them by the canonical phrase", () => {
+    const r = checkBannedPhrases("This GROUNDBREAKING release is unprecedented.");
+    expect(r.clean).toBe(false);
+    expect(r.offenders.sort()).toEqual(["groundbreaking", "unprecedented"].sort());
+  });
+
+  it("respects word boundaries — 'evolutionary' does not trip 'revolutionary'", () => {
+    const r = checkBannedPhrases("An evolutionary improvement over the prior release.");
+    expect(r.clean).toBe(true);
+  });
+
+  it("covers every phrase in BANNED_PHRASES", () => {
+    // Sanity check that the canonical list and the regex list stay in
+    // sync — if someone adds a phrase to BANNED_PHRASES but the
+    // pattern builder drifts, this breaks.
+    for (const phrase of BANNED_PHRASES) {
+      const r = checkBannedPhrases(`Leading with ${phrase} framing.`);
+      expect(r.clean).toBe(false);
+      expect(r.offenders).toContain(phrase);
+    }
+  });
+});
+
+describe("buildFallbackCommentary — tier selection", () => {
+  it("tier1: full profile + matched sector + at least one matched topic", () => {
+    const out = buildFallbackCommentary(baseInput());
+    expect(out.tier).toBe("tier1");
+    expect(out.anomaly).toBeUndefined();
+    // Tier 1 should mention a matched topic by its human label
+    // ("foundation models") — anchors the fallback on the overlap.
+    expect(out.text.toLowerCase()).toContain("foundation models");
+  });
+
+  it("tier2: full profile + matched sector but NO matched topics", () => {
+    const out = buildFallbackCommentary(
+      baseInput({ matched: { matchedSector: true, matchedTopics: [] } }),
+    );
+    expect(out.tier).toBe("tier2");
+    expect(out.anomaly).toBeUndefined();
+    // Tier 2 still names the role.
+    expect(out.text.toLowerCase()).toContain("engineer");
+  });
+
+  it("tier3 + anomaly: profile missing role", () => {
+    const out = buildFallbackCommentary(
+      baseInput({ profile: { role: null, domain: "foo", seniority: "mid" } }),
+    );
+    expect(out.tier).toBe("tier3");
+    expect(out.anomaly).toBeDefined();
+    expect(out.anomaly!.reason).toBe("missing_profile_fields");
+    expect(out.anomaly!.missingProfileFields).toEqual(["role"]);
+  });
+
+  it("tier3 + anomaly: story sector not in user's sectors (off_sector)", () => {
+    // Full profile, but the story is for a sector the user didn't pick.
+    // Example: direct story-detail link to a finance story from a user
+    // who only onboarded AI + semiconductors.
+    const out = buildFallbackCommentary(
+      baseInput({ matched: { matchedSector: false, matchedTopics: [] } }),
+    );
+    expect(out.tier).toBe("tier3");
+    expect(out.anomaly).toBeDefined();
+    expect(out.anomaly!.reason).toBe("off_sector");
+  });
+
+  it("tier3 + anomaly: Haiku failure reason propagates verbatim", () => {
+    // The commentaryService layer maps Haiku errors to Tier3Reason
+    // values and passes them in via haikuFailureReason. The fallback
+    // must surface them in the anomaly without re-deriving.
+    const out = buildFallbackCommentary(
+      baseInput({ haikuFailureReason: "haiku_timeout" }),
+    );
+    expect(out.tier).toBe("tier3");
+    expect(out.anomaly).toBeDefined();
+    expect(out.anomaly!.reason).toBe("haiku_timeout");
+  });
+});
+
+describe("buildFallbackCommentary — anomaly log shape", () => {
+  it("always stamps the canonical event string", () => {
+    const out = buildFallbackCommentary(
+      baseInput({ profile: { role: null, domain: null, seniority: null } }),
+    );
+    expect(out.anomaly!.event).toBe("commentary_tier3_fallback");
+  });
+
+  it("missingProfileFields lists every missing field in order (role, domain, seniority)", () => {
+    const out = buildFallbackCommentary(
+      baseInput({ profile: { role: null, domain: null, seniority: null } }),
+    );
+    expect(out.anomaly!.missingProfileFields).toEqual([
+      "role",
+      "domain",
+      "seniority",
+    ]);
+  });
+
+  it("does NOT emit an anomaly on tier1 or tier2", () => {
+    const t1 = buildFallbackCommentary(baseInput());
+    const t2 = buildFallbackCommentary(
+      baseInput({ matched: { matchedSector: true, matchedTopics: [] } }),
+    );
+    expect(t1.anomaly).toBeUndefined();
+    expect(t2.anomaly).toBeUndefined();
+  });
+});
+
+describe("buildFallbackCommentary — template banned-phrase scrub (defense-in-depth)", () => {
+  // This exercises the scrubber path directly — in production, the
+  // hand-written templates should never trip the check, so this test
+  // simulates a regression where a template fragment leaked a banned
+  // phrase. We do it by feeding a whyItMatters that contains one
+  // — the template concatenates it, so the output inherits it.
+  it("scrubs a banned phrase from the story baseline and logs templateOffenders", () => {
+    const out = buildFallbackCommentary(
+      baseInput({
+        storyWhyItMatters: "A game-changing release with revolutionary implications.",
+      }),
+    );
+    expect(out.text.toLowerCase()).not.toContain("game-changing");
+    expect(out.text.toLowerCase()).not.toContain("revolutionary");
+    // Tier becomes tier3 (the scrub is always an anomaly) and the
+    // anomaly carries templateOffenders.
+    expect(out.tier).toBe("tier3");
+    expect(out.anomaly).toBeDefined();
+    expect(out.anomaly!.templateOffenders).toBeDefined();
+    const offenders = out.anomaly!.templateOffenders ?? [];
+    expect(offenders).toContain("game-changing");
+    expect(offenders).toContain("revolutionary");
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/commentaryPrompt.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/commentaryPrompt.test.ts
@@ -1,0 +1,105 @@
+import { buildCommentaryPrompt } from "../src/services/commentaryPrompt";
+import { BANNED_PHRASES } from "../src/services/commentaryFallback";
+
+function baseInputs(): Parameters<typeof buildCommentaryPrompt>[0] {
+  return {
+    depth: "standard",
+    profile: {
+      role: "engineer",
+      domain: "climate_weather_forecasting",
+      seniority: "mid",
+      sectors: ["ai", "semiconductors"],
+      goals: ["stay_current", "deep_learning"],
+    },
+    matchedTopics: ["foundation_models", "agents"],
+    story: {
+      sector: "ai",
+      headline: "OpenAI announces GPT-5 with frontier-grade reasoning",
+      context: "The release includes a new chain-of-thought mode and raised context window.",
+      whyItMatters: "Resets the top of the capability frontier for commercial models.",
+    },
+  };
+}
+
+describe("buildCommentaryPrompt", () => {
+  it("includes every profile field surfaced to the model", () => {
+    const p = buildCommentaryPrompt(baseInputs());
+    expect(p).toContain("Role: engineer");
+    // Underscore values are humanized for display but we don't require
+    // a specific rewrite — just that the raw token isn't leaked.
+    expect(p).toContain("climate weather forecasting");
+    expect(p).toContain("Seniority: mid");
+    expect(p.toLowerCase()).toContain("ai");
+    expect(p.toLowerCase()).toContain("semiconductors");
+    expect(p.toLowerCase()).toContain("stay current");
+  });
+
+  it("surfaces matched topics when present", () => {
+    const p = buildCommentaryPrompt(baseInputs());
+    expect(p.toLowerCase()).toContain("foundation models");
+    expect(p.toLowerCase()).toContain("agents");
+  });
+
+  it("omits the matched-topics line entirely when no topics matched", () => {
+    // When the user picked no topics in this story's sector, the
+    // prompt should NOT attempt to fabricate a connection. The line
+    // key is "Topics they flagged in" — its absence is the contract.
+    const p = buildCommentaryPrompt({ ...baseInputs(), matchedTopics: [] });
+    expect(p).not.toContain("Topics they flagged in");
+  });
+
+  it("includes the story headline, context, and editorial baseline", () => {
+    const p = buildCommentaryPrompt(baseInputs());
+    expect(p).toContain("OpenAI announces GPT-5 with frontier-grade reasoning");
+    expect(p).toContain("The release includes a new chain-of-thought mode");
+    expect(p).toContain("Resets the top of the capability frontier");
+  });
+
+  it("includes depth-specific guidance that differs per depth", () => {
+    const accessible = buildCommentaryPrompt({ ...baseInputs(), depth: "accessible" });
+    const technical = buildCommentaryPrompt({ ...baseInputs(), depth: "technical" });
+    expect(accessible).toContain("Audience depth: accessible");
+    expect(technical).toContain("Audience depth: technical");
+    // Depth guidance must differ between the two — if someone
+    // flattens the DEPTH_GUIDANCE map this catches it.
+    expect(accessible).not.toBe(technical);
+    expect(accessible).toContain("Plain language");
+    expect(technical).toContain("Domain insider");
+  });
+
+  it("enumerates every entry in BANNED_PHRASES inside the prompt's banned list", () => {
+    // The prompt instructs the model to avoid these phrases; drift
+    // between the list and what we embed in the prompt would silently
+    // weaken the gate.
+    const p = buildCommentaryPrompt(baseInputs());
+    for (const phrase of BANNED_PHRASES) {
+      expect(p).toContain(phrase);
+    }
+  });
+
+  it("tells the model to output ONLY the commentary (no preamble, no headers)", () => {
+    const p = buildCommentaryPrompt(baseInputs());
+    // Exact-substring assertion — the v2 controller layer relies on
+    // the absence of preamble to surface the text directly, so this
+    // line is a stability anchor, not just a style note.
+    expect(p).toContain("Output ONLY the commentary paragraph.");
+  });
+
+  it("tolerates null profile fields without crashing or leaking 'null' into the prompt", () => {
+    // Landing here with a null-heavy profile means the service layer
+    // is about to bail to Tier 3 fallback, but the prompt builder must
+    // not crash mid-assembly if a caller invokes it anyway.
+    const p = buildCommentaryPrompt({
+      ...baseInputs(),
+      profile: {
+        role: null,
+        domain: null,
+        seniority: null,
+        sectors: null,
+        goals: null,
+      },
+    });
+    expect(p).not.toContain("null");
+    expect(p).not.toContain("Role: null");
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/commentaryService.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/commentaryService.test.ts
@@ -1,0 +1,199 @@
+// Phase 12c — service-level orchestration tests.
+//
+// commentaryEndpoint.test.ts mocks the service boundary; the prompt/
+// fallback/haiku-client modules have unit tests of their own. What's
+// left untested is getOrGenerateCommentary's own logic: the cache hit
+// branch, the cache-miss-then-Haiku-success persistence path, and the
+// cache-miss-then-Haiku-failure tier3 path with its anomaly log.
+//
+// The mockDb helper ignores WHERE predicates and just drains queued
+// result lists in call order — so the implicit contract here is the
+// call sequence the service executes. Each test queues rows in the
+// order the service reads them.
+
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import { getOrGenerateCommentary } from "../src/services/commentaryService";
+
+describe("commentaryService — getOrGenerateCommentary", () => {
+  const baseInput = {
+    userId: "user-1",
+    storyId: "story-1",
+    depth: "standard" as const,
+    profileVersion: 3,
+  };
+
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("returns source=cache when a cache row exists, without calling Haiku", async () => {
+    // 1. Cache lookup returns a row.
+    mock.queueSelect([
+      {
+        id: "cache-1",
+        userId: baseInput.userId,
+        storyId: baseInput.storyId,
+        depth: baseInput.depth,
+        profileVersion: baseInput.profileVersion,
+        commentary: "cached text",
+      },
+    ]);
+    // 2. last_accessed_at update runs (mockDb treats it as delete-
+    //    style, just returns rowCount:1 — no queue entry needed).
+
+    const create = jest.fn();
+    const result = await getOrGenerateCommentary(baseInput, {
+      db: mock.db,
+      haiku: { client: { create } },
+    });
+
+    expect(result).toEqual({
+      commentary: "cached text",
+      depth: "standard",
+      profileVersion: 3,
+      source: "cache",
+    });
+    // Cache-hit path must not wake the model.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("calls Haiku on cache miss and persists + returns source=haiku", async () => {
+    // 1. Cache lookup — miss.
+    mock.queueSelect([]);
+    // 2. Story lookup.
+    mock.queueSelect([
+      {
+        id: baseInput.storyId,
+        sector: "ai",
+        headline: "A headline",
+        context: "context",
+        whyItMatters: "base reason",
+      },
+    ]);
+    // 3. Profile lookup.
+    mock.queueSelect([
+      {
+        role: "engineer",
+        domain: "ml_engineering",
+        seniority: "senior",
+        sectors: ["ai"],
+        goals: ["stay_current"],
+      },
+    ]);
+    // 4. Topic interests.
+    mock.queueSelect([{ sector: "ai", topic: "agents" }]);
+    // 5. Insert .returning() — Haiku success persists.
+    mock.queueInsert([
+      {
+        id: "cache-new",
+        userId: baseInput.userId,
+        storyId: baseInput.storyId,
+        depth: baseInput.depth,
+        profileVersion: baseInput.profileVersion,
+        commentary: "fresh Haiku commentary for the engineer",
+      },
+    ]);
+
+    const create = jest.fn().mockResolvedValue({
+      content: [
+        { type: "text", text: "fresh Haiku commentary for the engineer" },
+      ],
+    });
+
+    const result = await getOrGenerateCommentary(baseInput, {
+      db: mock.db,
+      haiku: { client: { create } },
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe("haiku");
+    expect(result.commentary).toBe("fresh Haiku commentary for the engineer");
+    expect(result.profileVersion).toBe(3);
+  });
+
+  it("routes to tier3 fallback and emits a warn when Haiku times out", async () => {
+    // 1. Cache miss.
+    mock.queueSelect([]);
+    // 2. Story.
+    mock.queueSelect([
+      {
+        id: baseInput.storyId,
+        sector: "ai",
+        headline: "Headline",
+        context: "context",
+        whyItMatters: "base reason",
+      },
+    ]);
+    // 3. Profile.
+    mock.queueSelect([
+      {
+        role: "engineer",
+        domain: "ml_engineering",
+        seniority: "senior",
+        sectors: ["ai"],
+        goals: ["stay_current"],
+      },
+    ]);
+    // 4. Topics.
+    mock.queueSelect([]);
+    // No insert queued — tier3 path must not persist.
+
+    // Simulate the SDK aborting on timeout. The client raises an
+    // AbortError-shaped exception; the Haiku client normalizes this to
+    // `{ ok: false, reason: "timeout" }` and the service routes that
+    // through the tier3 mapper (`haiku_timeout`).
+    const abortErr = Object.assign(new Error("aborted"), { name: "AbortError" });
+    const create = jest.fn().mockRejectedValue(abortErr);
+
+    const warn = jest.fn();
+    const result = await getOrGenerateCommentary(baseInput, {
+      db: mock.db,
+      haiku: { client: { create } },
+      logger: { info: jest.fn(), warn, error: jest.fn() },
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    // Tier3 is the tier the fallback module produces for a haiku-side
+    // failure (prompt wasn't the problem — the model was).
+    expect(result.source).toBe("fallback_tier3");
+    // Anomaly log ran exactly once with the userId/storyId context
+    // plus the reason key stamped into the event payload.
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [payload] = warn.mock.calls[0];
+    expect(payload).toMatchObject({
+      userId: baseInput.userId,
+      storyId: baseInput.storyId,
+      depth: baseInput.depth,
+      profileVersion: baseInput.profileVersion,
+    });
+  });
+
+  it("throws STORY_NOT_FOUND-shaped error when the story is missing", async () => {
+    // 1. Cache miss.
+    mock.queueSelect([]);
+    // 2. Story lookup — empty. Service throws so the controller can
+    //    map to a 404 before touching Haiku or the profile.
+    mock.queueSelect([]);
+
+    const create = jest.fn();
+    await expect(
+      getOrGenerateCommentary(baseInput, {
+        db: mock.db,
+        haiku: { client: { create } },
+      }),
+    ).rejects.toThrow(/story not found/);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/matchedInterests.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/matchedInterests.test.ts
@@ -1,0 +1,63 @@
+import { computeMatchedInterests } from "../src/utils/matchedInterests";
+
+describe("computeMatchedInterests", () => {
+  it("returns matchedSector=true when the story sector is in the user's sectors", () => {
+    const out = computeMatchedInterests({
+      storySector: "ai",
+      userSectors: ["ai", "finance"],
+      userTopicsForSector: [],
+    });
+    expect(out.matchedSector).toBe(true);
+  });
+
+  it("returns matchedSector=false when the story sector is NOT in the user's sectors", () => {
+    const out = computeMatchedInterests({
+      storySector: "semiconductors",
+      userSectors: ["ai", "finance"],
+      userTopicsForSector: [],
+    });
+    expect(out.matchedSector).toBe(false);
+  });
+
+  it("filters topics to those declared against the story's sector only", () => {
+    // Cross-sector topic picks must not appear — a user who picked
+    // "foundation_models" under ai does NOT have that as a matched
+    // topic for a finance story.
+    const out = computeMatchedInterests({
+      storySector: "finance",
+      userSectors: ["ai", "finance"],
+      userTopicsForSector: [
+        { sector: "ai", topic: "foundation_models" },
+        { sector: "finance", topic: "rates_and_macro" },
+        { sector: "ai", topic: "agents" },
+        { sector: "finance", topic: "credit" },
+      ],
+    });
+    expect(out.matchedTopics).toEqual(["rates_and_macro", "credit"]);
+  });
+
+  it("dedupes duplicate (sector, topic) pairs in the input", () => {
+    const out = computeMatchedInterests({
+      storySector: "ai",
+      userSectors: ["ai"],
+      userTopicsForSector: [
+        { sector: "ai", topic: "foundation_models" },
+        { sector: "ai", topic: "foundation_models" },
+        { sector: "ai", topic: "agents" },
+      ],
+    });
+    expect(out.matchedTopics).toEqual(["foundation_models", "agents"]);
+  });
+
+  it("treats null/undefined inputs as empty", () => {
+    // Mirrors the production path where a pre-onboarding profile row
+    // (from unsubscribe) exists with null sectors + no topics yet.
+    const out = computeMatchedInterests({
+      storySector: "ai",
+      userSectors: null,
+      userTopicsForSector: undefined,
+    });
+    expect(out.matchedSector).toBe(false);
+    expect(out.matchedTopics).toEqual([]);
+  });
+});

--- a/OneDrive/Desktop/signal-app/backend/tests/onboarding.integration.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/onboarding.integration.test.ts
@@ -26,10 +26,16 @@ const email = "a@b.com";
 
 // A minimally-valid completion payload. Tests override individual
 // fields to exercise validation edges.
+//
+// Phase 12c added `domain` (Screen 2) to the completion contract.
+// Using "general_not_sure" in the fixture because it's always valid
+// regardless of which sectors the test ships with — the per-sector
+// domain options may drift, but the sentinel is guaranteed stable.
 function validCompletionPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     sectors: ["ai"],
     role: "engineer",
+    domain: "general_not_sure",
     seniority: "mid",
     depth_preference: "standard",
     topics: [{ sector: "ai", topic: "foundation_models" }],

--- a/OneDrive/Desktop/signal-app/backend/tests/users.integration.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/users.integration.test.ts
@@ -184,7 +184,21 @@ describe("user profile endpoints", () => {
     });
 
     it("updates an existing profile row", async () => {
-      mock.queueSelect([{ userId }]); // existence check inside txn
+      // Phase 12c: existence-check SELECT now projects the diff
+      // columns (role/domain/seniority/sectors/goals/profileVersion).
+      // When the diff detects a commentary-relevant change, patch
+      // includes a bumped profileVersion.
+      mock.queueSelect([
+        {
+          userId,
+          role: "engineer",
+          domain: null,
+          seniority: null,
+          sectors: ["ai"],
+          goals: ["stay_current"],
+          profileVersion: 3,
+        },
+      ]);
       mock.queueInsert([
         {
           userId,
@@ -193,6 +207,7 @@ describe("user profile endpoints", () => {
           goals: ["network", "find_opportunities"],
           emailFrequency: "daily",
           emailUnsubscribed: false,
+          profileVersion: 4,
         },
       ]); // update .returning()
 
@@ -210,6 +225,7 @@ describe("user profile endpoints", () => {
       expect(res.body.data.profile.role).toBe("vc");
       expect(res.body.data.profile.sectors).toEqual(["ai", "finance"]);
       expect(res.body.data.profile.emailFrequency).toBe("daily");
+      expect(res.body.data.profile.profileVersion).toBe(4);
     });
 
     it("inserts a new profile row when none exists", async () => {
@@ -243,7 +259,19 @@ describe("user profile endpoints", () => {
     // column is optional on write (see userController.ts) but must be
     // persisted when supplied.
     it("accepts and persists depth_preference when supplied", async () => {
-      mock.queueSelect([{ userId }]); // existence check inside txn
+      // depth_preference is NOT a commentary-relevant field — flipping
+      // it alone must NOT bump profile_version.
+      mock.queueSelect([
+        {
+          userId,
+          role: "engineer",
+          domain: null,
+          seniority: null,
+          sectors: ["ai"],
+          goals: ["deep_learning"],
+          profileVersion: 2,
+        },
+      ]);
       mock.queueInsert([
         {
           userId,
@@ -253,6 +281,7 @@ describe("user profile endpoints", () => {
           emailFrequency: "weekly",
           emailUnsubscribed: false,
           depthPreference: "technical",
+          profileVersion: 2,
         },
       ]); // update .returning()
 
@@ -269,6 +298,223 @@ describe("user profile endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.profile.depthPreference).toBe("technical");
+      expect(res.body.data.profile.profileVersion).toBe(2);
+    });
+
+    // Phase 12c — profile_version bump discipline. These tests pin
+    // the three decisions that make commentary caching work:
+    //   1. flipping a commentary-relevant field bumps
+    //   2. flipping email-only fields does NOT bump
+    //   3. supplying the same topic set in a different order is a no-op
+    //      (set equality, not order equality)
+
+    it("does NOT bump profile_version when only email fields change", async () => {
+      // Same role/sectors/goals/no domain/no seniority → no
+      // commentary-relevant delta → profileVersion stays put.
+      mock.queueSelect([
+        {
+          userId,
+          role: "engineer",
+          domain: null,
+          seniority: null,
+          sectors: ["ai"],
+          goals: ["stay_current"],
+          profileVersion: 5,
+        },
+      ]);
+      mock.queueInsert([
+        {
+          userId,
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          emailFrequency: "daily",
+          emailUnsubscribed: true,
+          profileVersion: 5,
+        },
+      ]);
+
+      const res = await request(app)
+        .put("/api/v1/users/me/profile")
+        .set(...auth(token))
+        .send({
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          email_frequency: "daily",
+          email_unsubscribed: true,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.profile.profileVersion).toBe(5);
+    });
+
+    it("bumps profile_version when domain changes", async () => {
+      mock.queueSelect([
+        {
+          userId,
+          role: "engineer",
+          domain: "ml_engineering",
+          seniority: "senior",
+          sectors: ["ai"],
+          goals: ["stay_current"],
+          profileVersion: 7,
+        },
+      ]);
+      mock.queueInsert([
+        {
+          userId,
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          domain: "ai_safety_alignment",
+          seniority: "senior",
+          profileVersion: 8,
+        },
+      ]);
+
+      const res = await request(app)
+        .put("/api/v1/users/me/profile")
+        .set(...auth(token))
+        .send({
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          email_frequency: "weekly",
+          domain: "ai_safety_alignment",
+          seniority: "senior",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.profile.profileVersion).toBe(8);
+      expect(res.body.data.profile.domain).toBe("ai_safety_alignment");
+    });
+
+    it("bumps profile_version when topic_interests changes (set-wise)", async () => {
+      // Existing row (no change to role/domain/etc).
+      mock.queueSelect([
+        {
+          userId,
+          role: "engineer",
+          domain: "ml_engineering",
+          seniority: "senior",
+          sectors: ["ai"],
+          goals: ["stay_current"],
+          profileVersion: 1,
+        },
+      ]);
+      // Existing topics: just "ai:agents".
+      mock.queueSelect([{ sector: "ai", topic: "agents" }]);
+      // Update .returning().
+      mock.queueInsert([
+        {
+          userId,
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          domain: "ml_engineering",
+          seniority: "senior",
+          profileVersion: 2,
+        },
+      ]);
+
+      const res = await request(app)
+        .put("/api/v1/users/me/profile")
+        .set(...auth(token))
+        .send({
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          email_frequency: "weekly",
+          domain: "ml_engineering",
+          seniority: "senior",
+          topic_interests: [
+            { sector: "ai", topic: "agents" },
+            { sector: "ai", topic: "foundation_models" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.profile.profileVersion).toBe(2);
+    });
+
+    it("does NOT bump when topic_interests supplied in a different order with same set", async () => {
+      // Existing: agents + foundation_models.
+      mock.queueSelect([
+        {
+          userId,
+          role: "engineer",
+          domain: "ml_engineering",
+          seniority: "senior",
+          sectors: ["ai"],
+          goals: ["stay_current"],
+          profileVersion: 9,
+        },
+      ]);
+      mock.queueSelect([
+        { sector: "ai", topic: "agents" },
+        { sector: "ai", topic: "foundation_models" },
+      ]);
+      mock.queueInsert([
+        {
+          userId,
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          domain: "ml_engineering",
+          seniority: "senior",
+          profileVersion: 9,
+        },
+      ]);
+
+      const res = await request(app)
+        .put("/api/v1/users/me/profile")
+        .set(...auth(token))
+        .send({
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          email_frequency: "weekly",
+          domain: "ml_engineering",
+          seniority: "senior",
+          // Same set, reversed order — set equality should short-circuit.
+          topic_interests: [
+            { sector: "ai", topic: "foundation_models" },
+            { sector: "ai", topic: "agents" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.profile.profileVersion).toBe(9);
+    });
+
+    it("rejects an unknown topic for a given sector", async () => {
+      const res = await request(app)
+        .put("/api/v1/users/me/profile")
+        .set(...auth(token))
+        .send({
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          email_frequency: "weekly",
+          topic_interests: [{ sector: "ai", topic: "not_a_real_topic" }],
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("INVALID_INPUT");
+    });
+
+    it("rejects an invalid domain value", async () => {
+      const res = await request(app)
+        .put("/api/v1/users/me/profile")
+        .set(...auth(token))
+        .send({
+          sectors: ["ai"],
+          role: "engineer",
+          goals: ["stay_current"],
+          email_frequency: "weekly",
+          domain: "definitely_not_a_domain",
+        });
+      expect(res.status).toBe(400);
     });
 
     it("rejects an invalid depth_preference value", async () => {

--- a/OneDrive/Desktop/signal-app/frontend/src/app/(app)/settings/page.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/(app)/settings/page.tsx
@@ -18,9 +18,17 @@ import {
   GOALS,
   ROLES,
   SECTORS,
+  SENIORITIES,
+  TOPICS_BY_SECTOR,
 } from "@/lib/onboarding";
+import { getDomainOptionsForSectors } from "@/lib/onboarding/domainOptions";
 import { Toast, type ToastTone } from "@/components/ui/Toast";
-import type { DepthPreference, EmailFrequency, UserProfile } from "@/types/auth";
+import type {
+  DepthPreference,
+  EmailFrequency,
+  TopicInterest,
+  UserProfile,
+} from "@/types/auth";
 
 const profileFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(255),
@@ -48,6 +56,15 @@ export default function SettingsPage(): JSX.Element {
 
   const [sectors, setSectors] = useState<string[]>([]);
   const [role, setRole] = useState<string>("");
+  // Phase 12c — domain, seniority, and topics join the editable set so
+  // the full commentary-input surface can be tweaked without going
+  // back through onboarding. Empty string means "not set yet" — stored
+  // as null on the profile, distinguished here so the <select> renders
+  // the placeholder option rather than accidentally picking the first
+  // real value.
+  const [domain, setDomain] = useState<string>("");
+  const [seniority, setSeniority] = useState<string>("");
+  const [topics, setTopics] = useState<TopicInterest[]>([]);
   const [goals, setGoals] = useState<string[]>([]);
   const [depthPreference, setDepthPreference] = useState<DepthPreference>(
     DEFAULT_DEPTH_PREFERENCE,
@@ -81,7 +98,7 @@ export default function SettingsPage(): JSX.Element {
           profile_picture_url: data.user.profilePictureUrl ?? "",
         });
         setUser(data.user);
-        applyProfile(data.profile);
+        applyProfile(data.profile, data.topic_interests);
       } catch (err) {
         if (!cancelled) setLoadError(extractApiError(err, "Could not load settings"));
       } finally {
@@ -89,9 +106,15 @@ export default function SettingsPage(): JSX.Element {
       }
     };
 
-    const applyProfile = (profile: UserProfile | null): void => {
+    const applyProfile = (
+      profile: UserProfile | null,
+      topicInterests: TopicInterest[],
+    ): void => {
       setSectors(profile?.sectors ?? []);
       setRole(profile?.role ?? "");
+      setDomain(profile?.domain ?? "");
+      setSeniority(profile?.seniority ?? "");
+      setTopics(topicInterests ?? []);
       setGoals(profile?.goals ?? []);
       setDepthPreference(profile?.depthPreference ?? DEFAULT_DEPTH_PREFERENCE);
       setEmailFrequency(profile?.emailFrequency ?? "weekly");
@@ -147,9 +170,20 @@ export default function SettingsPage(): JSX.Element {
       // the toast. Without that, the (app) layout's useRequireOnboarded
       // reads the stale cache on next render and can bounce a just-
       // saved user back to onboarding. (Issue #5.)
+      //
+      // Phase 12c — domain/seniority/topic_interests are sent only when
+      // the user has a value for them; otherwise the backend keeps its
+      // current stored value untouched. topic_interests is sent as [] to
+      // mean "I explicitly want no topics" so the wholesale replacement
+      // path fires correctly; the "unset" case is represented by not
+      // sending the key at all. Here we always send whatever is in
+      // state because the Settings UI always renders the topics editor.
       await updateProfile.mutateAsync({
         sectors,
         role,
+        domain: domain || undefined,
+        seniority: seniority || undefined,
+        topic_interests: topics,
         goals,
         depth_preference: depthPreference,
         email_frequency: emailFrequency,
@@ -177,14 +211,43 @@ export default function SettingsPage(): JSX.Element {
   };
 
   const toggleSector = (value: string): void => {
-    setSectors((current) =>
-      current.includes(value) ? current.filter((v) => v !== value) : [...current, value],
-    );
+    setSectors((current) => {
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value];
+      // When a sector is removed, strip any topic pairs under it so we
+      // never submit `{sector: "finance", topic: ...}` while finance is
+      // no longer selected — the backend would accept (topics are
+      // independent rows) but it would violate the UI invariant that
+      // topics mirror selected sectors. Cheap, done in the same render
+      // as the sector change.
+      setTopics((t) => t.filter((pair) => next.includes(pair.sector)));
+      // Domain options are derived from selected sectors; if the stored
+      // domain is no longer in the union, fall back to the sentinel.
+      // Skip this check when domain is blank or is already the
+      // general_not_sure sentinel (always valid).
+      if (domain && domain !== "general_not_sure") {
+        const valid = getDomainOptionsForSectors(next).some(
+          (o) => o.value === domain,
+        );
+        if (!valid) setDomain("general_not_sure");
+      }
+      return next;
+    });
   };
   const toggleGoal = (value: string): void => {
     setGoals((current) =>
       current.includes(value) ? current.filter((v) => v !== value) : [...current, value],
     );
+  };
+  const toggleTopic = (sector: string, topic: string): void => {
+    setTopics((current) => {
+      const key = `${sector}:${topic}`;
+      const has = current.some((p) => `${p.sector}:${p.topic}` === key);
+      return has
+        ? current.filter((p) => `${p.sector}:${p.topic}` !== key)
+        : [...current, { sector, topic }];
+    });
   };
 
   if (loading) {
@@ -300,6 +363,96 @@ export default function SettingsPage(): JSX.Element {
             ))}
           </select>
         </div>
+
+        <div className="space-y-2">
+          <label htmlFor="domain" className="text-sm font-medium">
+            Field / domain
+          </label>
+          <p className="text-xs text-muted-foreground">
+            The specific area you work in within your sector(s). Feeds the
+            commentary prompt so insights speak to your day-to-day.
+          </p>
+          <select
+            id="domain"
+            value={domain}
+            onChange={(e) => setDomain(e.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="">Select a field…</option>
+            {getDomainOptionsForSectors(sectors).map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="seniority" className="text-sm font-medium">
+            Seniority
+          </label>
+          <select
+            id="seniority"
+            value={seniority}
+            onChange={(e) => setSeniority(e.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="">Select your seniority…</option>
+            {SENIORITIES.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {sectors.length > 0 && (
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm font-medium">Topics</p>
+              <p className="text-xs text-muted-foreground">
+                Narrow the commentary within each sector. Leaving all topics
+                unchecked for a sector means you want the full sector feed.
+              </p>
+            </div>
+            {sectors.map((sector) => {
+              const options = TOPICS_BY_SECTOR[sector] ?? [];
+              if (options.length === 0) return null;
+              const sectorLabel =
+                SECTORS.find((s) => s.value === sector)?.label ?? sector;
+              return (
+                <div key={sector} className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {sectorLabel}
+                  </p>
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {options.map((option) => {
+                      const checked = topics.some(
+                        (t) => t.sector === sector && t.topic === option.value,
+                      );
+                      return (
+                        <label
+                          key={option.value}
+                          className={`flex cursor-pointer items-center gap-2 rounded-md border p-3 text-sm ${
+                            checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleTopic(sector, option.value)}
+                            className="h-4 w-4"
+                          />
+                          {option.label}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
 
         <div className="space-y-2">
           <p className="text-sm font-medium">Commentary depth</p>

--- a/OneDrive/Desktop/signal-app/frontend/src/app/onboarding/[step]/page.test.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/onboarding/[step]/page.test.tsx
@@ -74,8 +74,12 @@ describe("Onboarding step dispatcher", () => {
     expect(pushMock).toHaveBeenCalledWith("/onboarding/2");
   });
 
-  it("Screen 5: skip fills the store with all topics for selected sectors", async () => {
-    paramsMock.current = { step: "5" };
+  // Phase 12c reordered the flow: topics moved from Screen 5 to Screen
+  // 4, goals from Screen 6 to Screen 5, depth from Screen 4 to Screen
+  // 6. Skip defaults + semantics are unchanged; only the step numbers
+  // and push targets move.
+  it("Screen 4 (topics, post-12c): skip fills the store with all topics for selected sectors and routes to 5", async () => {
+    paramsMock.current = { step: "4" };
     useOnboardingStore.getState().setSectors(["ai"]);
     const user = userEvent.setup();
     renderPage();
@@ -83,15 +87,27 @@ describe("Onboarding step dispatcher", () => {
     const topics = useOnboardingStore.getState().topics;
     expect(topics.length).toBeGreaterThan(0);
     expect(topics.every((t) => t.sector === "ai")).toBe(true);
-    expect(pushMock).toHaveBeenCalledWith("/onboarding/6");
+    expect(pushMock).toHaveBeenCalledWith("/onboarding/5");
   });
 
-  it("Screen 6: skip submits ['stay_current'] as the default goal", async () => {
-    paramsMock.current = { step: "6" };
+  it("Screen 5 (goals, post-12c): skip submits ['stay_current'] and routes to 6 (depth)", async () => {
+    paramsMock.current = { step: "5" };
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole("button", { name: /skip/i }));
     expect(useOnboardingStore.getState().goals).toEqual(["stay_current"]);
+    expect(pushMock).toHaveBeenCalledWith("/onboarding/6");
+  });
+
+  it("Screen 6 (depth, post-12c): Continue routes to 7 (digest)", async () => {
+    paramsMock.current = { step: "6" };
+    const user = userEvent.setup();
+    renderPage();
+    // Depth screen has canContinue={true} on initial render — the store
+    // seeds depthPreference="standard" so Continue is always live.
+    const cont = screen.getByRole("button", { name: /continue/i });
+    expect(cont).not.toBeDisabled();
+    await user.click(cont);
     expect(pushMock).toHaveBeenCalledWith("/onboarding/7");
   });
 
@@ -104,6 +120,11 @@ describe("Onboarding step dispatcher", () => {
     const store = useOnboardingStore.getState();
     store.setSectors(["ai"]);
     store.setRole("engineer");
+    // Phase 12c — domain required by the server-side completion schema.
+    // The test mocks the API so validation never actually runs, but
+    // seeding keeps the store shape realistic and future-proofs against
+    // a switch to a non-mock client.
+    store.setDomain("general_not_sure");
     store.setSeniority("mid");
     store.setDepthPreference("standard");
     store.setGoals(["stay_current"]);

--- a/OneDrive/Desktop/signal-app/frontend/src/app/onboarding/[step]/page.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/onboarding/[step]/page.tsx
@@ -252,60 +252,18 @@ function Screen3(): JSX.Element {
   );
 }
 
-// ---------- Screen 4: depth preference ----------
+// ---------- Screen 4: topics (skippable) ----------
+//
+// Phase 12c reordered the flow so topics runs directly after seniority
+// (used to be Screen 5). The depth selector moved to *after* goals —
+// rationale: depth is a presentation preference that users anchor more
+// confidently once they've already declared what they care about. See
+// Screen 6 for the depth body.
 
 function Screen4(): JSX.Element {
-  const { depthPreference, setDepthPreference } = useOnboardingStore();
+  const { sectors, topics, setTopics } = useOnboardingStore();
   useScreenViewEvent(4);
   const nav = useOnboardingNav(4);
-
-  return (
-    <OnboardingShell
-      step={4}
-      title="How deep do you want to go?"
-      description="The free tier defaults to Standard. You can change this any time."
-      canContinue={true}
-      onContinue={() => nav.goNext(5)}
-      onBack={nav.goBack}
-    >
-      <div className="space-y-3">
-        {DEPTH_PREFERENCES.map((d) => {
-          const checked = depthPreference === d.value;
-          return (
-            <label
-              key={d.value}
-              className={`flex cursor-pointer items-start gap-3 rounded-md border p-4 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-              }`}
-            >
-              <input
-                type="radio"
-                name="depth"
-                value={d.value}
-                className="mt-1 h-4 w-4"
-                checked={checked}
-                onChange={() => setDepthPreference(d.value as DepthPreference)}
-              />
-              <div>
-                <p className="font-medium">{d.label}</p>
-                {d.description && (
-                  <p className="text-sm text-muted-foreground">{d.description}</p>
-                )}
-              </div>
-            </label>
-          );
-        })}
-      </div>
-    </OnboardingShell>
-  );
-}
-
-// ---------- Screen 5: topics (skippable) ----------
-
-function Screen5(): JSX.Element {
-  const { sectors, topics, setTopics } = useOnboardingStore();
-  useScreenViewEvent(5);
-  const nav = useOnboardingNav(5);
 
   // Build the master list of all valid (sector, topic) pairs for the
   // currently selected sectors. Skipping fills `topics` with this full
@@ -332,16 +290,16 @@ function Screen5(): JSX.Element {
     // Fill the store BEFORE nav.skip emits + routes; skip's event goes
     // out with the router.push so the order is stable in tests.
     setTopics(allPairs);
-    nav.skip(6);
+    nav.skip(5);
   };
 
   return (
     <OnboardingShell
-      step={5}
+      step={4}
       title="Any topics you especially care about?"
       description="Pick any — or skip and we'll show you everything in your sectors."
       canContinue={true}
-      onContinue={() => nav.goNext(6)}
+      onContinue={() => nav.goNext(5)}
       onSkip={handleSkip}
       onBack={nav.goBack}
     >
@@ -388,12 +346,16 @@ function Screen5(): JSX.Element {
   );
 }
 
-// ---------- Screen 6: goals (skippable) ----------
+// ---------- Screen 5: goals (skippable) ----------
+//
+// Phase 12c: goals moved up one slot (was Screen 6) so the depth
+// selector can follow it at Screen 6. The skip default is unchanged —
+// still [DEFAULT_GOAL] — only the downstream route target moves.
 
-function Screen6(): JSX.Element {
+function Screen5(): JSX.Element {
   const { goals, setGoals } = useOnboardingStore();
-  useScreenViewEvent(6);
-  const nav = useOnboardingNav(6);
+  useScreenViewEvent(5);
+  const nav = useOnboardingNav(5);
 
   const toggle = (value: string): void => {
     setGoals(
@@ -406,16 +368,16 @@ function Screen6(): JSX.Element {
   const handleSkip = (): void => {
     // Per spec: Skip submits the default single-goal list.
     setGoals([DEFAULT_GOAL]);
-    nav.skip(7);
+    nav.skip(6);
   };
 
   return (
     <OnboardingShell
-      step={6}
+      step={5}
       title="What do you want to get out of SIGNAL?"
       description="Select any that apply — or skip to use the default."
       canContinue={goals.length >= 1}
-      onContinue={() => nav.goNext(7)}
+      onContinue={() => nav.goNext(6)}
       onSkip={handleSkip}
       onBack={nav.goBack}
     >
@@ -436,6 +398,61 @@ function Screen6(): JSX.Element {
                 onChange={() => toggle(g.value)}
               />
               <span className="font-medium">{g.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    </OnboardingShell>
+  );
+}
+
+// ---------- Screen 6: depth preference ----------
+//
+// Phase 12c: depth selector moved from Screen 4 to Screen 6. Rationale
+// in the phase prompt — users calibrate depth more confidently after
+// they've declared sectors, topics, and goals. Wire shape is unchanged
+// (depth_preference still ships as part of the /onboarding/complete
+// payload); only the screen position moved, so the only source-level
+// changes are the hook args + the next-step target.
+
+function Screen6(): JSX.Element {
+  const { depthPreference, setDepthPreference } = useOnboardingStore();
+  useScreenViewEvent(6);
+  const nav = useOnboardingNav(6);
+
+  return (
+    <OnboardingShell
+      step={6}
+      title="How deep do you want to go?"
+      description="The free tier defaults to Standard. You can change this any time."
+      canContinue={true}
+      onContinue={() => nav.goNext(7)}
+      onBack={nav.goBack}
+    >
+      <div className="space-y-3">
+        {DEPTH_PREFERENCES.map((d) => {
+          const checked = depthPreference === d.value;
+          return (
+            <label
+              key={d.value}
+              className={`flex cursor-pointer items-start gap-3 rounded-md border p-4 transition-colors ${
+                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+              }`}
+            >
+              <input
+                type="radio"
+                name="depth"
+                value={d.value}
+                className="mt-1 h-4 w-4"
+                checked={checked}
+                onChange={() => setDepthPreference(d.value as DepthPreference)}
+              />
+              <div>
+                <p className="font-medium">{d.label}</p>
+                {d.description && (
+                  <p className="text-sm text-muted-foreground">{d.description}</p>
+                )}
+              </div>
             </label>
           );
         })}

--- a/OneDrive/Desktop/signal-app/frontend/src/app/onboarding/[step]/page.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/onboarding/[step]/page.tsx
@@ -14,6 +14,7 @@ import {
   TOPICS_BY_SECTOR,
   DEFAULT_GOAL,
 } from "@/lib/onboarding";
+import { getDomainOptionsForSectors } from "@/lib/onboarding/domainOptions";
 import { useOnboardingComplete } from "@/hooks/useProfile";
 import {
   markOnboardingCompletedInSession,
@@ -95,44 +96,114 @@ function Screen1(): JSX.Element {
   );
 }
 
-// ---------- Screen 2: role ----------
+// ---------- Screen 2: role + domain ----------
+
+// Phase 12c: Screen 2 expanded to capture `domain` (field-within-
+// sector) alongside role. Role stays as a radio grid (9 options);
+// domain is a native dropdown because the union of per-sector options
+// can reach ~50 entries when the user has all three sectors selected.
+// Domain options are filtered by the sectors the user picked on
+// Screen 1, with "General / Not sure" always pinned at the bottom.
+//
+// If the user navigates back to Screen 1, changes sectors, then
+// returns here, a previously-chosen domain may no longer be in the
+// filtered list. We reset `domain` to null in that case — the user
+// must re-pick before Continue. This runs once per sectors change,
+// not per render.
 
 function Screen2(): JSX.Element {
-  const { role, setRole } = useOnboardingStore();
+  const { sectors, role, setRole, domain, setDomain } = useOnboardingStore();
   useScreenViewEvent(2);
   const nav = useOnboardingNav(2);
+
+  const domainOptions = useMemo(
+    () => getDomainOptionsForSectors(sectors),
+    [sectors],
+  );
+
+  // If the previously-selected domain is no longer a valid option
+  // (because sectors changed), clear it so the user re-picks. Safe
+  // to run as an effect: setDomain is a no-op when the value already
+  // matches, and the dependency on the options array only changes
+  // when sectors change.
+  useEffect(() => {
+    if (domain === null) return;
+    const stillValid = domainOptions.some((opt) => opt.value === domain);
+    if (!stillValid) {
+      // Clear — typed as `string` setter, so use empty + treat null
+      // below in canContinue. (Store default is null; passing '' would
+      // drift the type. Cast through unknown to bypass the setter's
+      // string requirement without widening it.)
+      (setDomain as (v: string | null) => void)(null);
+    }
+  }, [domain, domainOptions, setDomain]);
+
+  const canContinue =
+    role !== null && role.length > 0 && domain !== null && domain.length > 0;
 
   return (
     <OnboardingShell
       step={2}
-      title="What's your role?"
-      description="We tailor commentary framing to your role."
-      canContinue={role !== null && role.length > 0}
+      title="Tell us about your work"
+      description="Role and field. We use both to tailor commentary — the field question sharpens the signal beyond role alone."
+      canContinue={canContinue}
       onContinue={() => nav.goNext(3)}
       onBack={nav.goBack}
     >
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        {ROLES.map((r) => {
-          const checked = role === r.value;
-          return (
-            <label
-              key={r.value}
-              className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-              }`}
-            >
-              <input
-                type="radio"
-                name="role"
-                value={r.value}
-                className="h-4 w-4"
-                checked={checked}
-                onChange={() => setRole(r.value)}
-              />
-              <span className="font-medium">{r.label}</span>
-            </label>
-          );
-        })}
+      <div className="space-y-6">
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Your role
+          </legend>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {ROLES.map((r) => {
+              const checked = role === r.value;
+              return (
+                <label
+                  key={r.value}
+                  className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
+                    checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="role"
+                    value={r.value}
+                    className="h-4 w-4"
+                    checked={checked}
+                    onChange={() => setRole(r.value)}
+                  />
+                  <span className="font-medium">{r.label}</span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            What field do you work in?
+          </legend>
+          <p className="text-sm text-muted-foreground">
+            Pick the closest match. Options are scoped to your selected
+            sectors — choose &ldquo;General / Not sure&rdquo; if nothing
+            fits.
+          </p>
+          <select
+            className="w-full rounded-md border bg-background p-3 font-medium"
+            value={domain ?? ""}
+            onChange={(e) => setDomain(e.target.value)}
+          >
+            <option value="" disabled>
+              Select a field&hellip;
+            </option>
+            {domainOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </fieldset>
       </div>
     </OnboardingShell>
   );
@@ -431,6 +502,12 @@ function Screen7(): JSX.Element {
       await complete.mutateAsync({
         sectors: store.sectors,
         role: store.role ?? "",
+        // Phase 12c — domain added to the completion payload. Screen 2
+        // gates Continue on domain !== null, so in the normal flow this
+        // coalescing branch never fires; kept for type-safety with the
+        // backend zod `.min(1)` guard surfacing a clean error if we ever
+        // land here with nothing set.
+        domain: store.domain ?? "",
         seniority: store.seniority ?? "",
         depth_preference: store.depthPreference,
         topics: resolvedTopics,

--- a/OneDrive/Desktop/signal-app/frontend/src/components/stories/PersonalizationBox.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/components/stories/PersonalizationBox.tsx
@@ -1,18 +1,46 @@
 import { Sparkles } from "lucide-react";
 
 interface PersonalizationBoxProps {
-  text: string;
+  // Final commentary to display. Null/undefined = loading skeleton.
+  text: string | null | undefined;
+  // Phase 12c: when true, render the shimmer skeleton instead of text.
+  // Separated from text-null because we want to show the header chrome
+  // (icon + "Why it matters to you") immediately and only swap the
+  // body between skeleton and commentary.
+  loading?: boolean;
 }
 
-export function PersonalizationBox({ text }: PersonalizationBoxProps): JSX.Element {
+// Three-line shimmer that visually matches the commentary density
+// produced by DEPTH_GUIDANCE["standard"] (~120-160 words, ~3 lines in
+// the feed card width). Using pulse rather than a moving gradient
+// because tailwind ships it out of the box and it doesn't fight
+// React 18 StrictMode's double-render in dev.
+function CommentarySkeleton(): JSX.Element {
+  return (
+    <div aria-busy="true" aria-live="polite" className="space-y-2">
+      <span className="sr-only">Generating your personalized commentary</span>
+      <div className="h-3 w-[95%] animate-pulse rounded bg-violet-200/80" />
+      <div className="h-3 w-[88%] animate-pulse rounded bg-violet-200/70" />
+      <div className="h-3 w-[60%] animate-pulse rounded bg-violet-200/60" />
+    </div>
+  );
+}
+
+export function PersonalizationBox({ text, loading }: PersonalizationBoxProps): JSX.Element {
+  const showSkeleton = loading || text === null || text === undefined;
+
   return (
     <div className="flex gap-3 rounded-lg border border-violet-200 bg-violet-50/60 p-4">
       <Sparkles className="mt-0.5 h-4 w-4 flex-shrink-0 text-violet-600" />
-      <div className="space-y-1">
+      <div className="flex-1 space-y-1">
         <p className="text-xs font-semibold uppercase tracking-wide text-violet-700">
           Why it matters to you
         </p>
-        <p className="text-sm leading-relaxed text-slate-800">{text}</p>
+        {showSkeleton ? (
+          <CommentarySkeleton />
+        ) : (
+          <p className="text-sm leading-relaxed text-slate-800">{text}</p>
+        )}
       </div>
     </div>
   );

--- a/OneDrive/Desktop/signal-app/frontend/src/components/stories/StoryCard.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/components/stories/StoryCard.tsx
@@ -1,8 +1,12 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { MessageSquare, ExternalLink } from "lucide-react";
 import { SectorBadge } from "./SectorBadge";
 import { StorySaveButton } from "./StorySaveButton";
 import { PersonalizationBox } from "./PersonalizationBox";
+import { useStoryCommentary } from "@/hooks/useStoryCommentary";
 import type { Story } from "@/types/story";
 
 function formatDate(value: string | null): string {
@@ -20,11 +24,76 @@ interface StoryCardProps {
   story: Story;
 }
 
+// Phase 12c — each card self-manages when to fire its commentary
+// fetch via IntersectionObserver with a rootMargin that provides
+// roughly 5 cards of lookahead. Coupled with COMMENTARY_MAX_CONCURRENT
+// in lib/commentaryQueue, this produces:
+//   - first page: ~first 5-8 cards above-the-fold trigger immediately,
+//     saturating the 8-slot semaphore; the remaining 2-5 queue and
+//     resolve as soon as the first wave returns.
+//   - scrolling: newly-visible cards (and ~5 more below them) flip
+//     to enabled; queue absorbs the spike.
+//
+// Card height is ~200-240px; 1200px of rootMargin ≈ 5-6 cards of
+// scroll-ahead, which matches the "5-story prefetch" product spec.
+// We use only vertical margin (0px horizontal) — the feed is a
+// single column.
+const VISIBILITY_ROOT_MARGIN = "1200px 0px";
+
 export function StoryCard({ story }: StoryCardProps): JSX.Element {
   const date = formatDate(story.published_at ?? story.created_at);
 
+  // Once a card has been "close enough" to the viewport to prefetch,
+  // we latch that state — scrolling away must NOT cancel an in-flight
+  // request (StrictMode would already double-fire; canceling would
+  // waste the slot and churn TanStack Query's cache).
+  const [shouldLoad, setShouldLoad] = useState(false);
+  const cardRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el || shouldLoad) return;
+    // If the browser doesn't support IntersectionObserver, fall back
+    // to enabling immediately. The 8-slot semaphore still caps fanout.
+    if (typeof IntersectionObserver === "undefined") {
+      setShouldLoad(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setShouldLoad(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: VISIBILITY_ROOT_MARGIN },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [shouldLoad]);
+
+  const commentaryQuery = useStoryCommentary(story.id, { enabled: shouldLoad });
+
+  // Fallback text layering (in priority order):
+  //   1. the freshly-loaded commentary from the endpoint
+  //   2. any commentary that arrived pre-loaded on the story (future-
+  //      proofing for a server-side hydration path we don't ship in 12c)
+  //   3. the 12b why_it_matters_to_you personalization (the surface's
+  //      "always at least something" floor during the 12c rollout)
+  // We pass `loading` to the skeleton only while (1) and (2) are
+  // empty AND the query is actively fetching — otherwise the
+  // 12b fallback renders directly.
+  const resolvedCommentary =
+    commentaryQuery.data?.commentary ?? story.commentary ?? null;
+  const isCommentaryLoading =
+    shouldLoad && resolvedCommentary === null && commentaryQuery.isFetching;
+  const displayText = resolvedCommentary ?? story.why_it_matters_to_you;
+
   return (
-    <article className="group rounded-lg border border-slate-200 bg-white p-6 transition-shadow hover:shadow-md">
+    <article
+      ref={cardRef}
+      className="group rounded-lg border border-slate-200 bg-white p-6 transition-shadow hover:shadow-md"
+    >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <SectorBadge sector={story.sector} />
@@ -42,7 +111,7 @@ export function StoryCard({ story }: StoryCardProps): JSX.Element {
         </p>
       </Link>
 
-      <PersonalizationBox text={story.why_it_matters_to_you} />
+      <PersonalizationBox text={displayText} loading={isCommentaryLoading} />
 
       <div className="mt-4 flex items-center justify-between text-xs text-slate-500">
         <div className="flex items-center gap-4">

--- a/OneDrive/Desktop/signal-app/frontend/src/components/stories/StoryDetail.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/components/stories/StoryDetail.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import { ExternalLink, MessageSquare } from "lucide-react";
 import { SectorBadge } from "./SectorBadge";
 import { StorySaveButton } from "./StorySaveButton";
 import { PersonalizationBox } from "./PersonalizationBox";
+import { useStoryCommentary } from "@/hooks/useStoryCommentary";
 import type { Story } from "@/types/story";
 
 function formatDate(value: string | null): string {
@@ -21,6 +24,19 @@ interface StoryDetailProps {
 
 export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
   const date = formatDate(story.published_at ?? story.created_at);
+
+  // Detail is a single-story surface — fire the commentary fetch
+  // immediately rather than gating on IntersectionObserver. The
+  // 8-slot semaphore still protects against an unlikely burst (e.g. a
+  // user rapidly cmd-clicking multiple story links into new tabs,
+  // each of which wakes a detail page that mounts this hook).
+  const commentaryQuery = useStoryCommentary(story.id, { enabled: true });
+
+  const resolvedCommentary =
+    commentaryQuery.data?.commentary ?? story.commentary ?? null;
+  const isCommentaryLoading =
+    resolvedCommentary === null && commentaryQuery.isFetching;
+  const displayText = resolvedCommentary ?? story.why_it_matters_to_you;
 
   return (
     <article className="space-y-6">
@@ -47,7 +63,7 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
         </div>
       </header>
 
-      <PersonalizationBox text={story.why_it_matters_to_you} />
+      <PersonalizationBox text={displayText} loading={isCommentaryLoading} />
 
       <section className="space-y-4">
         <div>

--- a/OneDrive/Desktop/signal-app/frontend/src/hooks/useStoryCommentary.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/hooks/useStoryCommentary.ts
@@ -1,0 +1,50 @@
+"use client";
+
+// Phase 12c — lazy per-story commentary fetch, semaphore-gated.
+//
+// One useQuery per visible story. The `enabled` flag is driven by the
+// feed's 5-story scroll-ahead window (see components/stories/StoryCard
+// and app/(app)/feed/page for the visibility wiring). Even with
+// enabled=true across many cards, withCommentarySlot caps parallel
+// requests to COMMENTARY_MAX_CONCURRENT — queued fetches resolve in
+// FIFO order as slots free up.
+//
+// Cache key includes `depth` so a Premium depth-selector flip
+// (story detail) gets its own cache entry and a 404/error on the
+// flipped depth doesn't poison the default-depth result.
+//
+// staleTime is Infinity: the server's own cache key bumps on profile
+// changes (profile_version), so the client has no independent reason
+// to revalidate commentary within a session. Navigating away and back
+// reuses the cached result.
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { getStoryCommentaryRequest } from "@/lib/api";
+import { withCommentarySlot } from "@/lib/commentaryQueue";
+import type { CommentaryResponse } from "@/types/story";
+
+export type DepthOverride = "accessible" | "standard" | "technical";
+
+interface UseStoryCommentaryOptions {
+  enabled?: boolean;
+  depth?: DepthOverride;
+}
+
+export function useStoryCommentary(
+  storyId: string,
+  options: UseStoryCommentaryOptions = {},
+): UseQueryResult<CommentaryResponse, Error> {
+  const enabled = options.enabled ?? true;
+  const depth = options.depth;
+
+  return useQuery({
+    // depth is part of the key so an explicit override maintains a
+    // separate cache entry from the server-default-depth result.
+    queryKey: ["commentary", storyId, depth ?? null],
+    queryFn: () => withCommentarySlot(() => getStoryCommentaryRequest(storyId, depth)),
+    enabled: Boolean(storyId) && enabled,
+    staleTime: Infinity,
+    gcTime: 10 * 60 * 1000, // 10 min — keep across feed⇄detail navigation
+    retry: 1, // the server always returns a result (fallback tiers); one retry covers a transient network blip
+  });
+}

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/api.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/api.ts
@@ -497,6 +497,10 @@ export async function revokeTeamInviteRequest(
 export interface OnboardingCompleteInput {
   sectors: string[];
   role: string;
+  // Phase 12c — Screen 2 field-within-sector dropdown. Required;
+  // validated server-side against the DOMAIN_OPTIONS union including
+  // the "general_not_sure" sentinel.
+  domain: string;
   seniority: string;
   depth_preference: DepthPreference;
   topics: { sector: string; topic: string }[];

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/api.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/api.ts
@@ -120,6 +120,12 @@ export interface UpdateProfileInput {
   // the onboarding questionnaire. Optional to preserve backward compat
   // for any older caller that doesn't supply it.
   depth_preference?: DepthPreference;
+  // Phase 12c: Settings "Interests" card now also edits the full
+  // commentary-input set. Optional for backward compat — the backend
+  // diffs only the fields it receives, and leaves the others alone.
+  domain?: string;
+  seniority?: string;
+  topic_interests?: { sector: string; topic: string }[];
 }
 
 export interface UpdateUserInput {

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/api.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   UserProfile,
 } from "@/types/auth";
 import type {
+  CommentaryResponse,
   FeedResponse,
   SaveToggleResponse,
   SavedStoriesResponse,
@@ -206,6 +207,22 @@ export async function getFeedRequest(params: FeedParams = {}): Promise<FeedRespo
 export async function getStoryRequest(id: string): Promise<Story> {
   const res = await api.get<{ data: { story: Story } }>(`/api/v1/stories/${id}`);
   return res.data.data.story;
+}
+
+// Phase 12c — lazy per-user, per-story commentary fetch. The feed
+// endpoint returns `commentary: null` for every row; this call
+// hydrates one row. `depth` is optional: omit to let the server use
+// the user's stored depth_preference (the common path); pass it for
+// depth-selector overrides on story detail.
+export async function getStoryCommentaryRequest(
+  id: string,
+  depth?: "accessible" | "standard" | "technical",
+): Promise<CommentaryResponse> {
+  const res = await api.get<{ data: CommentaryResponse }>(
+    `/api/v1/stories/${id}/commentary`,
+    { params: depth ? { depth } : undefined },
+  );
+  return res.data.data;
 }
 
 export async function getRelatedStoriesRequest(id: string): Promise<Story[]> {

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/commentaryQueue.test.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/commentaryQueue.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  COMMENTARY_MAX_CONCURRENT,
+  __commentaryQueueSnapshot,
+  __resetCommentaryQueueForTests,
+  withCommentarySlot,
+} from "./commentaryQueue";
+
+// Deferred-promise helper — callers can independently kick off a
+// batch of pending fetches and resolve them one at a time to prove
+// the semaphore is actually admitting work in order as slots free.
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Flush all pending microtasks. Resolving a deferred triggers a chain
+// (release → waiter resolve → awaiter continuation → fn() body), and
+// a single `await Promise.resolve()` only walks one step of that
+// chain. Using setTimeout(0) jumps to the next macrotask, which
+// guarantees all microtasks (including nested ones) have drained.
+function flushMicrotasks(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe("commentaryQueue — withCommentarySlot", () => {
+  beforeEach(() => {
+    __resetCommentaryQueueForTests();
+  });
+
+  it("runs a single task inline without queueing", async () => {
+    const result = await withCommentarySlot(() => Promise.resolve("ok"));
+    expect(result).toBe("ok");
+    // Post-resolution, active must return to zero — otherwise a
+    // subsequent batch could permanently lose a slot.
+    expect(__commentaryQueueSnapshot()).toEqual({ active: 0, waiting: 0 });
+  });
+
+  it("admits at most COMMENTARY_MAX_CONCURRENT tasks at once", async () => {
+    const deferreds = Array.from({ length: COMMENTARY_MAX_CONCURRENT + 4 }, () =>
+      deferred<string>(),
+    );
+    const results: Array<Promise<string>> = deferreds.map((d, i) =>
+      withCommentarySlot(() => d.promise.then((v) => `${v}-${i}`)),
+    );
+
+    // Let the event loop run once so the queue can admit the first
+    // wave — without this, active is still 0 because withCommentarySlot's
+    // body hasn't progressed past `await acquire()` yet.
+    await Promise.resolve();
+
+    const snap = __commentaryQueueSnapshot();
+    expect(snap.active).toBe(COMMENTARY_MAX_CONCURRENT);
+    expect(snap.waiting).toBe(4);
+
+    // Resolve the first wave; queued tasks should start admitting.
+    for (let i = 0; i < COMMENTARY_MAX_CONCURRENT; i += 1) {
+      deferreds[i].resolve("done");
+    }
+    // Resolve the overflow too.
+    for (let i = COMMENTARY_MAX_CONCURRENT; i < deferreds.length; i += 1) {
+      deferreds[i].resolve("done");
+    }
+
+    const resolved = await Promise.all(results);
+    expect(resolved).toHaveLength(COMMENTARY_MAX_CONCURRENT + 4);
+    expect(__commentaryQueueSnapshot()).toEqual({ active: 0, waiting: 0 });
+  });
+
+  it("releases the slot even when the wrapped task throws", async () => {
+    await expect(
+      withCommentarySlot<string>(() => Promise.reject(new Error("boom"))),
+    ).rejects.toThrow("boom");
+    expect(__commentaryQueueSnapshot()).toEqual({ active: 0, waiting: 0 });
+
+    // And a subsequent task gets the slot back — proving we didn't
+    // leak it on the throw path.
+    const second = await withCommentarySlot(() => Promise.resolve("next"));
+    expect(second).toBe("next");
+  });
+
+  it("admits queued tasks in FIFO order as slots free", async () => {
+    const order: number[] = [];
+    const deferreds = Array.from({ length: COMMENTARY_MAX_CONCURRENT + 3 }, () =>
+      deferred<void>(),
+    );
+    const all = deferreds.map((d, i) =>
+      withCommentarySlot(async () => {
+        order.push(i);
+        await d.promise;
+      }),
+    );
+
+    await flushMicrotasks();
+    // First wave should have already pushed indices 0..MAX-1 into `order`.
+    expect(order).toEqual(
+      Array.from({ length: COMMENTARY_MAX_CONCURRENT }, (_, i) => i),
+    );
+
+    // Free one slot — the next queued task (index MAX) should admit.
+    deferreds[0].resolve();
+    await flushMicrotasks();
+    expect(order[COMMENTARY_MAX_CONCURRENT]).toBe(COMMENTARY_MAX_CONCURRENT);
+
+    // Free two more and make sure the next two queued tasks admit in
+    // the same order they were enqueued.
+    deferreds[1].resolve();
+    await flushMicrotasks();
+    deferreds[2].resolve();
+    await flushMicrotasks();
+    expect(order[COMMENTARY_MAX_CONCURRENT + 1]).toBe(COMMENTARY_MAX_CONCURRENT + 1);
+    expect(order[COMMENTARY_MAX_CONCURRENT + 2]).toBe(COMMENTARY_MAX_CONCURRENT + 2);
+
+    // Drain the rest.
+    for (const d of deferreds) d.resolve();
+    await Promise.all(all);
+    expect(__commentaryQueueSnapshot()).toEqual({ active: 0, waiting: 0 });
+  });
+});

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/commentaryQueue.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/commentaryQueue.ts
@@ -1,0 +1,74 @@
+// Phase 12c — module-local semaphore that caps in-flight commentary
+// fetches. The client can have many StoryCard mounts all with
+// `enabled=true` at once (think: user scrolls to the bottom of a
+// 50-story feed); without a cap we would fan out 50 parallel requests
+// to a Haiku-backed endpoint.
+//
+// Why 8: the feed route serves 10 stories per page, so 8 slots lets
+// the first page's requests run in two back-to-back waves rather than
+// one wave of 10 (which saturates every browser's per-origin parallel
+// HTTP cap of 6 and then stalls) — and Haiku itself doesn't like 50
+// fanouts either. The number is a deliberate product decision, not
+// browser-imposed: it's the cap _above_ the browser cap, shaping
+// queue pressure on the server.
+//
+// The 5-story scroll-ahead prefetch mechanic lives in the feed page —
+// cards only become `enabled` as they enter a ~5-row lookahead window
+// of the viewport. This module is the concurrency gate behind that
+// enablement.
+//
+// Revisit in 12c.1 if instrumentation says queue wait is >100ms P95.
+
+const MAX_CONCURRENT = 8;
+
+let active = 0;
+const waiters: Array<() => void> = [];
+
+function acquire(): Promise<void> {
+  if (active < MAX_CONCURRENT) {
+    active += 1;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waiters.push(() => {
+      active += 1;
+      resolve();
+    });
+  });
+}
+
+function release(): void {
+  active -= 1;
+  const next = waiters.shift();
+  if (next) next();
+}
+
+/**
+ * Wraps a fetch so it only runs when a semaphore slot is available.
+ * Never rejects on its own; forwards the wrapped function's result
+ * (resolve or reject) verbatim and always releases its slot.
+ */
+export async function withCommentarySlot<T>(fn: () => Promise<T>): Promise<T> {
+  await acquire();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+// Exported for tests — lets a test suite reset the module singleton
+// between cases so a throw in one case doesn't leak into the next.
+export function __resetCommentaryQueueForTests(): void {
+  active = 0;
+  waiters.length = 0;
+}
+
+// Exported for tests + potential future telemetry. Do NOT use from
+// product code to gate behavior — read it once and the value is
+// already stale.
+export function __commentaryQueueSnapshot(): { active: number; waiting: number } {
+  return { active, waiting: waiters.length };
+}
+
+export const COMMENTARY_MAX_CONCURRENT = MAX_CONCURRENT;

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/onboarding.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/onboarding.ts
@@ -78,7 +78,12 @@ export const SENIORITIES: readonly LabeledOption[] = [
   { value: "leadership", label: "Leadership" },
 ] as const;
 
-// ---------- Depth preference (Screen 4, default = standard) ----------
+// ---------- Depth preference (Screen 6 as of Phase 12c; was Screen 4 in 12b) ----------
+//
+// Position change only — the option list and default are unchanged.
+// Depth moved from Screen 4 to Screen 6 (after goals) so users anchor
+// the depth pick on concrete selections they've already made rather
+// than as an abstract preference up front.
 
 export const DEPTH_PREFERENCES: readonly LabeledOption[] = [
   {
@@ -100,7 +105,7 @@ export const DEPTH_PREFERENCES: readonly LabeledOption[] = [
 
 export const DEFAULT_DEPTH_PREFERENCE = "standard" as const;
 
-// ---------- Topics per sector (Screen 5) ----------
+// ---------- Topics per sector (Screen 4 as of Phase 12c; was Screen 5 in 12b) ----------
 
 export interface TopicOption {
   value: string;
@@ -146,7 +151,7 @@ export const TOPICS_BY_SECTOR: Readonly<Record<string, readonly TopicOption[]>> 
   ],
 };
 
-// ---------- Goals (Screen 6, default on skip) ----------
+// ---------- Goals (Screen 5 as of Phase 12c; was Screen 6 in 12b, default on skip) ----------
 
 // Labels match the spec (Phase 12b fix-it Fix 4 / Issue #10). Values
 // are unchanged so persisted profiles keep working. The `deep_learning`

--- a/OneDrive/Desktop/signal-app/frontend/src/lib/onboarding/domainOptions.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/lib/onboarding/domainOptions.ts
@@ -1,0 +1,124 @@
+// CONTENT DECISION — REVIEW BEFORE MERGE.
+// These domain lists will be seen by every new user during onboarding.
+// 15–20 options per sector, plus the "General / Not sure" sentinel.
+// Sensible defaults proposed by Claude Code; Omar to validate pre-merge.
+//
+// Phase 12c — Screen 2 "what field do you work in?" dropdown.
+// Canonical value strings live in
+// `backend/src/constants/domainOptions.ts` and are enforced by the
+// Zod validator on /onboarding/complete. This file mirrors the values
+// and adds display labels. When you edit one, edit the other; a drift
+// manifests as the UI offering an option the server then rejects with
+// INVALID_INPUT.
+//
+// Display contract: when a user has multiple sectors selected on
+// Screen 1, Screen 2 shows the union of those sectors' options
+// deduplicated, with "General / Not sure" always pinned at the
+// bottom of the list.
+//
+// The value strings are stable identifiers — once shipped, they
+// persist in user_profiles.domain and are referenced by the Haiku
+// prompt. Changing a value is a data migration; changing only a
+// label is cosmetic.
+//
+// If Omar overrides any of these before merge, update both this
+// file and backend/src/constants/domainOptions.ts in the same PR.
+
+export const GENERAL_DOMAIN_OPTION = {
+  value: "general_not_sure",
+  label: "General / Not sure",
+} as const;
+
+export interface DomainOption {
+  value: string;
+  label: string;
+}
+
+export const DOMAIN_OPTIONS_BY_SECTOR: Readonly<Record<string, readonly DomainOption[]>> = {
+  ai: [
+    { value: "foundation_model_research", label: "Foundation model research" },
+    { value: "model_training_infra", label: "Model training infrastructure" },
+    { value: "inference_infra", label: "Inference infrastructure" },
+    { value: "ai_product_engineering", label: "AI product engineering" },
+    { value: "ai_application_development", label: "AI application development" },
+    { value: "ml_engineering", label: "ML engineering" },
+    { value: "ai_safety_alignment", label: "AI safety & alignment" },
+    { value: "ai_policy_governance", label: "AI policy & governance" },
+    { value: "ai_developer_tools", label: "AI developer tools" },
+    { value: "computer_vision", label: "Computer vision" },
+    { value: "nlp_conversational_ai", label: "NLP / conversational AI" },
+    { value: "robotics_embodied_ai", label: "Robotics & embodied AI" },
+    { value: "ai_healthcare_biotech", label: "AI for healthcare / biotech" },
+    { value: "ai_enterprise_productivity", label: "AI for enterprise / productivity" },
+    { value: "ai_investing_vc", label: "AI investing / VC" },
+    { value: "ai_journalism_analyst", label: "AI journalism / analyst" },
+    { value: "data_engineering_ml", label: "Data engineering for ML" },
+    { value: "generative_ai_applications", label: "Generative AI applications" },
+  ],
+  finance: [
+    { value: "equity_research", label: "Equity research" },
+    { value: "equity_sales_trading", label: "Equity sales & trading" },
+    { value: "fixed_income_credit", label: "Fixed income / credit" },
+    { value: "macro_rates_strategy", label: "Macro / rates strategy" },
+    { value: "quantitative_research", label: "Quantitative research" },
+    { value: "quantitative_trading", label: "Quantitative trading" },
+    { value: "risk_management", label: "Risk management" },
+    { value: "investment_banking_ma", label: "Investment banking / M&A" },
+    { value: "private_equity", label: "Private equity" },
+    { value: "venture_capital", label: "Venture capital" },
+    { value: "hedge_fund_fundamental", label: "Hedge fund (fundamental / long-short)" },
+    { value: "hedge_fund_systematic", label: "Hedge fund (systematic)" },
+    { value: "wealth_management", label: "Wealth / asset management" },
+    { value: "corporate_strategy", label: "Corporate strategy / development" },
+    { value: "financial_regulation_compliance", label: "Regulation / compliance" },
+    { value: "financial_journalism_analyst", label: "Financial journalism / analyst" },
+    { value: "crypto_digital_assets", label: "Crypto / digital assets" },
+    { value: "fintech_product_engineering", label: "Fintech product / engineering" },
+  ],
+  semiconductors: [
+    { value: "chip_design_architecture", label: "Chip design / architecture" },
+    { value: "verification_validation", label: "Verification & validation" },
+    { value: "physical_design_layout", label: "Physical design / layout" },
+    { value: "eda_design_automation", label: "EDA / design automation" },
+    { value: "foundry_operations", label: "Foundry operations" },
+    { value: "advanced_packaging", label: "Advanced packaging" },
+    { value: "memory_dram_nand", label: "Memory (DRAM / HBM / NAND)" },
+    { value: "gpu_accelerator_engineering", label: "GPU / accelerator engineering" },
+    { value: "networking_silicon", label: "Networking silicon" },
+    { value: "automotive_embedded", label: "Automotive / embedded silicon" },
+    { value: "analog_mixed_signal", label: "Analog / mixed-signal" },
+    { value: "rf_wireless_silicon", label: "RF / wireless silicon" },
+    { value: "power_management_ic", label: "Power management IC" },
+    { value: "semiconductor_supply_chain", label: "Supply chain / sourcing" },
+    { value: "semiconductor_equipment_oem", label: "Semiconductor equipment / OEM" },
+    { value: "export_controls_trade_policy", label: "Export controls / trade policy" },
+    { value: "semiconductor_investing_vc", label: "Semiconductor investing / VC" },
+    { value: "semiconductor_journalism_analyst", label: "Semiconductor journalism / analyst" },
+  ],
+};
+
+/**
+ * Returns the displayable options for Screen 2 given the currently-
+ * selected sectors on Screen 1. Union-dedupes by value, preserves
+ * sector-order appearance, and pins "General / Not sure" to the end.
+ *
+ * If no sectors are selected (shouldn't happen — Screen 1 requires
+ * ≥ 1 — but defensive default), only the sentinel is returned so the
+ * user is never stuck without any option.
+ */
+export function getDomainOptionsForSectors(
+  selectedSectors: readonly string[],
+): readonly DomainOption[] {
+  const seen = new Set<string>();
+  const union: DomainOption[] = [];
+  for (const sector of selectedSectors) {
+    const opts = DOMAIN_OPTIONS_BY_SECTOR[sector] ?? [];
+    for (const opt of opts) {
+      if (seen.has(opt.value)) continue;
+      seen.add(opt.value);
+      union.push(opt);
+    }
+  }
+  union.push(GENERAL_DOMAIN_OPTION);
+  return union;
+}

--- a/OneDrive/Desktop/signal-app/frontend/src/store/onboardingStore.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/store/onboardingStore.ts
@@ -21,8 +21,13 @@ const INITIAL_SECTORS: string[] = SECTORS.map((s) => s.value);
 export interface OnboardingState {
   // Screen 1 — required, multi-select
   sectors: string[];
-  // Screen 2 — required, single
+  // Screen 2 — role + domain, both required, both single
   role: string | null;
+  // Phase 12c: Screen 2 now also captures `domain` (the specific
+  // field-within-sector the user works in). Required; no default.
+  // Validated server-side against the DOMAIN_OPTIONS union including
+  // the "general_not_sure" sentinel. Feeds the Haiku commentary prompt.
+  domain: string | null;
   // Screen 3 — required, single
   seniority: string | null;
   // Screen 4 — required, defaults to "standard"
@@ -43,6 +48,7 @@ export interface OnboardingState {
   // Actions
   setSectors: (sectors: string[]) => void;
   setRole: (role: string) => void;
+  setDomain: (domain: string) => void;
   setSeniority: (seniority: string) => void;
   setDepthPreference: (depth: DepthPreference) => void;
   setTopics: (topics: { sector: string; topic: string }[]) => void;
@@ -56,6 +62,7 @@ const initialState: Omit<
   OnboardingState,
   | "setSectors"
   | "setRole"
+  | "setDomain"
   | "setSeniority"
   | "setDepthPreference"
   | "setTopics"
@@ -66,6 +73,7 @@ const initialState: Omit<
 > = {
   sectors: INITIAL_SECTORS,
   role: null,
+  domain: null,
   seniority: null,
   depthPreference: "standard",
   topics: [],
@@ -80,6 +88,7 @@ export const useOnboardingStore = create<OnboardingState>()(
       ...initialState,
       setSectors: (sectors) => set({ sectors }),
       setRole: (role) => set({ role }),
+      setDomain: (domain) => set({ domain }),
       setSeniority: (seniority) => set({ seniority }),
       setDepthPreference: (depthPreference) => set({ depthPreference }),
       setTopics: (topics) => set({ topics }),

--- a/OneDrive/Desktop/signal-app/frontend/src/types/auth.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/types/auth.ts
@@ -14,12 +14,19 @@ export interface UserProfile {
   userId: string;
   sectors: string[] | null;
   role: string | null;
+  // Phase 12c — Screen 2 field-within-sector; feeds the Haiku prompt.
+  domain: string | null;
   seniority: string | null;
   depthPreference: DepthPreference | null;
   goals: string[] | null;
   digestPreference: DigestPreference | null;
   timezone: string | null;
   completedAt: string | null;
+  // Phase 12c — monotonic version integer. Bumped on post-onboarding
+  // mutations to commentary-affecting profile fields (role, domain,
+  // seniority, sectors, topics, goals). Part of the commentary_cache
+  // key, so a bump invalidates prior cache rows on next view.
+  profileVersion: number;
   emailFrequency: EmailFrequency;
   emailUnsubscribed: boolean;
   createdAt?: string;

--- a/OneDrive/Desktop/signal-app/frontend/src/types/story.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/types/story.ts
@@ -6,13 +6,39 @@ export interface StoryAuthor {
   bio: string | null;
 }
 
+// Phase 12c — per-user, per-story commentary that the client hydrates
+// lazily after the feed lands. Possible values on the wire:
+//   "cache"           — served from commentary_cache, same user+story+depth+version
+//   "haiku"           — freshly generated
+//   "fallback_tier1"  — template with matched sector + topic overlap
+//   "fallback_tier2"  — template with matched sector, no topic overlap
+//   "fallback_tier3"  — template with anomaly (missing profile, off_sector,
+//                       or any Haiku-side failure). Not cached on the server.
+// The client currently treats all non-null sources as equivalent for
+// display, but the field is preserved for future telemetry (e.g. a
+// "generating…" affordance while tier3 regenerates on next view).
+export type CommentarySource =
+  | "cache"
+  | "haiku"
+  | "fallback_tier1"
+  | "fallback_tier2"
+  | "fallback_tier3";
+
 export interface Story {
   id: string;
   sector: Sector | string;
   headline: string;
   context: string;
   why_it_matters: string;
+  // Phase 12b personalization output. Kept on the payload through the
+  // 12c rollout so any surface that hasn't been migrated to the
+  // lazy-commentary hook still has something to render. Removed in 12d.
   why_it_matters_to_you: string;
+  // Phase 12c: null on feed-list responses; populated by the dedicated
+  // /stories/:id/commentary endpoint. `commentary_source` mirrors the
+  // service-layer CommentaryResult.source and is null until hydrated.
+  commentary: string | null;
+  commentary_source: CommentarySource | null;
   source_url: string;
   source_name: string | null;
   published_at: string | null;
@@ -21,6 +47,16 @@ export interface Story {
   is_saved: boolean;
   save_count: number;
   comment_count: number;
+}
+
+// Response envelope for GET /api/v1/stories/:id/commentary. The
+// `depth` field is echoed back because the server may have resolved
+// a ?depth= override against the user's stored preference.
+export interface CommentaryResponse {
+  commentary: string;
+  depth: "accessible" | "standard" | "technical";
+  profile_version: number;
+  source: CommentarySource;
 }
 
 export interface FeedResponse {


### PR DESCRIPTION
# Phase 12c: Personalized Haiku-Generated Commentary

## Summary

Replaces the 12a templated "Why It Matters To You" commentary with per-user, per-story commentary generated by Claude Haiku, incorporating the full user profile including a new `domain` field and the existing `depth_preference`. Adds a tiered improved fallback template used only when Haiku calls fail.

## Commit manifest

| # | SHA | Scope |
|---|---|---|
| 1 | `4132b7a` | Migration 0009 + schema (user_profiles domain/profile_version, commentary_cache table) |
| 2 | `643768f` | DOMAIN_OPTIONS_BY_SECTOR + Screen 2 role+domain expansion |
| 3 | `602b6d5` | Depth screen relocated 4→6 (flow: sectors → role+domain → seniority → topics → goals → depth → digest) |
| 4 | `e43c0b6` | Commentary service + Haiku client + prompt + tiered fallback + banned-phrase enforcement |
| 5 | `fc58df7` | Feed wire-up (`commentary:null` contract + `GET /stories/:id/commentary` + client hydration with 8-cap queue + skeletons) |
| 6 | `b795a08` | Settings editors for domain/seniority/topics + `profile_version` bump on commentary-relevant edits |
| 7 | `fcf613f` | CLAUDE.md phase summary (§3 dated model, §9 12c subsection, §14 test count, §16 phase table) + service-level integration test |
| 8 | `98c56f6` | Distinct Tier 3 reason for post-insert re-read empty (cache-race anomaly log correctness) |

## Gates

- Backend: type-check ✓, lint ✓, jest **435 tests / 37 suites** (369/31 at end of 12a → +66 tests, +6 suites)
- Frontend: type-check ✓, lint ✓, vitest **55 tests / 14 suites**

## Flagged deviations from the v2 spec

Each was necessary to match the actual codebase or was a better-than-specified outcome. All were flagged in their respective commit bodies.

- **Migration hand-written per CLAUDE.md §7** (Commit 1). v2 prompt said to use `drizzle-kit generate`; §7 explicitly bans it, and all 9 existing migrations are hand-written. Migration 0009 follows the 0008 template with manual `_journal.json` update.
- **`domain` + `profile_version` on `user_profiles`, not `users`** (Commit 1). Every onboarding field lives on `user_profiles`; putting these on `users` would have forced a cross-table JOIN on every commentary call.
- **`domain` nullable at the DB layer** (Commit 1). Zod enforces non-empty at onboarding completion. Matches 0008's pattern — `user_profiles` rows exist pre-onboarding via the unsubscribe flow.
- **`last_accessed_at` updated on every cache hit** (Commit 4). Gated by `LAST_ACCESSED_UPDATE_MODE = "every_hit"` constant for one-line swap to opportunistic mode in 12c.1.
- **10s Haiku timeout via AbortController, zero retries** (Commit 4). Fail-fast to template on any error. Retries revisited in 12d if observability warrants.
- **Role schema tightened `z.string()` → `z.enum(ROLES)`** (Commit 6). Invalid roles rejected at the boundary instead of landing in the DB.
- **Model pin strategy split** (Commit 7). Alias `claude-haiku-4-5` retained for the offline 12a regeneration script; dated `claude-haiku-4-5-20251001` used for the 12c request path. §3 documents the distinction.

## Self-report on gate discipline (Commit 2)

Commit 2's body quoted gate counts ("backend 323/323 / 26 suites, frontend 37/37 / 10 suites") from the *main repo* directory instead of the worktree. Real counts (discovered before Commit 3 and used for all subsequent commits) are 391/32 backend and 51/13 frontend at that point in the phase. Correctness wasn't affected — the changes were present and green in the worktree — but the Commit 2 body undercounts. Not amending a pushed commit for telemetry alone. Flagged here for accurate record.

## Architecture highlights

**Three-layer banned-phrase enforcement.** (1) Self-filter — banned phrases listed explicitly in the Haiku prompt. (2) Post-generation trip-wire — `\bphrase\b` word-boundary regex on Haiku output; any hit short-circuits cache write and routes to fallback with `reason: "haiku_banned_phrase"` + offenders. (3) Template defense-in-depth — same check on fallback output, escalates to Tier 3 if a future template edit introduces a banned phrase.

**Cache key `(user_id, story_id, depth, profile_version)`.** Append mode (no overwrites). Depth changes and profile-field changes both invalidate via cache-miss + regen. `profile_version` bumps atomically in a single transaction with the profile update, scoped to commentary-relevant fields only (role/domain/seniority/sectors/goals/topics — not email, not depth).

**Global 8-concurrency cap** via module-level semaphore in `frontend/src/lib/commentaryQueue.ts`. Shared across feed page + story detail + any future consumer. Decision 12's "global across foreground and prefetch requests" satisfied.

**Fallback tiers.** Tier 1 (matched topic exists) → topic-aware framing. Tier 2 (no topic match, sector matches) → sector + role framing. Tier 3 (unreachable in practice since feed is sector-filtered; also used for any Haiku failure) → minimal neutral sentence + structured anomaly log. Single register across all tiers, no visible fallback indicator.

## Migration

Migration 0009 SQL file is at `backend/src/db/migrations/0009_phase12c_commentary_cache.sql`. **Not applied to any database by this PR.** Application sequence:

1. Apply to Neon dev via web SQL editor (manual, per CLAUDE.md §7 / worked-around drizzle-kit issue #8)
2. Apply to Railway prod via `railway connect` CLI *before* code deploy (per PR Ground rules; avoids Railway dashboard SQL read inconsistency #14)
3. Verify schema with explicit queries
4. Deploy code

## Manual smoke test checklist (to run pre-merge on dev)

- [ ] Fresh signup → complete onboarding including new Screen 2 domain and relocated depth screen (position 6)
- [ ] Feed loads with skeleton loaders; commentary fills in within 1–3s per story
- [ ] Change depth in Settings → next feed view regenerates commentary at new depth
- [ ] Change a profile field (e.g., topics) in Settings → next feed view regenerates commentary at bumped profile_version
- [ ] No "As a [role]…" phrasings in Haiku output or template output
- [ ] Topic-tagged story shows topic-aware commentary (matched_interests working)

## Resolves

Closes #12 — Phase 12a commentary is templated, not personalized.

## Related

See comment on #11 for defer rationale on field-of-work/study question.