### PR TITLE
Cluster 1.2: Clean up story detail page hierarchy (closes #25)

### DIFF
--- a/OneDrive/Desktop/signal-app/frontend/src/components/stories/StoryDetail.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/components/stories/StoryDetail.tsx
@@ -48,17 +48,7 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
         <h1 className="text-3xl font-bold leading-tight text-slate-900">
           {story.headline}
         </h1>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4 text-sm text-slate-600">
-            {story.author && (
-              <div>
-                <span className="font-medium text-slate-900">{story.author.name}</span>
-                {story.author.bio && (
-                  <span className="ml-2 text-slate-500">{story.author.bio}</span>
-                )}
-              </div>
-            )}
-          </div>
+        <div className="flex items-center justify-end">
           <StorySaveButton story={story} />
         </div>
       </header>
@@ -75,18 +65,10 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
       <section className="space-y-4">
         <div>
           <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-700">
-            Context
+            From the source
           </h2>
           <p className="whitespace-pre-line text-base leading-relaxed text-slate-800">
             {story.context}
-          </p>
-        </div>
-        <div>
-          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-700">
-            Why it matters
-          </h2>
-          <p className="whitespace-pre-line text-base leading-relaxed text-slate-800">
-            {story.why_it_matters}
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Cleans up the story detail page information hierarchy per Issue #25. Removes the dual-WHY-IT-MATTERS problem and tightens visual weight while preserving the per-reader Commentary surface from Phase 12d.

## Changes

All in `frontend/src/components/stories/StoryDetail.tsx` (1 file, +2/−20):

- **Cut editorial "Why it matters" section.** Eliminates the role-neutral framing that was visually competing with the per-reader "WHY IT MATTERS TO YOU" Commentary block at the top. Resolves the dual-WIM problem flagged in #25.
- **Cut "SIGNAL Editorial" byline boilerplate.** Generic per-story text that added zero signal between headline and first content block.
- **Relabeled "Context" → "From the source".** Clarifies the section's role now that the editorial framing is gone. The wrapping `justify-between` flex row updated to `justify-end` to keep the Save button right-aligned as a single child after the byline (its sibling) was removed.

## Out of scope

- `story.why_it_matters` and `story.author` fields stay on the API payload — still consumed by `TeamStoryCard`, the digest email service, V2 stories controller, and the fallback-commentary templates. UI cuts only; no schema or API contract change.
- Reactions and share buttons (filed as a separate issue per the LinkedIn-style engagement footer discussion).
- Related stories treatment (kept as full cards at bottom per scoping decision).

## Verification

Run from `frontend/` after `npm ci` at repo root:

- `npm run type-check` — 0 errors
- `npm run lint` — clean
- `npm test` — 55 passed across 14 files

## Risk

Pure template diff in one file. No data layer, no API, no migrations, no test changes. Visual smoke verified locally before PR open.

Closes #25