### PR TITLE
Cluster 1.3: Smoke-pass cleanup (#29 + #27 + #30)

### DIFF
--- a/OneDrive/Desktop/signal-app/backend/src/services/commentaryFallback.ts
+++ b/OneDrive/Desktop/signal-app/backend/src/services/commentaryFallback.ts
@@ -66,12 +66,17 @@ const BANNED_PATTERNS: readonly RegExp[] = BANNED_PHRASES.map(
 // 12d — banned openers (positional, per-field). The prompt forbids
 // thesis/support from opening with these patronizing audience-framing
 // templates; this is the post-generation trip-wire. Anchored at start
-// (modulo leading whitespace), case-insensitive, and require a word
-// after so we don't flag e.g. "As you've already seen" via overly
-// loose matching — the `\w+` is the audience verb that makes the
-// opener feel addressed-at rather than analytical.
+// (modulo leading whitespace), case-insensitive. The `As you\b` pattern
+// catches both bare-verb ("As you build…") and apostrophe-contracted
+// ("As you're thinking…") forms via the word boundary after `you`.
+// `For (a|an|the) \w+` catches role-framing openers ("For an ML
+// engineer…", "For a researcher…") and is intentionally permissive —
+// it false-positives on temporal phrasings like "For a brief moment…",
+// which is acceptable because a hit demotes to Tier 3 fallback rather
+// than erroring.
 export const BANNED_OPENERS: readonly RegExp[] = [
-  /^\s*As you\s+\w+/i,
+  /^\s*As you\b/i,
+  /^\s*For (a|an|the)\s+\w+/i,
   /^\s*For someone\s+\w+/i,
 ] as const;
 

--- a/OneDrive/Desktop/signal-app/backend/tests/commentaryFallback.test.ts
+++ b/OneDrive/Desktop/signal-app/backend/tests/commentaryFallback.test.ts
@@ -1,6 +1,7 @@
 import {
   BANNED_PHRASES,
   buildFallbackCommentary,
+  checkBannedOpeners,
   checkBannedPhrases,
 } from "../src/services/commentaryFallback";
 
@@ -49,6 +50,86 @@ describe("checkBannedPhrases", () => {
       expect(r.clean).toBe(false);
       expect(r.offenders).toContain(phrase);
     }
+  });
+});
+
+describe("checkBannedOpeners", () => {
+  const cleanSupport = "Inference cost dropped roughly 40% versus the prior tier.";
+
+  it("flags 'As you build…' (bare-verb form, regression)", () => {
+    const r = checkBannedOpeners({
+      thesis: "As you build agents on top of this stack, latency budgets shift.",
+      support: cleanSupport,
+    });
+    expect(r.clean).toBe(false);
+    expect(r.offenders).toEqual([
+      { field: "thesis", pattern: "^\\s*As you\\b" },
+    ]);
+  });
+
+  it("flags 'As you're thinking…' (apostrophe contraction)", () => {
+    // Pre-Cluster-1.3 the regex was /^\s*As you\s+\w+/i, which required
+    // whitespace + a word after "you" and so missed contractions like
+    // "As you're". The \b form catches the boundary between `you` and
+    // the apostrophe.
+    const r = checkBannedOpeners({
+      thesis: "As you're thinking about MCP servers, the cost calculus changes.",
+      support: cleanSupport,
+    });
+    expect(r.clean).toBe(false);
+    expect(r.offenders).toEqual([
+      { field: "thesis", pattern: "^\\s*As you\\b" },
+    ]);
+  });
+
+  it("flags 'For an X…' role-framing openers", () => {
+    const r = checkBannedOpeners({
+      thesis: "For an ML engineer tracking foundation-model latency, this lands.",
+      support: cleanSupport,
+    });
+    expect(r.clean).toBe(false);
+    expect(r.offenders).toEqual([
+      { field: "thesis", pattern: "^\\s*For (a|an|the)\\s+\\w+" },
+    ]);
+  });
+
+  it("flags 'For a brief moment…' (known false-positive — soft-fail tradeoff)", () => {
+    // The /^\s*For (a|an|the)\s+\w+/ pattern intentionally accepts this
+    // false-positive: it would take a much heavier classifier to
+    // distinguish role-framing ("For an engineer…") from temporal
+    // openings ("For a brief moment…"). Because a BANNED_OPENERS hit
+    // demotes the response to the Tier-3 fallback (per the file header
+    // in commentaryFallback.ts) rather than erroring, the cost of a
+    // false-positive is a templated commentary instead of the Haiku
+    // output — acceptable trade for closing the role-framing loophole.
+    const r = checkBannedOpeners({
+      thesis: "For a brief moment, the market priced this in as a regime change.",
+      support: cleanSupport,
+    });
+    expect(r.clean).toBe(false);
+    expect(r.offenders).toEqual([
+      { field: "thesis", pattern: "^\\s*For (a|an|the)\\s+\\w+" },
+    ]);
+  });
+
+  it("returns clean=true for analytical openers", () => {
+    const r = checkBannedOpeners({
+      thesis: "Inference cost is the headline; ranking implications follow.",
+      support: cleanSupport,
+    });
+    expect(r.clean).toBe(true);
+    expect(r.offenders).toEqual([]);
+  });
+
+  it("checks support independently of thesis", () => {
+    const r = checkBannedOpeners({
+      thesis: "Inference cost dropped 40% across the board.",
+      support: "As you ship to prod, watch the new ceiling on context tokens.",
+    });
+    expect(r.clean).toBe(false);
+    expect(r.offenders).toEqual([
+      { field: "support", pattern: "^\\s*As you\\b" },
+    ]);
   });
 });
 

