### PR TITLE
Hotfix #13 — reseed dev stories + URL liveness audit

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/package.json
+++ b/OneDrive/Desktop/signal-app/backend/package.json
@@ -17,6 +17,7 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "ts-node src/db/seed.ts",
     "seed:stories": "ts-node src/scripts/seedStories.ts",
+    "wipe:dev-stories": "ts-node src/scripts/wipeDevStories.ts",
     "send-digest-now": "ts-node src/scripts/sendDigestNow.ts",
     "run-aggregation": "ts-node src/scripts/runAggregation.ts",
     "regenerate-depth-variants": "ts-node src/scripts/regenerateDepthVariants.ts",

--- a/OneDrive/Desktop/signal-app/backend/package.json
+++ b/OneDrive/Desktop/signal-app/backend/package.json
@@ -18,6 +18,7 @@
     "db:seed": "ts-node src/db/seed.ts",
     "seed:stories": "ts-node src/scripts/seedStories.ts",
     "wipe:dev-stories": "ts-node src/scripts/wipeDevStories.ts",
+    "audit:story-urls": "ts-node src/scripts/auditStoryUrls.ts",
     "send-digest-now": "ts-node src/scripts/sendDigestNow.ts",
     "run-aggregation": "ts-node src/scripts/runAggregation.ts",
     "regenerate-depth-variants": "ts-node src/scripts/regenerateDepthVariants.ts",

--- a/OneDrive/Desktop/signal-app/backend/seed-data/stories.json
+++ b/OneDrive/Desktop/signal-app/backend/seed-data/stories.json
@@ -213,7 +213,7 @@
         "standard": "ASML's raised guide is the cleanest single data point confirming the AI capex supercycle is real and accelerating rather than plateauing. The stock setup is complicated by China exposure (19% of net system sales in Q1, down from 36% in Q4 2025) and the MATCH Act legislation that could extend restrictions to DUV tools. Expect Q2-Q3 ASML commentary to drive the semi-capital-equipment comps (Applied Materials, Lam Research, KLA) in ways that have nothing to do with their own prints. Long ASML, watch for MATCH Act progress as the asymmetric downside risk.",
         "technical": "The 60-to-80 low-NA EUV shipment trajectory is the single most important capacity number in the industry right now. Every advanced-node roadmap — TSMC N2, Samsung SF2, Intel 18A and 14A, SK Hynix 1c DRAM — gates on EUV tool availability. ASML dropping order-number disclosures starting this quarter makes forward visibility harder, but Fouquet's \"order intake continues to be very strong\" language plus the raised guide means lead times are extending. Memory mix jumped to 51% of new-tool sales in Q1 (from 30% prior), which signals HBM4/HBM4E production capacity is getting built now for 2027 deliveries."
       },
-      "source_url": "https://www.cnbc.com/amp/2026/04/15/asml-q1-2026-earnings-report.html",
+      "source_url": "https://www.cnbc.com/2026/04/15/asml-q1-2026-earnings-report.html",
       "source_name": "CNBC",
       "author_id": "SIGNAL_EDITORIAL",
       "published_at": "2026-04-15T09:00:00Z"

