### PR TITLE
fix(db): bootstrap drizzle audit schema for fresh DBs

### DIFF
--- a/OneDrive/Desktop/signal-app/CLAUDE.md
+++ b/OneDrive/Desktop/signal-app/CLAUDE.md
@@ -394,7 +394,9 @@ The runner's own recovery hints describe escape hatches (`UPDATE schema_migratio
 
 **Deleted: `meta/_journal.json`.** drizzle-kit's old per-folder bookkeeping. The new runner tracks state in `schema_migrations` and doesn't read or write the journal, so the file (and the now-empty `meta/` directory) was removed.
 
-**Retained read-only: `drizzle.__drizzle_migrations`.** drizzle-kit's pre-runner migration log. Migration `0012_deprecate_drizzle_migrations_table.sql` applies a deprecation comment to the table; the table itself is kept as historical audit of what drizzle-kit thought it had applied before the cutover. The comment is queryable — `SELECT obj_description('drizzle.__drizzle_migrations'::regclass);` returns the deprecation string. Don't write to the table; the runner's source of truth is `schema_migrations`.
+**Retained read-only: `drizzle.__drizzle_migrations`.** drizzle-kit's pre-runner migration log. Migration `0012_deprecate_drizzle_migrations_table.sql` applies a deprecation comment to the table; the table itself is kept as historical audit of what drizzle-kit thought it had applied before the cutover. The comment is queryable — `SELECT obj_description('drizzle.__drizzle_migrations'::regclass);` returns the deprecation string. Don't write to the table; the runner's source of truth is `schema_migrations`. On fresh DBs that never ran drizzle-kit, the schema and table are bootstrapped idempotently by `0011_a_create_drizzle_audit_schema.sql` so 0012's `COMMENT ON TABLE` succeeds in any environment.
+
+**Mid-sequence repair migrations.** Use the `NNNN_a_*` / `NNNN_b_*` naming form when a fix needs to land between two existing numbered migrations (sorts alphabetically between adjacent numbered files; passes the runner's `^\d{4}_.*\.sql$` filename regex). Reserve for genuine repair cases — usually a previously-applied migration assumed precondition state that newly-provisioned environments don't have.
 
 **0001 and 0008 hash artifacts**
 

--- a/OneDrive/Desktop/signal-app/backend/src/db/migrations/0011_a_create_drizzle_audit_schema.sql
+++ b/OneDrive/Desktop/signal-app/backend/src/db/migrations/0011_a_create_drizzle_audit_schema.sql
@@ -1,0 +1,35 @@
+-- 0011_a — Bootstrap migration creating the legacy drizzle.__drizzle_migrations
+-- schema and table on databases that never ran drizzle-kit. The next migration
+-- (0012) COMMENTs on this table and would fail with "schema 'drizzle' does
+-- not exist" on fresh DBs without this bootstrap. On environments that did
+-- run drizzle-kit pre-cutover (production, pre-cutover dev DBs), this is a
+-- no-op — CREATE SCHEMA IF NOT EXISTS and CREATE TABLE IF NOT EXISTS are
+-- both idempotent.
+--
+-- Surfaced during 12e.1 (PR #43) Task 2 verification when running
+-- db:migrate against a fresh Postgres container failed at 0012. See PR #43
+-- session notes for the discovery context.
+--
+-- Column shape matches drizzle-kit's standard generated shape so prod and
+-- fresh DBs converge on the same schema for the deprecated audit table.
+-- The table itself remains read-only / deprecated per CLAUDE.md §7 and
+-- 0012's COMMENT — this bootstrap exists so that COMMENT has a target,
+-- not to revive any write path.
+--
+-- Filename uses the `NNNN_a_*` mid-sequence-repair form (rather than `0014_*`)
+-- so the bootstrap lands as a pending migration on fresh DBs and sorts
+-- before 0012 in the runner's lexical ordering. The runner's filename
+-- regex (backend/src/db/migrate.ts: /^\d{4}_.*\.sql$/) requires the
+-- underscore to follow the four-digit prefix immediately, so a bare
+-- `0011a_*` form would be filtered out. The `0011_a_*` form passes the
+-- regex and still sorts before `0012_*` lexically. Establishes the
+-- convention for future mid-sequence repair migrations: `NNNN_a_*`,
+-- `NNNN_b_*`, etc.
+
+CREATE SCHEMA IF NOT EXISTS drizzle;
+
+CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+  id SERIAL PRIMARY KEY,
+  hash TEXT NOT NULL,
+  created_at BIGINT
+);


### PR DESCRIPTION
## Summary

A new bootstrap migration (`0011_a_create_drizzle_audit_schema.sql`) idempotently creates the legacy `drizzle.__drizzle_migrations` schema and table before `0012` tries to `COMMENT` on them. Unblocks fresh-DB migration chains (staging, CI, fresh dev clones, DR restores) without touching any other migration file or the runner.

## Discovery

Surfaced during **PR #43 (Phase 12e.1)** Task 2 verification when `npm run db:migrate` against a fresh Docker Postgres failed at:

```
[migrate] applying 0012_deprecate_drizzle_migrations_table.sql…
[migrate] failed: schema "drizzle" does not exist
```

`0012`'s body is one line — `COMMENT ON TABLE drizzle.__drizzle_migrations IS '…'` — and that schema/table only exists on environments that previously ran drizzle-kit pre-cutover (production, pre-cutover dev DBs). Fresh DBs blow up. The runner's per-file transaction rolled back cleanly, but no fresh environment could ever progress past this point. **Pre-existing on `origin/main`; not introduced by 12e.1.**

## Why Path Y (new bootstrap migration), not Path X (edit 0012) or Path Z (script)

Phase 1 diagnostic of [`backend/src/db/migrate.ts`](OneDrive/Desktop/signal-app/backend/src/db/migrate.ts):

- **Hash mismatch behavior:** the runner aborts hard ([migrate.ts:148-172](OneDrive/Desktop/signal-app/backend/src/db/migrate.ts:148) + [migrate.ts:241-244](OneDrive/Desktop/signal-app/backend/src/db/migrate.ts:241)). Editing `0012` would change its content_hash → every existing env that has 0012 applied would refuse to migrate further until someone manually `UPDATE`d `schema_migrations.content_hash`. Bad blast radius. Also violates CLAUDE.md §7's "migrations are immutable once applied" policy. **Path X blocked.**
- **Mid-sequence file insertion behavior:** validated per-applied-row, not per-disk-prefix. Files processed in sorted-filename order. Inserting `0011_a_*` between 0011 and 0012 sorts cleanly and applies as a no-op on existing envs. **Path Y feasible and clean.**
- **Bootstrap script (Path Z):** would require updates to the Dockerfile CMD, CI, and human discipline. Path Y handles the same case automatically through the existing single entrypoint.

## What's in this PR

**[`backend/src/db/migrations/0011_a_create_drizzle_audit_schema.sql`](OneDrive/Desktop/signal-app/backend/src/db/migrations/0011_a_create_drizzle_audit_schema.sql)** — new bootstrap migration:

```sql
CREATE SCHEMA IF NOT EXISTS drizzle;

CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
  id SERIAL PRIMARY KEY,
  hash TEXT NOT NULL,
  created_at BIGINT
);
```

Column shape matches drizzle-kit's standard generated shape so prod and fresh DBs converge on the same schema for the deprecated audit table.

**[`CLAUDE.md`](CLAUDE.md) §7** updated with:
- A note that fresh DBs get the legacy schema bootstrapped by `0011_a_*` so 0012's COMMENT succeeds in any environment.
- A brief documented convention: mid-sequence repair migrations use the `NNNN_a_*` / `NNNN_b_*` filename pattern (sorts alphabetically between adjacent numbered migrations; passes the runner's `/^\d{4}_.*\.sql$/` filename regex). Reserve for genuine repair cases.

## Filename naming — `0011_a_*` vs `0011a_*`

First attempt used `0011a_*` (digit-letter-no-underscore). The runner's filename regex requires the underscore to immediately follow the four-digit prefix — `0011a_*` fails the regex, gets filtered out at [`listMigrationFiles`](OneDrive/Desktop/signal-app/backend/src/db/migrate.ts:84-99), runner skips the file entirely. Renamed to `0011_a_*` (digit-underscore-letter) which matches `/^\d{4}_.*\.sql$/` cleanly. Functionally identical for sort-ordering purposes; no runner modification required.

## Verification matrix — all three runs passed

### Run 1 — fresh DB, full chain

```
[migrate] found 15 migration file(s) on disk
[migrate] applying 15 migration(s) as elkha
[migrate] applying 0000_dashing_colleen_wing.sql…
…
[migrate] applying 0011_a_create_drizzle_audit_schema.sql…
[migrate]   ✓ 0011_a_create_drizzle_audit_schema.sql (39ms)
[migrate] applying 0011_drop_phase12b_helper.sql…
[migrate]   ✓ 0011_drop_phase12b_helper.sql (12ms)
[migrate] applying 0012_deprecate_drizzle_migrations_table.sql…
[migrate]   ✓ 0012_deprecate_drizzle_migrations_table.sql (12ms)
[migrate] applying 0013_rename_standard_tier.sql…
[migrate]   ✓ 0013_rename_standard_tier.sql (18ms)
[migrate] done — 15 applied in 1056ms
```

Verification:
```
SELECT EXISTS (... 'drizzle')           -> t
SELECT EXISTS (... '__drizzle_migrations') -> t
SELECT obj_description('drizzle.__drizzle_migrations'::regclass)
  -> "DEPRECATED 2026-04-25 — replaced by schema_migrations. Retained for historical audit. Do not write."
```

### Run 2 — idempotent re-run

```
[migrate] found 15 migration file(s) on disk
[migrate] up to date (15 applied, 0 pending)
```

No re-execution of 0011_a.

### Run 3 — simulated existing-environment DB

Pre-created `drizzle.__drizzle_migrations` with a synthetic legacy row before running migrations:

```
INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
VALUES ('legacy_drizzle_kit_marker_hash', 1734000000000);
-- row_count: 1
```

Then `npm run db:migrate`:

```
[migrate] applying 0011_a_create_drizzle_audit_schema.sql…
[migrate]   ✓ 0011_a_create_drizzle_audit_schema.sql (10ms)
…
[migrate] applying 0012_deprecate_drizzle_migrations_table.sql…
[migrate]   ✓ 0012_deprecate_drizzle_migrations_table.sql (10ms)
…
[migrate] done — 15 applied in 817ms
```

Post-migrate verification:
```
SELECT COUNT(*), MAX(hash) FROM drizzle.__drizzle_migrations;
-- 1, "legacy_drizzle_kit_marker_hash"
```

The synthetic row is **preserved** — `CREATE TABLE IF NOT EXISTS` no-ops on the existing table, doesn't drop or recreate. This was the safety property I most wanted to verify on prod-shaped environments.

## Gates

- ✅ `npm --workspace=backend run type-check`
- ✅ `npm --workspace=backend run lint`
- ✅ `npm --workspace=backend test` — 467/467 across 39 suites

## Dependent work

[**PR #43 (Phase 12e.1)**](https://github.com/omarelkhateeb06-tech/signal-app/pull/43) is paused on its branch awaiting this fix to merge. Once this lands on `main`, that branch rebases and Task 2's verification matrix can finish (which it couldn't before because the migration chain blocked at 0012).

🤖 Generated with [Claude Code](https://claude.com/claude-code)