--- a/OneDrive/Desktop/signal-app/frontend/src/app/(app)/feed/page.test.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/(app)/feed/page.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FeedResponse } from "@/types/story";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/feed",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getFeedRequest: vi.fn(),
+  listTeamsRequest: vi.fn(),
+  extractApiError: (_err: unknown, fallback: string) => fallback,
+}));
+
+import * as api from "@/lib/api";
+import FeedPage from "./page";
+
+const emptyFeed: FeedResponse = {
+  stories: [],
+  total: 0,
+  limit: 10,
+  offset: 0,
+  has_more: false,
+};
+
+function renderPage(): { client: QueryClient } {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  render(<FeedPage />, { wrapper: Wrapper });
+  return { client };
+}
+
+describe("FeedPage refresh button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getFeedRequest).mockResolvedValue(emptyFeed);
+    vi.mocked(api.listTeamsRequest).mockResolvedValue([]);
+  });
+
+  it("renders an accessible refresh affordance", async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /refresh feed/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("invalidates feed and commentary caches on click", async () => {
+    const { client } = renderPage();
+    // Wait for the initial feed fetch to settle so the refetch we
+    // trigger below is the one being asserted on.
+    await waitFor(() => expect(api.getFeedRequest).toHaveBeenCalledTimes(1));
+
+    // Seed inactive cache entries the click should invalidate via the
+    // prefix match. We assert isInvalidated on these because they have
+    // no observers — invalidate marks them stale but doesn't refetch,
+    // so the flag stays true. The active ["feed", []] query is covered
+    // by the getFeedRequest refetch assertion below: invalidate+refetch
+    // would un-flip isInvalidated on settle, so observing the network
+    // call is the cleaner signal.
+    client.setQueryData(["feed", ["ai"]], emptyFeed);
+    client.setQueryData(["commentary", "story-1", null], "x");
+    client.setQueryData(["commentary", "story-2", "technical"], "y");
+
+    const button = screen.getByRole("button", { name: /refresh feed/i });
+    await userEvent.click(button);
+
+    // The active feed query refetches.
+    await waitFor(() =>
+      expect(api.getFeedRequest).toHaveBeenCalledTimes(2),
+    );
+
+    // Inactive prefix-matched entries are marked stale.
+    expect(client.getQueryState(["feed", ["ai"]])?.isInvalidated).toBe(true);
+    expect(
+      client.getQueryState(["commentary", "story-1", null])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState(["commentary", "story-2", "technical"])
+        ?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/OneDrive/Desktop/signal-app/frontend/src/app/(app)/feed/page.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/(app)/feed/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { RefreshCw } from "lucide-react";
 import { useStories } from "@/hooks/useStories";
 import { useTeams } from "@/hooks/useTeams";
 import { useTeamsStore } from "@/store/teamsStore";
@@ -37,6 +39,16 @@ export default function FeedPage(): JSX.Element {
     fetchNextPage,
   } = useStories({ sectors });
 
+  const queryClient = useQueryClient();
+  // Prefix-match: any in-flight ["feed", …] query — including the
+  // initial load, sector-switch refetches, and the manual invalidation
+  // below — keeps the icon spinning.
+  const isFetchingFeed = useIsFetching({ queryKey: ["feed"] }) > 0;
+  const handleRefresh = (): void => {
+    void queryClient.invalidateQueries({ queryKey: ["feed"] });
+    void queryClient.invalidateQueries({ queryKey: ["commentary"] });
+  };
+
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -60,7 +72,21 @@ export default function FeedPage(): JSX.Element {
   return (
     <div className="space-y-6">
       <header className="space-y-3">
-        <h1 className="text-2xl font-bold tracking-tight text-slate-900">Your feed</h1>
+        <div className="flex items-center justify-between gap-3">
+          <h1 className="text-2xl font-bold tracking-tight text-slate-900">Your feed</h1>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isFetchingFeed}
+            aria-label="Refresh feed"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border bg-white text-slate-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${isFetchingFeed ? "animate-spin" : ""}`}
+              aria-hidden
+            />
+          </button>
+        </div>
         <SectorFilter selected={sectors} onChange={setSectors} />
         {!isLoading && (
           <p className="text-xs text-slate-500">

--- a/OneDrive/Desktop/signal-app/frontend/src/app/(app)/settings/page.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/app/(app)/settings/page.tsx
@@ -266,57 +266,109 @@ export default function SettingsPage(): JSX.Element {
 
       <section className="space-y-4 rounded-lg border bg-card p-6 shadow-sm">
         <div>
-          <h2 className="text-lg font-semibold">Profile</h2>
-          <p className="text-xs text-muted-foreground">Signed in as {user?.email}</p>
+          <h2 className="text-lg font-semibold">Commentary depth & topics</h2>
+          <p className="text-xs text-muted-foreground">
+            How deep the commentary goes, and which topics within each sector.
+          </p>
         </div>
-        <form onSubmit={onSubmitProfile} className="space-y-4" noValidate>
-          <div className="space-y-1">
-            <label htmlFor="name" className="text-sm font-medium">
-              Name
-            </label>
-            <input
-              id="name"
-              type="text"
-              autoComplete="name"
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-              {...register("name")}
-            />
-            {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
-            )}
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Commentary depth</p>
+          <p className="text-xs text-muted-foreground">
+            How deep the commentary goes on each story. Change any time.
+          </p>
+          <div
+            role="radiogroup"
+            aria-label="Commentary depth"
+            className="grid grid-cols-1 gap-2 sm:grid-cols-3"
+          >
+            {DEPTH_PREFERENCES.map((option) => {
+              const checked = depthPreference === option.value;
+              return (
+                <label
+                  key={option.value}
+                  className={`flex cursor-pointer flex-col gap-1 rounded-md border p-3 text-sm ${
+                    checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <span className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="depth_preference"
+                      value={option.value}
+                      checked={checked}
+                      onChange={() =>
+                        setDepthPreference(option.value as DepthPreference)
+                      }
+                      className="h-4 w-4"
+                    />
+                    <span className="font-medium">{option.label}</span>
+                  </span>
+                  {option.description && (
+                    <span className="text-xs text-muted-foreground">
+                      {option.description}
+                    </span>
+                  )}
+                </label>
+              );
+            })}
           </div>
-          <div className="space-y-1">
-            <label htmlFor="profile_picture_url" className="text-sm font-medium">
-              Profile picture URL
-            </label>
-            <input
-              id="profile_picture_url"
-              type="url"
-              placeholder="https://…"
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-              {...register("profile_picture_url")}
-            />
-            {errors.profile_picture_url && (
-              <p className="text-xs text-destructive">{errors.profile_picture_url.message}</p>
-            )}
+        </div>
+
+        {sectors.length > 0 && (
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm font-medium">Topics</p>
+              <p className="text-xs text-muted-foreground">
+                Narrow the commentary within each sector. Leaving all topics
+                unchecked for a sector means you want the full sector feed.
+              </p>
+            </div>
+            {sectors.map((sector) => {
+              const options = TOPICS_BY_SECTOR[sector] ?? [];
+              if (options.length === 0) return null;
+              const sectorLabel =
+                SECTORS.find((s) => s.value === sector)?.label ?? sector;
+              return (
+                <div key={sector} className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {sectorLabel}
+                  </p>
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {options.map((option) => {
+                      const checked = topics.some(
+                        (t) => t.sector === sector && t.topic === option.value,
+                      );
+                      return (
+                        <label
+                          key={option.value}
+                          className={`flex cursor-pointer items-center gap-2 rounded-md border p-3 text-sm ${
+                            checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleTopic(sector, option.value)}
+                            className="h-4 w-4"
+                          />
+                          {option.label}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
           </div>
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
-            >
-              {isSubmitting ? "Saving…" : "Save profile"}
-            </button>
-          </div>
-        </form>
+        )}
       </section>
 
       <section className="space-y-4 rounded-lg border bg-card p-6 shadow-sm">
         <div>
-          <h2 className="text-lg font-semibold">Interests</h2>
+          <h2 className="text-lg font-semibold">Sectors & goals</h2>
           <p className="text-xs text-muted-foreground">
-            What we use to personalize your feed and insights.
+            What you&apos;re tracking and what you want to get out of the feed.
           </p>
         </div>
 
@@ -343,6 +395,44 @@ export default function SettingsPage(): JSX.Element {
               );
             })}
           </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Goals</p>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {GOALS.map((goal) => {
+              const checked = goals.includes(goal.value);
+              return (
+                <label
+                  key={goal.value}
+                  className={`flex cursor-pointer items-center gap-2 rounded-md border p-3 text-sm ${
+                    checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleGoal(goal.value)}
+                    className="h-4 w-4"
+                  />
+                  {goal.label}
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* The "Save interests" button at the bottom of this section is
+          the single commit point for everything in the three sections
+          above — depth, topics, sectors, goals, role, domain, seniority
+          all flow through one saveInterests mutation. */}
+      <section className="space-y-4 rounded-lg border bg-card p-6 shadow-sm">
+        <div>
+          <h2 className="text-lg font-semibold">Profile basics</h2>
+          <p className="text-xs text-muted-foreground">
+            Helps us calibrate commentary to your role and seniority.
+          </p>
         </div>
 
         <div className="space-y-2">
@@ -406,122 +496,6 @@ export default function SettingsPage(): JSX.Element {
           </select>
         </div>
 
-        {sectors.length > 0 && (
-          <div className="space-y-3">
-            <div>
-              <p className="text-sm font-medium">Topics</p>
-              <p className="text-xs text-muted-foreground">
-                Narrow the commentary within each sector. Leaving all topics
-                unchecked for a sector means you want the full sector feed.
-              </p>
-            </div>
-            {sectors.map((sector) => {
-              const options = TOPICS_BY_SECTOR[sector] ?? [];
-              if (options.length === 0) return null;
-              const sectorLabel =
-                SECTORS.find((s) => s.value === sector)?.label ?? sector;
-              return (
-                <div key={sector} className="space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    {sectorLabel}
-                  </p>
-                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                    {options.map((option) => {
-                      const checked = topics.some(
-                        (t) => t.sector === sector && t.topic === option.value,
-                      );
-                      return (
-                        <label
-                          key={option.value}
-                          className={`flex cursor-pointer items-center gap-2 rounded-md border p-3 text-sm ${
-                            checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleTopic(sector, option.value)}
-                            className="h-4 w-4"
-                          />
-                          {option.label}
-                        </label>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-
-        <div className="space-y-2">
-          <p className="text-sm font-medium">Commentary depth</p>
-          <p className="text-xs text-muted-foreground">
-            How deep the commentary goes on each story. Change any time.
-          </p>
-          <div
-            role="radiogroup"
-            aria-label="Commentary depth"
-            className="grid grid-cols-1 gap-2 sm:grid-cols-3"
-          >
-            {DEPTH_PREFERENCES.map((option) => {
-              const checked = depthPreference === option.value;
-              return (
-                <label
-                  key={option.value}
-                  className={`flex cursor-pointer flex-col gap-1 rounded-md border p-3 text-sm ${
-                    checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-                  }`}
-                >
-                  <span className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      name="depth_preference"
-                      value={option.value}
-                      checked={checked}
-                      onChange={() =>
-                        setDepthPreference(option.value as DepthPreference)
-                      }
-                      className="h-4 w-4"
-                    />
-                    <span className="font-medium">{option.label}</span>
-                  </span>
-                  {option.description && (
-                    <span className="text-xs text-muted-foreground">
-                      {option.description}
-                    </span>
-                  )}
-                </label>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <p className="text-sm font-medium">Goals</p>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {GOALS.map((goal) => {
-              const checked = goals.includes(goal.value);
-              return (
-                <label
-                  key={goal.value}
-                  className={`flex cursor-pointer items-center gap-2 rounded-md border p-3 text-sm ${
-                    checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => toggleGoal(goal.value)}
-                    className="h-4 w-4"
-                  />
-                  {goal.label}
-                </label>
-              );
-            })}
-          </div>
-        </div>
-
         <div className="flex justify-end">
           <button
             type="button"
@@ -532,6 +506,54 @@ export default function SettingsPage(): JSX.Element {
             {updateProfile.isPending ? "Saving…" : "Save interests"}
           </button>
         </div>
+      </section>
+
+      <section className="space-y-4 rounded-lg border bg-card p-6 shadow-sm">
+        <div>
+          <h2 className="text-lg font-semibold">Account</h2>
+          <p className="text-xs text-muted-foreground">Signed in as {user?.email}</p>
+        </div>
+        <form onSubmit={onSubmitProfile} className="space-y-4" noValidate>
+          <div className="space-y-1">
+            <label htmlFor="name" className="text-sm font-medium">
+              Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              autoComplete="name"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              {...register("name")}
+            />
+            {errors.name && (
+              <p className="text-xs text-destructive">{errors.name.message}</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="profile_picture_url" className="text-sm font-medium">
+              Profile picture URL
+            </label>
+            <input
+              id="profile_picture_url"
+              type="url"
+              placeholder="https://…"
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              {...register("profile_picture_url")}
+            />
+            {errors.profile_picture_url && (
+              <p className="text-xs text-destructive">{errors.profile_picture_url.message}</p>
+            )}
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            >
+              {isSubmitting ? "Saving…" : "Save profile"}
+            </button>
+          </div>
+        </form>
       </section>
 
       <section className="space-y-4 rounded-lg border bg-card p-6 shadow-sm">

--- a/OneDrive/Desktop/signal-app/frontend/src/hooks/useProfile.test.tsx
+++ b/OneDrive/Desktop/signal-app/frontend/src/hooks/useProfile.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateProfileInput } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  updateMyProfileRequest: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
+import { PROFILE_QUERY_KEY, useUpdateMyProfile } from "./useProfile";
+
+const samplePayload: UpdateProfileInput = {
+  sectors: ["ai"],
+  role: "engineer",
+  domain: "general_not_sure",
+  seniority: "mid",
+  topic_interests: [],
+  goals: ["stay_informed"],
+  depth_preference: "standard",
+  email_frequency: "weekly",
+  email_unsubscribed: false,
+};
+
+function makeWrapper(): {
+  client: QueryClient;
+  Wrapper: (props: { children: ReactNode }) => JSX.Element;
+} {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, Wrapper };
+}
+
+describe("useUpdateMyProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invalidates profile, feed, and commentary caches on success", async () => {
+    vi.mocked(api.updateMyProfileRequest).mockResolvedValue(
+      // The hook only forwards the response; shape doesn't matter for
+      // the cache-invalidation assertion this test cares about.
+      {} as never,
+    );
+    const { client, Wrapper } = makeWrapper();
+
+    // Seed every cache key the hook is supposed to invalidate so we can
+    // assert isInvalidated flips per key. Multiple ["feed", …] and
+    // ["commentary", …] entries verify the prefix-match behavior.
+    client.setQueryData(PROFILE_QUERY_KEY, { user: {}, profile: null });
+    client.setQueryData(["feed", []], { stories: [], total: 0 });
+    client.setQueryData(["feed", ["ai"]], { stories: [], total: 0 });
+    client.setQueryData(["commentary", "story-1", null], "x");
+    client.setQueryData(["commentary", "story-2", "technical"], "y");
+
+    const { result } = renderHook(() => useUpdateMyProfile(), {
+      wrapper: Wrapper,
+    });
+
+    await result.current.mutateAsync(samplePayload);
+
+    await waitFor(() => {
+      expect(client.getQueryState(PROFILE_QUERY_KEY)?.isInvalidated).toBe(true);
+      expect(client.getQueryState(["feed", []])?.isInvalidated).toBe(true);
+      expect(client.getQueryState(["feed", ["ai"]])?.isInvalidated).toBe(true);
+      expect(
+        client.getQueryState(["commentary", "story-1", null])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState(["commentary", "story-2", "technical"])
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+});

--- a/OneDrive/Desktop/signal-app/frontend/src/hooks/useProfile.ts
+++ b/OneDrive/Desktop/signal-app/frontend/src/hooks/useProfile.ts
@@ -72,6 +72,16 @@ export function useOnboardingEvents(): ReturnType<
  * (app) layout's useRequireOnboarded keeps reading the stale cache and
  * (if completed_at was previously null and has just been set elsewhere)
  * can bounce back to /onboarding/1 after a perfectly successful save.
+ *
+ * Also invalidates the feed and per-story commentary caches because a
+ * Settings save can change anything that affects ranking or commentary
+ * generation (sectors, role, domain, seniority, depth, topics, goals).
+ * Without this, navigating back to the feed after a Settings save shows
+ * the pre-save copy until the next foreground refetch — which is the
+ * "no in-app affordance for 'my settings changed'" UX gap reported by
+ * users. ["feed"] and ["commentary"] are TanStack prefix matches so
+ * every variant (per-sector, per-story, per-depth) is invalidated in
+ * one call.
  */
 export function useUpdateMyProfile(): ReturnType<
   typeof useMutation<UserProfile, Error, UpdateProfileInput>
@@ -80,7 +90,11 @@ export function useUpdateMyProfile(): ReturnType<
   return useMutation({
     mutationFn: updateMyProfileRequest,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: PROFILE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: ["feed"] }),
+        queryClient.invalidateQueries({ queryKey: ["commentary"] }),
+      ]);
     },
   });
 }


### PR DESCRIPTION
## Summary

Three smoke-pass issues addressed as one PR.

### #29 — banned-phrase regex extension (commit `0d9ea69`)

Extends `BANNED_OPENERS` in `backend/src/services/commentaryFallback.ts` to catch the two patterns the issue named that the 12d ship missed:

- `As you\b` (was `As you\s+\w+`) — the word-boundary form catches apostrophe contractions like `As you're thinking…` that the old `\s+` could not span.
- `For (a|an|the)\s+\w+` — new pattern, catches role-framing openers like `For an ML engineer tracking…`.
- `For someone\s+\w+` retained.

**Tradeoff to flag:** the new `For (a|an|the)\s+\w+` pattern false-positives on legitimate temporal openings (e.g. `For a brief moment, the market…`). This is intentional and matches the spec — a `BANNED_OPENERS` hit demotes to the Tier-3 fallback (per the file header), it doesn't error. Soft-fail. The cost of a false-positive is a templated commentary instead of the Haiku output; cheaper than letting the role-framing form leak. If real-world traffic shows the false-positive rate is high, easy to tighten with a negative-lookahead or a dedicated `For a brief|short|while` allowlist.

### #27 — Settings reorganization by change-frequency (commit `ec039c2`)

`frontend/src/app/(app)/settings/page.tsx` — split the previously-flat "Interests" section into three sections ordered by how often each field changes, plus a renamed "Account" at the bottom:

1. **Commentary depth & topics** (most-changed, top)
2. **Sectors & goals**
3. **Profile basics** — role / domain / seniority — **+ single "Save interests" button**
4. **Account** (renamed from "Profile" — name + picture, own save)
5. **Email preferences** (unchanged — own save)

Template restructure only. Single mutation behavior preserved — the `saveInterests` button at the bottom of section 3 commits sections 1–3 in one `updateProfile.mutateAsync` call (same payload as before).

**UX wart to flag:** changes to depth/topics/sectors/goals require scrolling past sections 1 and 2 to reach the "Save interests" button in section 3. Same friction existed in the prior flat layout (button was at the very end of the single Interests section), but it's worth a follow-up if user testing shows the new section boundaries make the scroll feel longer. Alternatives discussed but not implemented (per `Don't extend scope`): per-section save buttons (would need 3× mutations or duplicated handler), or a sticky save bar (explicit scope-creep ban in the spec).

### #30 — Feed refresh + auto-invalidate (commit `5201734`)

**C.1 — Refresh button.** `RefreshCw` icon button in the feed header. Click invalidates `["feed"]` and `["commentary"]` query-key prefixes via `useQueryClient`; spinning state driven by `useIsFetching({ queryKey: ["feed"] })`. Native `<button>` handles Enter + Space; `aria-label="Refresh feed"`.

**C.2 — Auto-invalidate on Settings save.** `useUpdateMyProfile.onSuccess` now invalidates `["feed"]` and `["commentary"]` alongside the existing `PROFILE_QUERY_KEY`. Three calls run in parallel via `Promise.all`. Closes the "I changed depth and the feed didn't update" UX gap.

## Out of scope (adjacent findings, not fixed)

- The existing `saveInterests` payload includes `email_frequency` and `email_unsubscribed`, while the separate "Save preferences" button hits a different endpoint (`updateEmailPreferencesRequest`). Pre-existing — both code paths converge on the same DB columns. Not touched here per `Don't extend scope`.
- The existing `useStories` query key is `["feed", sectors]` — invalidating with `["feed"]` (no sectors) prefix-matches all variants. Verified via test (seeded `["feed", ["ai"]]` invalidates correctly).

## Verification

- `npm run type-check --workspace=backend` — clean
- `npm run lint --workspace=backend` — clean
- `npm test --workspace=backend` — **467 / 467** across 39 suites
- `npm run type-check --workspace=frontend` — clean
- `npm run lint --workspace=frontend` — clean (one round-trip after I shipped an unescaped `'` in JSX copy; fixed in-flight)
- `npm test --workspace=frontend` — **58 / 58** across 16 suites (was 55; +3 new — 1 useProfile, 2 feed page)

## Test plan

- [ ] Pull branch, `npm ci` from repo root, run all six gates locally.
- [ ] Manual: open `/settings`, verify five-section order top-to-bottom (Commentary depth & topics → Sectors & goals → Profile basics + Save → Account → Email preferences).
- [ ] Manual: change depth in `/settings`, click "Save interests", navigate to `/feed`, confirm a fresh feed fetch fires (network tab) without browser reload.
- [ ] Manual: on `/feed`, click the new top-right Refresh button, confirm RefreshCw spins during fetch and resolves to fresh data.
- [ ] Manual: in dev, send a fixture commentary that opens with `As you're thinking about…` or `For an X tracking…` through the Haiku path, confirm the response demotes to Tier-3 fallback (anomaly log includes `reason: "haiku_banned_opener"`).

Closes #29, closes #27, closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)