--- a/OneDrive/Desktop/signal-app/backend/seed-data/url-audit-2026-04-24.txt
+++ b/OneDrive/Desktop/signal-app/backend/seed-data/url-audit-2026-04-24.txt
@@ -1,0 +1,48 @@
+[audit] starting (User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36...)
+[audit] timeout 10000ms, max 5 redirects
+[audit] 20 stories to audit
+
+[200] https://www.trendforce.com/news/2025/12/24/news-samsung-sk-hynix-reportedly-plan-20-hbm3e-price-hike-for-2026-as-nvidia-h200-asic-demand-rises/ (story: Samsung and SK Hynix lift HBM3E prices ~20% for 2026 as ASIC demand...)
+[200] https://www.cnbc.com/2026/01/26/nvidia-set-to-supplant-apple-as-tsmcs-largest-customer.html (story: Nvidia to overtake Apple as TSMC's largest customer, formalizing AI...)
+[headers-overflow] https://finance.yahoo.com/news/intel-foundry-talks-nvidia-apple-171229595.html (story: Intel 18A enters HVM as Apple and Nvidia explore 2028 non-core prod...)
+[200] https://www.cnbc.com/2026/02/03/musk-xai-spacex-biggest-merger-ever.html (story: SpaceX absorbs xAI at $1.25T combined valuation, teeing up mid-2026...)
+[headers-overflow] https://finance.yahoo.com/markets/stocks/articles/openai-guarantees-17-5-minimum-165757294.html (story: OpenAI offers PE firms 17.5% guaranteed return to unlock enterprise...)
+[200] https://www.cnbc.com/2026/03/18/fed-interest-rate-decision-march-2026.html (story: Fed holds rates, sees one cut in 2026 as Iran oil shock complicates...)
+[200] https://www.cnbc.com/2026/03/31/openai-funding-round-ipo.html (story: OpenAI closes record $122B round at $852B valuation)
+[200] https://techcrunch.com/2026/03/31/openai-not-yet-public-raises-3b-from-retail-investors-in-monster-122b-fund-raise/ (story: OpenAI's $3B retail tranche signals IPO on-ramp via bank channels)
+[403] https://www.datacenterdynamics.com/en/news/samsung-and-sk-hynix-post-record-profits-but-warn-memory-chip-shortages-will-likely-persist-into-2027/ (story: SK Hynix, Samsung post record profits, warn memory shortages extend...)
+[200] https://www.cnbc.com/2026/04/08/tsmc-nvidia-advanced-packaging-intel.html (story: Nvidia locks majority of TSMC's CoWoS packaging capacity as bottlen...)
+[200] https://www.cnbc.com/2026/04/08/meta-debuts-first-major-ai-model-since-14-billion-deal-to-bring-in-alexandr-wang.html (story: Meta ships Muse Spark, its first major model under Alexandr Wang)
+[200] https://www.cnbc.com/2026/04/11/vibe-check-from-ai-industry-humanx-anthropic-is-talk-of-the-town.html (story: Claude Mythos Preview becomes HumanX centerpiece as Anthropic's foc...)
+[200] https://www.pwc.com/gx/en/news-room/press-releases/2026/pwc-2026-ai-performance-study.html (story: PwC: AI's economic gains concentrating, with 20% of firms capturing...)
+[200] https://www.prnewswire.com/news-releases/sp-global-market-intelligences-2026-private-equity-survey-shows-fundraising-confidence-rising-as-managers-pivot-to-operational-value-302740423.html (story: S&P Global: PE fundraising confidence rising, but AI adoption still...)
+[200] https://www.sec.gov/Archives/edgar/data/886982/000088698226000096/a1q26gsearningsresults.htm (story: Goldman Q1 sets equities-trading record, IB fees surge 48% — but st...)
+[200] https://www.cnbc.com/2026/04/14/jpmorgan-chase-jpm-earnings-1q-2026.html (story: JPMorgan beats Q1 on IB and trading, cuts full-year NII guidance)
+[403] https://www.bloomberg.com/news/articles/2026-04-14/anthropic-attracts-investor-offers-at-a-800-billion-valuation (story: Anthropic declines $800B-valuation term sheets — for now)
+[200] https://www.cnbc.com/2026/04/14/meta-commits-to-one-gigawatt-of-custom-chips-with-broadcom-as-hock-tan-agrees-to-leave-board.html (story: Meta commits 1GW to Broadcom custom silicon, extends MTIA partnersh...)
+[404] https://www.cnbc.com/amp/2026/04/15/asml-q1-2026-earnings-report.html (story: ASML raises 2026 guide to €36–40B, says demand "outpacing supply")
+[403] https://www.bloomberg.com/news/articles/2026-04-16/tsmc-s-profit-beats-estimates-after-war-failed-to-dent-ai-demand (story: TSMC Q1 profit +58%, raises 2026 revenue growth guide above 30%)
+
+[audit] summary:
+[audit]   2xx ok                         : 14
+[audit]   3xx (residual redirect)        : 0
+[audit]   403 blocked (bot guard)        : 3
+[audit]   4xx broken                     : 1
+[audit]   5xx server error               : 0
+[audit]   timeout                        : 0
+[audit]   headers-overflow (reachable)   : 2
+[audit]   error (dns/tls/other)          : 0
+
+[audit] 6 non-2xx URL(s) needing attention:
+[audit]   - [headers-overflow] https://finance.yahoo.com/news/intel-foundry-talks-nvidia-apple-171229595.html (story: Intel 18A enters HVM as Apple and Nvidia explore 2028 non-core prod...)
+[audit]       action: origin reachable but response headers exceed Node undici's 16KB limit — verify manually
+[audit]   - [headers-overflow] https://finance.yahoo.com/markets/stocks/articles/openai-guarantees-17-5-minimum-165757294.html (story: OpenAI offers PE firms 17.5% guaranteed return to unlock enterprise...)
+[audit]       action: origin reachable but response headers exceed Node undici's 16KB limit — verify manually
+[audit]   - [403] https://www.datacenterdynamics.com/en/news/samsung-and-sk-hynix-post-record-profits-but-warn-memory-chip-shortages-will-likely-persist-into-2027/ (story: SK Hynix, Samsung post record profits, warn memory shortages extend...)
+[audit]       action: blocked — likely bot protection, verify manually in a browser
+[audit]   - [403] https://www.bloomberg.com/news/articles/2026-04-14/anthropic-attracts-investor-offers-at-a-800-billion-valuation (story: Anthropic declines $800B-valuation term sheets — for now)
+[audit]       action: blocked — likely bot protection, verify manually in a browser
+[audit]   - [404] https://www.cnbc.com/amp/2026/04/15/asml-q1-2026-earnings-report.html (story: ASML raises 2026 guide to €36–40B, says demand "outpacing supply")
+[audit]       action: broken — consider updating source_url
+[audit]   - [403] https://www.bloomberg.com/news/articles/2026-04-16/tsmc-s-profit-beats-estimates-after-war-failed-to-dent-ai-demand (story: TSMC Q1 profit +58%, raises 2026 revenue growth guide above 30%)
+[audit]       action: blocked — likely bot protection, verify manually in a browser

--- a/OneDrive/Desktop/signal-app/backend/src/scripts/auditStoryUrls.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/scripts/auditStoryUrls.ts
@@ -1,0 +1,326 @@
+/* eslint-disable no-console */
+/**
+ * Read-only liveness audit for every `source_url` in the `stories` table.
+ *
+ * Usage:
+ *   npm run audit:story-urls --workspace=backend
+ *
+ * Behavior:
+ *   - SELECT id, headline, source_url FROM stories
+ *   - Per URL: HEAD first with a browser-like User-Agent, follow up to 5
+ *     redirects, 10s timeout per hop. On 405 Method Not Allowed, retry
+ *     once with GET (some publishers block HEAD).
+ *   - Runs sequentially to avoid publisher rate-limiting.
+ *   - Classifies results into buckets:
+ *       2xx ok
+ *       3xx redirect (should be rare — we follow)
+ *       403 blocked (bot protection — needs manual verification)
+ *       4xx broken
+ *       5xx server-error
+ *       timeout
+ *       error (DNS, TLS, aborted, unknown)
+ *   - Writes identical output to stdout and
+ *     `backend/seed-data/url-audit-<UTC-YYYY-MM-DD>.txt`.
+ *   - Exit code 0 iff every URL landed in 2xx; 1 otherwise.
+ *
+ * No DB writes. No URL mutation. Report-only.
+ */
+
+import "dotenv/config";
+import fs from "node:fs";
+import path from "node:path";
+import { db, pool } from "../db";
+import * as schema from "../db/schema";
+
+const UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const TIMEOUT_MS = 10_000;
+const MAX_REDIRECTS = 5;
+
+type Bucket = "2xx" | "3xx" | "403" | "4xx" | "5xx" | "timeout" | "headers-overflow" | "error";
+
+interface AuditResult {
+  storyId: string;
+  headline: string;
+  originalUrl: string;
+  finalUrl: string;
+  status: number | null;
+  bucket: Bucket;
+  method: "HEAD" | "GET";
+  hops: number;
+  errorClass?: string;
+}
+
+function bucketFor(status: number | null, errorClass?: string): Bucket {
+  if (errorClass === "timeout") return "timeout";
+  if (errorClass === "headers-overflow") return "headers-overflow";
+  if (errorClass) return "error";
+  if (status === null) return "error";
+  if (status === 403) return "403";
+  if (status >= 200 && status < 300) return "2xx";
+  if (status >= 300 && status < 400) return "3xx";
+  if (status >= 400 && status < 500) return "4xx";
+  if (status >= 500 && status < 600) return "5xx";
+  return "error";
+}
+
+// Node's built-in fetch (undici) rejects responses whose headers exceed
+// the default 16KB limit. Some publishers (Yahoo Finance is the usual
+// suspect) set so many cookies/telemetry headers that they trip this —
+// origin is fine, response is just unparseable by our client. Classify
+// distinctly so the report doesn't conflate with DNS/TLS/DNS failures.
+function classifyError(err: unknown): string {
+  const e = err as { name?: string; cause?: { code?: string; name?: string } };
+  if (e.name === "AbortError") return "timeout";
+  if (e.cause?.code === "UND_ERR_HEADERS_OVERFLOW") return "headers-overflow";
+  return e.name ?? "Error";
+}
+
+async function fetchOnce(
+  url: string,
+  method: "HEAD" | "GET",
+): Promise<{ status: number; location: string | null }> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method,
+      redirect: "manual",
+      headers: {
+        "User-Agent": UA,
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+      signal: ctrl.signal,
+    });
+    // Drain body for GET so the connection can close; HEAD has no body.
+    if (method === "GET") {
+      try {
+        await res.arrayBuffer();
+      } catch {
+        /* ignore */
+      }
+    }
+    return { status: res.status, location: res.headers.get("location") };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function resolveLocation(base: string, location: string): string {
+  try {
+    return new URL(location, base).toString();
+  } catch {
+    return location;
+  }
+}
+
+async function auditUrl(
+  storyId: string,
+  headline: string,
+  originalUrl: string,
+): Promise<AuditResult> {
+  let current = originalUrl;
+  let method: "HEAD" | "GET" = "HEAD";
+  let hops = 0;
+
+  for (; hops <= MAX_REDIRECTS; hops += 1) {
+    let status: number;
+    let location: string | null;
+    try {
+      ({ status, location } = await fetchOnce(current, method));
+    } catch (err) {
+      const errorClass = classifyError(err);
+      return {
+        storyId,
+        headline,
+        originalUrl,
+        finalUrl: current,
+        status: null,
+        bucket: bucketFor(null, errorClass),
+        method,
+        hops,
+        errorClass,
+      };
+    }
+
+    if (status === 405 && method === "HEAD") {
+      method = "GET";
+      continue;
+    }
+
+    if (status >= 300 && status < 400 && location) {
+      if (hops >= MAX_REDIRECTS) {
+        return {
+          storyId,
+          headline,
+          originalUrl,
+          finalUrl: current,
+          status,
+          bucket: "3xx",
+          method,
+          hops,
+          errorClass: "too-many-redirects",
+        };
+      }
+      current = resolveLocation(current, location);
+      method = "HEAD";
+      continue;
+    }
+
+    return {
+      storyId,
+      headline,
+      originalUrl,
+      finalUrl: current,
+      status,
+      bucket: bucketFor(status),
+      method,
+      hops,
+    };
+  }
+
+  return {
+    storyId,
+    headline,
+    originalUrl,
+    finalUrl: current,
+    status: null,
+    bucket: "error",
+    method,
+    hops,
+    errorClass: "redirect-loop",
+  };
+}
+
+function formatLine(r: AuditResult): string {
+  const statusStr = r.status === null ? r.errorClass ?? "error" : String(r.status);
+  const snippet = r.headline.length > 70 ? r.headline.slice(0, 67) + "..." : r.headline;
+  const arrow = r.finalUrl !== r.originalUrl ? ` -> ${r.finalUrl}` : "";
+  const hopStr = r.hops > 0 ? ` [${r.hops} hop${r.hops === 1 ? "" : "s"}]` : "";
+  const methodNote = r.method === "GET" ? " [GET fallback]" : "";
+  return `[${statusStr}]${methodNote}${hopStr} ${r.originalUrl}${arrow} (story: ${snippet})`;
+}
+
+function utcDateStamp(d: Date = new Date()): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+export async function run(): Promise<number> {
+  const lines: string[] = [];
+  const emit = (s: string): void => {
+    console.log(s);
+    lines.push(s);
+  };
+  const log = (s: string): void => emit(`[audit] ${s}`);
+
+  log(`starting (User-Agent: ${UA.slice(0, 60)}...)`);
+  log(`timeout ${TIMEOUT_MS}ms, max ${MAX_REDIRECTS} redirects`);
+
+  const rows = await db
+    .select({
+      id: schema.stories.id,
+      headline: schema.stories.headline,
+      sourceUrl: schema.stories.sourceUrl,
+    })
+    .from(schema.stories)
+    .orderBy(schema.stories.publishedAt);
+
+  log(`${rows.length} stories to audit`);
+  emit("");
+
+  const results: AuditResult[] = [];
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i];
+    if (!row) continue;
+    process.stdout.write(`[audit] ${i + 1}/${rows.length} ${row.sourceUrl}\r`);
+    const r = await auditUrl(row.id, row.headline, row.sourceUrl);
+    results.push(r);
+    // Clear the progress line, then emit result
+    process.stdout.write("\r".padEnd(120, " ") + "\r");
+    emit(formatLine(r));
+  }
+
+  emit("");
+  log("summary:");
+  const buckets: Record<Bucket, number> = {
+    "2xx": 0,
+    "3xx": 0,
+    "403": 0,
+    "4xx": 0,
+    "5xx": 0,
+    timeout: 0,
+    "headers-overflow": 0,
+    error: 0,
+  };
+  for (const r of results) buckets[r.bucket] += 1;
+  log(`  2xx ok                         : ${buckets["2xx"]}`);
+  log(`  3xx (residual redirect)        : ${buckets["3xx"]}`);
+  log(`  403 blocked (bot guard)        : ${buckets["403"]}`);
+  log(`  4xx broken                     : ${buckets["4xx"]}`);
+  log(`  5xx server error               : ${buckets["5xx"]}`);
+  log(`  timeout                        : ${buckets.timeout}`);
+  log(`  headers-overflow (reachable)   : ${buckets["headers-overflow"]}`);
+  log(`  error (dns/tls/other)          : ${buckets.error}`);
+
+  const nonOk = results.filter((r) => r.bucket !== "2xx");
+  if (nonOk.length > 0) {
+    emit("");
+    log(`${nonOk.length} non-2xx URL(s) needing attention:`);
+    for (const r of nonOk) {
+      const note =
+        r.bucket === "403"
+          ? "blocked — likely bot protection, verify manually in a browser"
+          : r.bucket === "timeout"
+            ? "timed out — check connectivity and retry"
+            : r.bucket === "3xx"
+              ? "unresolved redirect chain — verify final destination manually"
+              : r.bucket === "4xx"
+                ? "broken — consider updating source_url"
+                : r.bucket === "5xx"
+                  ? "origin server error — retry later or replace"
+                  : r.bucket === "headers-overflow"
+                    ? "origin reachable but response headers exceed Node undici's 16KB limit — verify manually"
+                    : "transport error — see error class";
+      log(`  - ${formatLine(r)}`);
+      log(`      action: ${note}`);
+    }
+  } else {
+    emit("");
+    log("all URLs returned 2xx");
+  }
+
+  // Persist to file
+  const outDir = path.resolve(process.cwd(), "seed-data");
+  const outFile = path.join(outDir, `url-audit-${utcDateStamp()}.txt`);
+  fs.writeFileSync(outFile, lines.join("\n") + "\n", "utf-8");
+  log(`wrote ${outFile}`);
+
+  return nonOk.length === 0 ? 0 : 1;
+}
+
+async function main(): Promise<void> {
+  let exitCode = 0;
+  try {
+    exitCode = await run();
+  } catch (err) {
+    exitCode = 1;
+    console.error("[audit] error:", err instanceof Error ? err.message : err);
+  } finally {
+    try {
+      await pool.end();
+    } catch {
+      /* ignore */
+    }
+  }
+  process.exit(exitCode);
+}
+
+if (require.main === module) {
+  void main();
+}

--- a/OneDrive/Desktop/signal-app/backend/src/scripts/wipeDevStories.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/scripts/wipeDevStories.ts
@@ -1,0 +1,164 @@
+/* eslint-disable no-console */
+/**
+ * Wipe dev `stories` and `writers` tables so the reseed from current
+ * `seed-data/stories.json` runs against an empty slate.
+ *
+ * Usage:
+ *   npm run wipe:dev-stories --workspace=backend -- --dry-run
+ *   npm run wipe:dev-stories --workspace=backend
+ *
+ * Safety:
+ *   - Refuses to run unless DATABASE_URL hostname contains "neon.tech"
+ *     (our dev DB). Prod on Railway is explicitly excluded. The only
+ *     bypass is `--force-prod` plus the typed confirmation string
+ *     "I UNDERSTAND THIS IS PROD" at the prompt; intended as a
+ *     documented guardrail, not a day-to-day option.
+ *   - Delete order (single transaction):
+ *       1. stories — cascades to commentary_cache, comments, user_saves,
+ *          learning_path_stories via existing FKs.
+ *       2. writers — safe because stories.author_id is ON DELETE SET NULL
+ *          and all rows were just removed.
+ *   - `--dry-run` reports current row counts and exits without writing.
+ *
+ * Exit codes: 0 on success or dry-run, 1 on validation/DB failure.
+ */
+
+import "dotenv/config";
+import readline from "node:readline";
+import { sql } from "drizzle-orm";
+import { db, pool } from "../db";
+import * as schema from "../db/schema";
+
+interface CliArgs {
+  dryRun: boolean;
+  forceProd: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { dryRun: false, forceProd: false };
+  for (const arg of argv) {
+    if (arg === "--dry-run") out.dryRun = true;
+    else if (arg === "--force-prod") out.forceProd = true;
+  }
+  return out;
+}
+
+function log(msg: string): void {
+  console.log(`[wipe] ${msg}`);
+}
+
+function describeDbFromUrl(url: string | undefined): { host: string; db: string } {
+  if (!url) return { host: "<unset>", db: "<unset>" };
+  try {
+    const u = new URL(url);
+    return { host: u.hostname, db: u.pathname.replace(/^\//, "") || "<no-db>" };
+  } catch {
+    return { host: "<unparsable>", db: "<unparsable>" };
+  }
+}
+
+async function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+async function getCounts(): Promise<{ stories: number; writers: number }> {
+  const s = await db.execute<{ count: string }>(sql`SELECT COUNT(*)::text AS count FROM stories`);
+  const w = await db.execute<{ count: string }>(sql`SELECT COUNT(*)::text AS count FROM writers`);
+  return {
+    stories: Number(s.rows[0]?.count ?? "0"),
+    writers: Number(w.rows[0]?.count ?? "0"),
+  };
+}
+
+export async function run(args: CliArgs): Promise<void> {
+  const dbInfo = describeDbFromUrl(process.env.DATABASE_URL);
+  log(`target: ${dbInfo.host}/${dbInfo.db}`);
+
+  const isNeon = dbInfo.host.includes("neon.tech");
+  if (!isNeon) {
+    if (!args.forceProd) {
+      log(`refusing to run: hostname "${dbInfo.host}" does not contain "neon.tech"`);
+      log(`this script is dev-only. bypass requires --force-prod and a typed confirmation.`);
+      throw new Error("non-dev database target");
+    }
+    const typed = await prompt(
+      `DANGER: you passed --force-prod against ${dbInfo.host}/${dbInfo.db}.\n` +
+        `Type exactly: I UNDERSTAND THIS IS PROD\n> `,
+    );
+    if (typed !== "I UNDERSTAND THIS IS PROD") {
+      log("confirmation mismatch — aborting");
+      throw new Error("prod confirmation failed");
+    }
+  }
+
+  log("counting existing rows...");
+  const before = await getCounts();
+  log(`  stories: ${before.stories}`);
+  log(`  writers: ${before.writers}`);
+
+  if (args.dryRun) {
+    log(`dry-run — would DELETE ${before.stories} stories (cascading) then ${before.writers} writers`);
+    log("done (dry-run)");
+    return;
+  }
+
+  if (before.stories === 0 && before.writers === 0) {
+    log("both tables already empty — nothing to do");
+    return;
+  }
+
+  const confirmMsg =
+    `Will DELETE ALL rows from stories (${before.stories}) and writers (${before.writers}) ` +
+    `on ${dbInfo.host}/${dbInfo.db}. ` +
+    `Cascades will also clear commentary_cache, comments, user_saves, learning_path_stories rows ` +
+    `referencing these stories. Proceed? (y/n) `;
+  const answer = await prompt(confirmMsg);
+  if (answer.trim().toLowerCase() !== "y") {
+    log("aborted by user");
+    return;
+  }
+
+  log("deleting in transaction...");
+  let deletedStories = 0;
+  let deletedWriters = 0;
+  await db.transaction(async (tx) => {
+    const s = await tx.delete(schema.stories).returning({ id: schema.stories.id });
+    deletedStories = s.length;
+    const w = await tx.delete(schema.writers).returning({ id: schema.writers.id });
+    deletedWriters = w.length;
+  });
+
+  log(`deleted ${deletedStories} stories and ${deletedWriters} writers`);
+  const after = await getCounts();
+  log(`  stories: ${after.stories}`);
+  log(`  writers: ${after.writers}`);
+  log("done");
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  let exitCode = 0;
+  try {
+    await run(args);
+  } catch (err) {
+    exitCode = 1;
+    console.error("[wipe] error:", err instanceof Error ? err.message : err);
+  } finally {
+    try {
+      await pool.end();
+    } catch {
+      /* ignore */
+    }
+  }
+  process.exit(exitCode);
+}
+
+if (require.main === module) {
+  void main();
+}


### PR DESCRIPTION
Closes #13.

Reseed dev (50 stale → 20 clean stories), URL audit script, fix dead CNBC ASML URL (drop /amp/).

Dev verified: feed loads, ASML link resolves to canonical CNBC article. Prod SQL UPDATE to follow post-merge.