### PR TITLE
feat(ingestion): Phase 12e.5c — chain orchestration, per-source cadence, observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,12 +408,14 @@ Both are benign quirks of drizzle-kit's old hash function, not file-integrity or
 
 ## 7. JOBS & SCHEDULERS
 
-Two BullMQ queues, both backed by the shared Redis connection:
+Four BullMQ queues, all backed by the shared Redis connection:
 
-| queue                | producer                          | worker                  | cadence                  |
-|----------------------|-----------------------------------|-------------------------|--------------------------|
-| `signal-email`       | `emailQueue.enqueue()`            | `emailWorker`           | on-demand + weekly trigger |
-| `signal-aggregation` | `scheduleAggregationRepeatable()` | `aggregationWorker`     | `0 2 * * *` UTC, configurable via `AGGREGATION_CRON` |
+| queue                     | producer                              | worker                  | cadence                  |
+|---------------------------|---------------------------------------|-------------------------|--------------------------|
+| `signal-email`            | `emailQueue.enqueue()`                | `emailWorker`           | on-demand + weekly trigger |
+| `signal-aggregation`      | `scheduleAggregationRepeatable()`     | `aggregationWorker`     | `0 2 * * *` UTC, configurable via `AGGREGATION_CRON` |
+| `signal-ingestion-poll`   | `scheduleSourcePollRepeatable()` + `enqueueSourcePoll()` (ad-hoc) | `sourcePollWorker`      | per-source `every: fetch_interval_seconds * 1000`, scheduled at boot from `ingestion_sources` rows (12e.5c) |
+| `signal-ingestion-enrich` | `enqueueEnrichment()` from poll-job tail + manual `runIngestionEnrich.ts` CLI | `enrichmentWorker`      | on-demand (one job per surviving candidate) |
 
 Plus one **in-process** scheduler:
 

--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -21,13 +21,14 @@
 import { eq } from "drizzle-orm";
 
 import { db as defaultDb } from "../../db";
-import { ingestionCandidates } from "../../db/schema";
+import { ingestionCandidates, ingestionSources } from "../../db/schema";
 import { HEURISTIC_REASONS, type HeuristicReason } from "./heuristics";
 import type { RelevanceReason, RelevanceSeamRaw, Sector } from "./relevanceSeam";
 import type { FactsSeamResult } from "./factsSeam";
 import type { TierSeamResult } from "./tierGenerationSeam";
 import { processTierGeneration } from "./tierOrchestration";
 import { writeEvent as defaultWriteEvent } from "./writeEvent";
+import { captureIngestionStageFailure } from "../../lib/sentryHelpers";
 
 export interface EnrichmentJobInput {
   candidateId: string;
@@ -107,6 +108,12 @@ export interface EnrichmentJobDeps {
   // to assert the call shape without exercising the full transactional
   // events + event_sources + candidate-status update chain.
   writeEvent?: typeof defaultWriteEvent;
+  // Optional override for the per-stage Sentry capture helper (12e.5c
+  // sub-step 6). Defaults to `captureIngestionStageFailure` from
+  // lib/sentryHelpers.ts. Tests inject a mock to assert per-stage tag
+  // payloads without booting Sentry; production calls flow into the
+  // real helper which is a no-op when SENTRY_DSN is unset.
+  captureFailure?: typeof captureIngestionStageFailure;
 }
 
 // Statuses at which the chain has terminated and re-processing would
@@ -157,16 +164,26 @@ interface CandidateSnapshot {
   factsExtractedAt: Date | null;
   tierOutputs: Record<string, unknown> | null;
   resolvedEventId: string | null;
+  // Joined from ingestion_sources for Sentry per-stage tagging
+  // (12e.5c sub-step 6). Null if the join couldn't resolve (e.g.,
+  // source row deleted with FK ON DELETE CASCADE — the candidate row
+  // would also be gone, so this should be unreachable, but the
+  // candidate existing without a source would defensively skip the
+  // source_slug tag in Sentry capture).
+  sourceSlug: string | null;
 }
 
 // Read persisted candidate state once at the top of `processEnrichmentJob`.
-// Used by both the whole-job short-circuit (terminal-state guard) and
-// the per-stage short-circuits (skip relevance/facts seam calls when
-// their outputs are already persisted). Snapshot reflects state BEFORE
-// any seam in this invocation runs — this is load-bearing for the
-// per-stage short-circuits to read llm_judgment_raw / facts_extracted_at
-// from the correct vintage even after `runHeuristic` transiently
-// overwrites `status` to 'heuristic_passed'.
+// Used by:
+//   - the whole-job short-circuit (terminal-state guard)
+//   - per-stage short-circuits (skip relevance/facts seam calls when
+//     their outputs are already persisted)
+//   - per-stage Sentry tagging (sub-step 6 — sourceSlug for the
+//     ingestion.source_slug tag)
+// Snapshot reflects state BEFORE any seam in this invocation runs —
+// load-bearing for the per-stage short-circuits to read llm_judgment_raw
+// / facts_extracted_at from the correct vintage even after `runHeuristic`
+// transiently overwrites `status` to 'heuristic_passed'.
 async function loadCandidateSnapshot(
   db: typeof defaultDb,
   candidateId: string,
@@ -179,8 +196,13 @@ async function loadCandidateSnapshot(
       factsExtractedAt: ingestionCandidates.factsExtractedAt,
       tierOutputs: ingestionCandidates.tierOutputs,
       resolvedEventId: ingestionCandidates.resolvedEventId,
+      sourceSlug: ingestionSources.slug,
     })
     .from(ingestionCandidates)
+    .leftJoin(
+      ingestionSources,
+      eq(ingestionSources.id, ingestionCandidates.ingestionSourceId),
+    )
     .where(eq(ingestionCandidates.id, candidateId))
     .limit(1);
   return (rows[0] as CandidateSnapshot | undefined) ?? null;
@@ -192,6 +214,7 @@ export async function processEnrichmentJob(
 ): Promise<EnrichmentJobResult> {
   const db = deps.db ?? defaultDb;
   const seams = deps.seams ?? {};
+  const captureFailure = deps.captureFailure ?? captureIngestionStageFailure;
 
   if (!seams.runHeuristic) {
     return {
@@ -327,6 +350,15 @@ export async function processEnrichmentJob(
         .update(ingestionCandidates)
         .set(relevanceUpdates)
         .where(eq(ingestionCandidates.id, input.candidateId));
+      // 12e.5c sub-step 6: per-stage Sentry tagging. Synchronous
+      // captureException with stage tags after the await above
+      // resolves — keeps withScope isolated under BullMQ concurrency=2.
+      captureFailure({
+        stage: "relevance",
+        candidateId: input.candidateId,
+        sourceSlug: snapshot?.sourceSlug ?? null,
+        rejectionReason: relevance.rejectionReason ?? "llm_rejected",
+      });
       return {
         candidateId: input.candidateId,
         resolvedEventId: null,
@@ -397,6 +429,13 @@ export async function processEnrichmentJob(
         .update(ingestionCandidates)
         .set(factsUpdates)
         .where(eq(ingestionCandidates.id, input.candidateId));
+      // 12e.5c sub-step 6: per-stage Sentry tagging.
+      captureFailure({
+        stage: "facts",
+        candidateId: input.candidateId,
+        sourceSlug: snapshot?.sourceSlug ?? null,
+        rejectionReason: facts.rejectionReason ?? "facts_parse_error",
+      });
       return {
         candidateId: input.candidateId,
         resolvedEventId: null,
@@ -434,6 +473,15 @@ export async function processEnrichmentJob(
     // markTierFailed has already written status='facts_extracted' with
     // status_reason set to the failed tier's class. Surface the failure
     // class in the result envelope.
+    // 12e.5c sub-step 6: per-stage Sentry tagging. The tier-call
+    // rejection class is the failed tier's reason; include the tier
+    // name as a secondary signal in the rejection_reason payload.
+    captureFailure({
+      stage: "tiers",
+      candidateId: input.candidateId,
+      sourceSlug: snapshot?.sourceSlug ?? null,
+      rejectionReason: `${tierSummary.failedTier.tier}:${tierSummary.failedTier.reason}`,
+    });
     return {
       candidateId: input.candidateId,
       resolvedEventId: null,
@@ -478,6 +526,17 @@ export async function processEnrichmentJob(
       // a separate mechanism (CLI sweep or out-of-band re-enqueue);
       // tracked as a follow-up issue.
       const detail = err instanceof Error ? err.message : String(err);
+      // 12e.5c sub-step 6: per-stage Sentry tagging. Pass the original
+      // error object through so its stack trace is preserved (writeEvent
+      // throws ZodError on assertTierTemplate failure or PG errors on
+      // constraint/connection issues — both have useful stacks).
+      captureFailure({
+        stage: "write_event",
+        candidateId: input.candidateId,
+        sourceSlug: snapshot?.sourceSlug ?? null,
+        rejectionReason: `write_event_error: ${detail}`,
+        err,
+      });
       return {
         candidateId: input.candidateId,
         resolvedEventId: null,
@@ -490,6 +549,14 @@ export async function processEnrichmentJob(
   // Defensive fall-through: tier orchestration neither completed nor
   // failed (e.g., its own loadTierState couldn't load the candidate row).
   // Treat as terminal facts_extracted — preserves the prior behavior.
+  // 12e.5c sub-step 6: capture as an anomalous tier-stage outcome so
+  // the soak surface picks up the rare degenerate state.
+  captureFailure({
+    stage: "tiers",
+    candidateId: input.candidateId,
+    sourceSlug: snapshot?.sourceSlug ?? null,
+    rejectionReason: "tier_orchestration_indeterminate",
+  });
   return {
     candidateId: input.candidateId,
     resolvedEventId: null,

--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -26,6 +26,7 @@ import { HEURISTIC_REASONS, type HeuristicReason } from "./heuristics";
 import type { RelevanceReason, RelevanceSeamRaw, Sector } from "./relevanceSeam";
 import type { FactsSeamResult } from "./factsSeam";
 import type { TierSeamResult } from "./tierGenerationSeam";
+import { processTierGeneration } from "./tierOrchestration";
 
 export interface EnrichmentJobInput {
   candidateId: string;
@@ -94,6 +95,12 @@ export interface EnrichmentSeams {
 export interface EnrichmentJobDeps {
   db?: typeof defaultDb;
   seams?: EnrichmentSeams;
+  // Optional override for the tier-generation orchestration call (12e.5c
+  // sub-step 2). Defaults to `processTierGeneration` from
+  // tierOrchestration.ts. Tests inject a mock to avoid threading the
+  // full per-tier mockDb queue setup that the orchestrator's internal
+  // loadTierState + jsonb_set executes would otherwise require.
+  processTier?: typeof processTierGeneration;
 }
 
 // Statuses at which the chain has terminated and re-processing would
@@ -403,8 +410,47 @@ export async function processEnrichmentJob(
       .where(eq(ingestionCandidates.id, input.candidateId));
   }
 
-  // Fall-through terminal: facts complete (either just-written by this
-  // invocation or short-circuited from the snapshot).
+  // ---- Tier generation (12e.5b orchestration; wired into the chain
+  // by 12e.5c sub-step 2) ----
+  // Per-tier idempotency lives inside processTierGeneration (see
+  // tierOrchestration.ts:181-198 — checks `tier_outputs->>'<tier>'`
+  // against the persisted JSONB column before invoking each tier).
+  // The whole-job short-circuit upstream already returned for any
+  // candidate at status='tier_generated', so by this point the
+  // candidate is at facts_extracted (or transient earlier states this
+  // invocation just walked through). The orchestrator owns its own DB
+  // writes (jsonb_set + status advance to 'tier_generated' on full-trio
+  // completion).
+  const runTier = deps.processTier ?? processTierGeneration;
+  const tierSummary = await runTier(input.candidateId, { db });
+
+  if (tierSummary.failedTier) {
+    // markTierFailed has already written status='facts_extracted' with
+    // status_reason set to the failed tier's class. Surface the failure
+    // class in the result envelope.
+    return {
+      candidateId: input.candidateId,
+      resolvedEventId: null,
+      terminalStatus: "failed",
+      failureReason: tierSummary.failedTier.reason,
+    };
+  }
+
+  if (tierSummary.completed) {
+    // markTierGeneratedComplete has written status='tier_generated' +
+    // tier_generated_at. Sub-step 3 will continue the chain into
+    // writeEvent; for sub-step 2 in isolation, this is the terminal.
+    return {
+      candidateId: input.candidateId,
+      resolvedEventId: null,
+      terminalStatus: "tier_generated",
+      failureReason: null,
+    };
+  }
+
+  // Defensive fall-through: tier orchestration neither completed nor
+  // failed (e.g., its own loadTierState couldn't load the candidate row).
+  // Treat as terminal facts_extracted — preserves the prior behavior.
   return {
     candidateId: input.candidateId,
     resolvedEventId: null,

--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -27,6 +27,7 @@ import type { RelevanceReason, RelevanceSeamRaw, Sector } from "./relevanceSeam"
 import type { FactsSeamResult } from "./factsSeam";
 import type { TierSeamResult } from "./tierGenerationSeam";
 import { processTierGeneration } from "./tierOrchestration";
+import { writeEvent as defaultWriteEvent } from "./writeEvent";
 
 export interface EnrichmentJobInput {
   candidateId: string;
@@ -101,6 +102,11 @@ export interface EnrichmentJobDeps {
   // full per-tier mockDb queue setup that the orchestrator's internal
   // loadTierState + jsonb_set executes would otherwise require.
   processTier?: typeof processTierGeneration;
+  // Optional override for the events row writer (12e.5c sub-step 3).
+  // Defaults to `writeEvent` from writeEvent.ts. Tests inject a mock
+  // to assert the call shape without exercising the full transactional
+  // events + event_sources + candidate-status update chain.
+  writeEvent?: typeof defaultWriteEvent;
 }
 
 // Statuses at which the chain has terminated and re-processing would
@@ -438,14 +444,47 @@ export async function processEnrichmentJob(
 
   if (tierSummary.completed) {
     // markTierGeneratedComplete has written status='tier_generated' +
-    // tier_generated_at. Sub-step 3 will continue the chain into
-    // writeEvent; for sub-step 2 in isolation, this is the terminal.
-    return {
-      candidateId: input.candidateId,
-      resolvedEventId: null,
-      terminalStatus: "tier_generated",
-      failureReason: null,
-    };
+    // tier_generated_at. Sub-step 3 wires the chain through to
+    // writeEvent: insert events + event_sources, advance candidate to
+    // 'published', set resolved_event_id.
+    const runWriteEvent = deps.writeEvent ?? defaultWriteEvent;
+    try {
+      const { eventId } = await runWriteEvent(input.candidateId, { db });
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: eventId,
+        terminalStatus: "published",
+        failureReason: null,
+      };
+    } catch (err) {
+      // writeEvent throws on validation failures (assertTierTemplate)
+      // or DB-level constraint/connection errors. Surface as terminal
+      // 'failed' in the result envelope so the worker's done log
+      // captures it; sub-step 6/7 will add Sentry capture inside this
+      // catch block.
+      //
+      // KNOWN LIMITATION: writeEvent failures leave the candidate at
+      // status='tier_generated' (markTierGeneratedComplete committed
+      // before writeEvent's transaction attempted; writeEvent's
+      // transaction rolls back atomically but the upstream tier-status
+      // commit stands). Per the planner-locked decision 4 ("Partial
+      // state lives on ingestion_candidates, never events"), this is
+      // the intended partial-state semantics: tier_generated WITH
+      // resolved_event_id=null means "tier work done, event-write
+      // pending or failed." A subsequent BullMQ retry on this job
+      // hits the whole-job short-circuit (tier_generated ∈
+      // TERMINAL_STATES) and returns terminalStatus='tier_generated'
+      // — does NOT auto-re-attempt writeEvent. Manual retry requires
+      // a separate mechanism (CLI sweep or out-of-band re-enqueue);
+      // tracked as a follow-up issue.
+      const detail = err instanceof Error ? err.message : String(err);
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: null,
+        terminalStatus: "failed",
+        failureReason: `write_event_error: ${detail}`,
+      };
+    }
   }
 
   // Defensive fall-through: tier orchestration neither completed nor

--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -47,6 +47,7 @@ export interface EnrichmentJobResult {
     | "llm_rejected"
     | "llm_relevant"
     | "facts_extracted"
+    | "tier_generated"
     | "published"
     | "duplicate"
     | "failed";
@@ -95,6 +96,83 @@ export interface EnrichmentJobDeps {
   seams?: EnrichmentSeams;
 }
 
+// Statuses at which the chain has terminated and re-processing would
+// either waste work (terminal-success) or destroy state (terminal-
+// rejection — re-running heuristic would overwrite the reason and
+// orphan the rejection). The whole-job short-circuit at the top of
+// `processEnrichmentJob` returns immediately for any candidate already
+// at one of these states.
+const TERMINAL_STATES: ReadonlySet<string> = new Set([
+  // Terminal-rejection
+  "heuristic_filtered",
+  "llm_rejected",
+  "failed",
+  // Terminal-success
+  "tier_generated",
+  "published",
+]);
+
+// Subset of TERMINAL_STATES used to decide whether the result envelope's
+// `failureReason` should carry the persisted `status_reason` (rejection)
+// or be null (success).
+const TERMINAL_REJECTIONS: ReadonlySet<string> = new Set([
+  "heuristic_filtered",
+  "llm_rejected",
+  "failed",
+]);
+
+// Statuses that imply the relevance gate has produced a verdict (whether
+// rejection or pass). Used by the per-stage short-circuit before
+// `runRelevanceGate` to detect that relevance has run in a prior job
+// invocation, even if this invocation's heuristic just transiently
+// overwrote `status` to 'heuristic_passed'. Includes 'tier_generated'
+// and 'published' for completeness, though the whole-job short-circuit
+// catches those upstream.
+const PAST_HEURISTIC_PASSED: ReadonlySet<string> = new Set([
+  "llm_rejected",
+  "llm_relevant",
+  "facts_extracted",
+  "tier_generated",
+  "enriching",
+  "published",
+]);
+
+interface CandidateSnapshot {
+  status: string;
+  statusReason: string | null;
+  llmJudgmentRaw: Record<string, unknown> | null;
+  factsExtractedAt: Date | null;
+  tierOutputs: Record<string, unknown> | null;
+  resolvedEventId: string | null;
+}
+
+// Read persisted candidate state once at the top of `processEnrichmentJob`.
+// Used by both the whole-job short-circuit (terminal-state guard) and
+// the per-stage short-circuits (skip relevance/facts seam calls when
+// their outputs are already persisted). Snapshot reflects state BEFORE
+// any seam in this invocation runs — this is load-bearing for the
+// per-stage short-circuits to read llm_judgment_raw / facts_extracted_at
+// from the correct vintage even after `runHeuristic` transiently
+// overwrites `status` to 'heuristic_passed'.
+async function loadCandidateSnapshot(
+  db: typeof defaultDb,
+  candidateId: string,
+): Promise<CandidateSnapshot | null> {
+  const rows = await db
+    .select({
+      status: ingestionCandidates.status,
+      statusReason: ingestionCandidates.statusReason,
+      llmJudgmentRaw: ingestionCandidates.llmJudgmentRaw,
+      factsExtractedAt: ingestionCandidates.factsExtractedAt,
+      tierOutputs: ingestionCandidates.tierOutputs,
+      resolvedEventId: ingestionCandidates.resolvedEventId,
+    })
+    .from(ingestionCandidates)
+    .where(eq(ingestionCandidates.id, candidateId))
+    .limit(1);
+  return (rows[0] as CandidateSnapshot | undefined) ?? null;
+}
+
 export async function processEnrichmentJob(
   input: EnrichmentJobInput,
   deps: EnrichmentJobDeps = {},
@@ -108,6 +186,28 @@ export async function processEnrichmentJob(
       resolvedEventId: null,
       terminalStatus: "failed",
       failureReason: "runHeuristic seam not provided",
+    };
+  }
+
+  // Whole-job short-circuit (12e.5c sub-step 1).
+  // Closes two correctness gaps that would otherwise fire on a BullMQ
+  // retry of an already-progressed candidate:
+  //   (1) LLM-double-charge — re-firing relevance/facts/tier seams.
+  //   (2) heuristic-overwrite data loss — re-running heuristic would
+  //       overwrite `status` (e.g., reverting 'llm_rejected' to
+  //       'heuristic_passed' or 'heuristic_filtered'), orphaning the
+  //       persisted rejection reason / facts / tier_outputs.
+  // Snapshot is also reused below by the per-stage short-circuits.
+  const snapshot = await loadCandidateSnapshot(db, input.candidateId);
+
+  if (snapshot && TERMINAL_STATES.has(snapshot.status)) {
+    return {
+      candidateId: input.candidateId,
+      resolvedEventId: snapshot.resolvedEventId,
+      terminalStatus: snapshot.status as EnrichmentJobResult["terminalStatus"],
+      failureReason: TERMINAL_REJECTIONS.has(snapshot.status)
+        ? snapshot.statusReason ?? "unknown"
+        : null,
     };
   }
 
@@ -154,132 +254,157 @@ export async function processEnrichmentJob(
     .where(eq(ingestionCandidates.id, input.candidateId));
 
   // ---- Relevance gate (12e.4) ----
-  // If runRelevanceGate is wired, continue past heuristic_passed.
-  // If not, terminate at heuristic_passed (preserves the 12e.3
-  // CLI-without-LLM behavior; opt-in for tests + future workers).
-  if (!seams.runRelevanceGate) {
-    return {
-      candidateId: input.candidateId,
-      resolvedEventId: null,
-      terminalStatus: "heuristic_passed",
-      failureReason: null,
+  // Per-stage short-circuit (12e.5c sub-step 1): skip if a prior job
+  // already wrote llm_judgment_raw and advanced status past
+  // heuristic_passed. Snapshot reflects pre-invocation state, so the
+  // transient 'heuristic_passed' that THIS job's runHeuristic just
+  // wrote does not break the predicate. The whole-job short-circuit
+  // upstream already returned for 'llm_rejected'; here we only need
+  // to handle the pass case (skip relevance, fall through to facts).
+  const relevanceAlreadyRan =
+    snapshot !== null &&
+    snapshot.llmJudgmentRaw !== null &&
+    PAST_HEURISTIC_PASSED.has(snapshot.status);
+
+  if (!relevanceAlreadyRan) {
+    // If runRelevanceGate is wired, continue past heuristic_passed.
+    // If not, terminate at heuristic_passed (preserves the 12e.3
+    // CLI-without-LLM behavior; opt-in for tests + future workers).
+    if (!seams.runRelevanceGate) {
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: null,
+        terminalStatus: "heuristic_passed",
+        failureReason: null,
+      };
+    }
+
+    const relevance = await seams.runRelevanceGate(input.candidateId);
+
+    // Always persist llm_judgment_raw when a successful Haiku call
+    // produced one (raw is set when at least one attempt returned text;
+    // unset on hard client-level failures like no_api_key / timeout).
+    // processedAt advances on every relevance-gate completion regardless
+    // of verdict.
+    const relevanceUpdates: {
+      processedAt: Date;
+      status?: "llm_relevant" | "llm_rejected";
+      statusReason?: string;
+      sector?: string | null;
+      llmJudgmentRaw?: Record<string, unknown> | null;
+    } = {
+      processedAt: new Date(),
     };
-  }
+    if (relevance.raw) {
+      // Cast: the seam's RelevanceSeamRaw is structurally a JSON-safe
+      // record. The schema column is jsonb<Record<string, unknown>>.
+      relevanceUpdates.llmJudgmentRaw = relevance.raw as unknown as Record<
+        string,
+        unknown
+      >;
+    }
 
-  const relevance = await seams.runRelevanceGate(input.candidateId);
+    if (!relevance.relevant) {
+      relevanceUpdates.status = "llm_rejected";
+      relevanceUpdates.statusReason =
+        relevance.rejectionReason ?? "llm_rejected";
+      // sector stays NULL on rejection (G5 — even if the LLM offered
+      // one, it's not actionable for a rejected candidate).
+      await db
+        .update(ingestionCandidates)
+        .set(relevanceUpdates)
+        .where(eq(ingestionCandidates.id, input.candidateId));
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: null,
+        terminalStatus: "llm_rejected",
+        failureReason: relevance.rejectionReason ?? "llm_rejected",
+      };
+    }
 
-  // Always persist llm_judgment_raw when a successful Haiku call
-  // produced one (raw is set when at least one attempt returned text;
-  // unset on hard client-level failures like no_api_key / timeout).
-  // processedAt advances on every relevance-gate completion regardless
-  // of verdict.
-  const relevanceUpdates: {
-    processedAt: Date;
-    status?: "llm_relevant" | "llm_rejected";
-    statusReason?: string;
-    sector?: string | null;
-    llmJudgmentRaw?: Record<string, unknown> | null;
-  } = {
-    processedAt: new Date(),
-  };
-  if (relevance.raw) {
-    // Cast: the seam's RelevanceSeamRaw is structurally a JSON-safe
-    // record. The schema column is jsonb<Record<string, unknown>>.
-    relevanceUpdates.llmJudgmentRaw = relevance.raw as unknown as Record<
-      string,
-      unknown
-    >;
-  }
-
-  if (!relevance.relevant) {
-    relevanceUpdates.status = "llm_rejected";
-    relevanceUpdates.statusReason =
-      relevance.rejectionReason ?? "llm_rejected";
-    // sector stays NULL on rejection (G5 — even if the LLM offered
-    // one, it's not actionable for a rejected candidate).
+    // Pass — sector populated, status advances to llm_relevant.
+    relevanceUpdates.status = "llm_relevant";
+    relevanceUpdates.sector = relevance.sector ?? null;
     await db
       .update(ingestionCandidates)
       .set(relevanceUpdates)
       .where(eq(ingestionCandidates.id, input.candidateId));
-    return {
-      candidateId: input.candidateId,
-      resolvedEventId: null,
-      terminalStatus: "llm_rejected",
-      failureReason: relevance.rejectionReason ?? "llm_rejected",
-    };
   }
-
-  // Pass — sector populated, status advances to llm_relevant.
-  relevanceUpdates.status = "llm_relevant";
-  relevanceUpdates.sector = relevance.sector ?? null;
-  await db
-    .update(ingestionCandidates)
-    .set(relevanceUpdates)
-    .where(eq(ingestionCandidates.id, input.candidateId));
 
   // ---- Fact extraction (12e.5a) ----
-  // If extractFacts is wired, continue past llm_relevant. If not,
-  // terminate at llm_relevant (preserves the 12e.4 behavior; opt-in
-  // for tests + future workers via seam injection).
-  if (!seams.extractFacts) {
-    return {
-      candidateId: input.candidateId,
-      resolvedEventId: null,
-      terminalStatus: "llm_relevant",
-      failureReason: null,
+  // Per-stage short-circuit (12e.5c sub-step 1): skip if a prior job
+  // already stamped facts_extracted_at. Snapshot's facts_extracted_at
+  // is read against pre-invocation state for the same reason as the
+  // relevance check above.
+  const factsAlreadyRan =
+    snapshot !== null && snapshot.factsExtractedAt !== null;
+
+  if (!factsAlreadyRan) {
+    // If extractFacts is wired, continue past llm_relevant. If not,
+    // terminate at llm_relevant (preserves the 12e.4 behavior; opt-in
+    // for tests + future workers via seam injection).
+    if (!seams.extractFacts) {
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: null,
+        terminalStatus: "llm_relevant",
+        failureReason: null,
+      };
+    }
+
+    const facts = await seams.extractFacts(input.candidateId);
+
+    // Persist facts_extraction_raw whenever a successful Haiku call
+    // produced one (raw is set when at least one attempt returned text;
+    // unset on hard client-level failures like no_api_key / timeout).
+    // processedAt advances on every facts-stage completion regardless of
+    // verdict.
+    const factsUpdates: {
+      processedAt: Date;
+      status?: "facts_extracted" | "failed";
+      statusReason?: string;
+      facts?: Record<string, unknown> | null;
+      factsExtractedAt?: Date | null;
+      factsExtractionRaw?: Record<string, unknown> | null;
+    } = {
+      processedAt: new Date(),
     };
-  }
+    if (facts.raw) {
+      factsUpdates.factsExtractionRaw = facts.raw as unknown as Record<
+        string,
+        unknown
+      >;
+    }
 
-  const facts = await seams.extractFacts(input.candidateId);
+    if (!facts.ok) {
+      factsUpdates.status = "failed";
+      factsUpdates.statusReason =
+        facts.rejectionReason ?? "facts_parse_error";
+      await db
+        .update(ingestionCandidates)
+        .set(factsUpdates)
+        .where(eq(ingestionCandidates.id, input.candidateId));
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: null,
+        terminalStatus: "failed",
+        failureReason: facts.rejectionReason ?? "facts_parse_error",
+      };
+    }
 
-  // Persist facts_extraction_raw whenever a successful Haiku call
-  // produced one (raw is set when at least one attempt returned text;
-  // unset on hard client-level failures like no_api_key / timeout).
-  // processedAt advances on every facts-stage completion regardless of
-  // verdict.
-  const factsUpdates: {
-    processedAt: Date;
-    status?: "facts_extracted" | "failed";
-    statusReason?: string;
-    facts?: Record<string, unknown> | null;
-    factsExtractedAt?: Date | null;
-    factsExtractionRaw?: Record<string, unknown> | null;
-  } = {
-    processedAt: new Date(),
-  };
-  if (facts.raw) {
-    factsUpdates.factsExtractionRaw = facts.raw as unknown as Record<
-      string,
-      unknown
-    >;
-  }
-
-  if (!facts.ok) {
-    factsUpdates.status = "failed";
-    factsUpdates.statusReason =
-      facts.rejectionReason ?? "facts_parse_error";
+    // Pass — facts populated, status advances to facts_extracted,
+    // facts_extracted_at stamped now.
+    factsUpdates.status = "facts_extracted";
+    factsUpdates.facts = facts.facts as unknown as Record<string, unknown>;
+    factsUpdates.factsExtractedAt = new Date();
     await db
       .update(ingestionCandidates)
       .set(factsUpdates)
       .where(eq(ingestionCandidates.id, input.candidateId));
-    return {
-      candidateId: input.candidateId,
-      resolvedEventId: null,
-      terminalStatus: "failed",
-      failureReason: facts.rejectionReason ?? "facts_parse_error",
-    };
   }
 
-  // Pass — facts populated, status advances to facts_extracted,
-  // facts_extracted_at stamped now.
-  factsUpdates.status = "facts_extracted";
-  factsUpdates.facts = facts.facts as unknown as Record<string, unknown>;
-  factsUpdates.factsExtractedAt = new Date();
-  await db
-    .update(ingestionCandidates)
-    .set(factsUpdates)
-    .where(eq(ingestionCandidates.id, input.candidateId));
-
+  // Fall-through terminal: facts complete (either just-written by this
+  // invocation or short-circuited from the snapshot).
   return {
     candidateId: input.candidateId,
     resolvedEventId: null,

--- a/backend/src/jobs/ingestion/enrichmentWorker.ts
+++ b/backend/src/jobs/ingestion/enrichmentWorker.ts
@@ -1,24 +1,50 @@
 // `signal-ingestion-enrich` worker. Receives one job per candidate
 // surviving the heuristic filter and runs it through `processEnrichmentJob`.
 // 12e.1 ships a thin shell; 12e.3 onward fills in the pipeline through
-// the enrichmentJob seams.
+// the enrichmentJob seams. 12e.5c sub-step 4 wires the four seams +
+// the tier orchestration + the events writer into the worker so
+// BullMQ-drained jobs flow through the full chain end-to-end.
 
 import { Worker, type Job } from "bullmq";
 import { getRedis, isRedisConfigured } from "../../lib/redis";
 import { ENRICHMENT_QUEUE_NAME } from "./enrichmentQueue";
-import { processEnrichmentJob, type EnrichmentJobInput } from "./enrichmentJob";
+import {
+  processEnrichmentJob,
+  type EnrichmentJobInput,
+  type EnrichmentSeams,
+} from "./enrichmentJob";
+import { runHeuristicSeam } from "./heuristicSeam";
+import { runRelevanceSeam } from "./relevanceSeam";
+import { runFactsSeam } from "./factsSeam";
 
 let cachedWorker: Worker<EnrichmentJobInput> | null = null;
 
+// Module-level seam construction mirrors `scripts/runIngestionEnrich.ts`'s
+// pattern. Each seam loads its own candidate row + makes its own LLM
+// call internally — the orchestration body in processEnrichmentJob
+// owns DB persistence + status transitions. The tier-generation +
+// writeEvent stages don't appear here because processEnrichmentJob's
+// EnrichmentJobDeps default to the production `processTierGeneration`
+// (sub-step 2) and `writeEvent` (sub-step 3) when those deps are
+// omitted. The CLI follows the same pattern.
+const seams: EnrichmentSeams = {
+  runHeuristic: (id) => runHeuristicSeam(id),
+  runRelevanceGate: (id) => runRelevanceSeam(id),
+  extractFacts: (id) => runFactsSeam(id),
+};
+
 async function handle(job: Job<EnrichmentJobInput>): Promise<void> {
-  // 12e.5c: wire seams here (runHeuristic, runRelevanceGate, etc.).
-  // Until then, this worker returns terminalStatus: "failed" for any
-  // drained job because seams are not injected. The CLI
-  // (runIngestionEnrich.ts) is the documented dev surface for 12e.3
-  // and 12e.4 — it injects the heuristic + relevance seams directly.
-  // No DB corruption: the orchestration body's missing-seam guard
-  // returns the structured result without writing to the DB.
-  const result = await processEnrichmentJob(job.data);
+  // Inject seams + mark `triggeredBy` as 'poll' if the producer didn't
+  // already set it (sourcePollWorker enqueues with no triggeredBy
+  // today; CLI sets 'cli'; tests set 'test'). The full chain runs
+  // end-to-end: heuristic → relevance → facts → tiers → writeEvent →
+  // status='published' on success. Failure modes return structured
+  // result envelopes; only unexpected exceptions reach the BullMQ
+  // failed handler (sub-step 7 wires that for Sentry capture).
+  const result = await processEnrichmentJob(
+    { ...job.data, triggeredBy: job.data.triggeredBy ?? "poll" },
+    { seams },
+  );
   // eslint-disable-next-line no-console
   console.log(
     `[signal-backend] [ingestion-enrich:done] candidate=${result.candidateId} terminal=${result.terminalStatus} event=${result.resolvedEventId ?? "none"} failure=${result.failureReason ?? "none"}`,

--- a/backend/src/jobs/ingestion/enrichmentWorker.ts
+++ b/backend/src/jobs/ingestion/enrichmentWorker.ts
@@ -16,6 +16,7 @@ import {
 import { runHeuristicSeam } from "./heuristicSeam";
 import { runRelevanceSeam } from "./relevanceSeam";
 import { runFactsSeam } from "./factsSeam";
+import { handleWorkerFailure } from "./enrichmentWorkerFailure";
 
 let cachedWorker: Worker<EnrichmentJobInput> | null = null;
 
@@ -70,10 +71,7 @@ export function startEnrichmentWorker(): Worker<EnrichmentJobInput> | null {
     concurrency: Number(process.env.INGESTION_ENRICH_CONCURRENCY ?? 2),
   });
   cachedWorker.on("failed", (job, err) => {
-    // eslint-disable-next-line no-console
-    console.error(
-      `[signal-backend] [ingestion-enrich:failed] candidate=${job?.data.candidateId ?? "unknown"}: ${err.message}`,
-    );
+    void handleWorkerFailure(job, err);
   });
   // eslint-disable-next-line no-console
   console.log("[signal-backend] enrichment worker started");

--- a/backend/src/jobs/ingestion/enrichmentWorkerFailure.ts
+++ b/backend/src/jobs/ingestion/enrichmentWorkerFailure.ts
@@ -1,0 +1,84 @@
+// Phase 12e.5c sub-step 7 — BullMQ `failed` event handler for the
+// enrichment worker, factored out of enrichmentWorker.ts so it's
+// testable without pulling in the heuristic seam's jsdom transitive
+// (see docs/discovery/phase-12e5b-audit.md §10 + the parallel split
+// in tierOrchestration.ts:1-19 for the same hygiene boundary).
+//
+// The split is purely a test-import hygiene boundary; runtime
+// semantics are unchanged from the prior in-line on("failed", ...)
+// handler.
+//
+// Contract:
+//   - Logs the failure to console (preserved from the prior handler).
+//   - Best-effort source_slug lookup so the Sentry tag set matches
+//     sub-step 6's per-stage convention. DB hiccup mid-failure → tag
+//     omitted, capture still fires (we're already in a failure handler;
+//     compounding the failure with a DB-error throw would lose the
+//     original error context).
+//   - Captures via captureIngestionStageFailure with stage='worker_failed'
+//     plus extraTags carrying BullMQ context (attempt count + queue name).
+//   - The failed job remains in BullMQ's failed-state for 7 days per
+//     the queue's `removeOnFail: { age: 604_800 }` config — that IS the
+//     DLQ. Audit §2 confirmed no separate dead_letter table is needed;
+//     same pattern as signal-emails and signal-aggregation.
+
+import { eq } from "drizzle-orm";
+import type { Job } from "bullmq";
+
+import { db as defaultDb } from "../../db";
+import { ingestionCandidates, ingestionSources } from "../../db/schema";
+import { captureIngestionStageFailure } from "../../lib/sentryHelpers";
+import { ENRICHMENT_QUEUE_NAME } from "./enrichmentQueue";
+import type { EnrichmentJobInput } from "./enrichmentJob";
+
+export interface HandleWorkerFailureDeps {
+  db?: typeof defaultDb;
+  captureFailure?: typeof captureIngestionStageFailure;
+}
+
+export async function handleWorkerFailure(
+  job: Job<EnrichmentJobInput> | undefined,
+  err: Error,
+  deps: HandleWorkerFailureDeps = {},
+): Promise<void> {
+  const candidateId = job?.data.candidateId ?? "unknown";
+  // eslint-disable-next-line no-console
+  console.error(
+    `[signal-backend] [ingestion-enrich:failed] candidate=${candidateId}: ${err.message}`,
+  );
+
+  let sourceSlug: string | null = null;
+  if (job?.data.candidateId) {
+    try {
+      const dbInstance = deps.db ?? defaultDb;
+      const rows = await dbInstance
+        .select({ slug: ingestionSources.slug })
+        .from(ingestionCandidates)
+        .leftJoin(
+          ingestionSources,
+          eq(ingestionSources.id, ingestionCandidates.ingestionSourceId),
+        )
+        .where(eq(ingestionCandidates.id, job.data.candidateId))
+        .limit(1);
+      sourceSlug =
+        (rows[0] as { slug: string | null } | undefined)?.slug ?? null;
+    } catch {
+      // Swallow lookup errors — we're already in a failure handler;
+      // compounding the failure with a DB-error throw would lose the
+      // original error context. sourceSlug stays null.
+    }
+  }
+
+  const captureFailure = deps.captureFailure ?? captureIngestionStageFailure;
+  captureFailure({
+    stage: "worker_failed",
+    candidateId,
+    sourceSlug,
+    rejectionReason: err.message || "unknown_error",
+    err,
+    extraTags: {
+      "bullmq.attempt": String(job?.attemptsMade ?? 0),
+      "bullmq.queue": ENRICHMENT_QUEUE_NAME,
+    },
+  });
+}

--- a/backend/src/jobs/ingestion/sourcePollQueue.ts
+++ b/backend/src/jobs/ingestion/sourcePollQueue.ts
@@ -2,13 +2,19 @@
 // Pattern matches `aggregationQueue.ts`: lazy queue construction,
 // graceful no-op when REDIS_URL is unset.
 //
-// 12e.1 ships the queue + a cron-stub scheduler that's a no-op until
-// 12e.5c wires it to actual per-source cadences (RSS hourly, EDGAR
-// 15-min business hours, arXiv daily 21:00 UTC, etc., per roadmap
-// §5.4). Per-source repeatable jobs keyed off
-// `ingestion_sources.fetch_interval_seconds` are introduced in 12e.5c.
+// 12e.1 ships the queue. 12e.5c sub-step 5 adds
+// `scheduleSourcePollRepeatable()` — reads `ingestion_sources.fetch_interval_seconds`
+// per row and creates one BullMQ repeatable job per enabled source with
+// the source-specific cadence. Disabled sources or sources with
+// non-positive intervals are skipped.
+//
+// 12e.5d will extend this for adapter-specific schedule semantics
+// (SEC EDGAR business-hours-aware, arXiv daily-at-fixed-time, etc.).
+// 12e.5c keeps the simple `every: ms` form.
 
 import { Queue, type JobsOptions } from "bullmq";
+import { db as defaultDb } from "../../db";
+import { ingestionSources } from "../../db/schema";
 import { getRedis, isRedisConfigured } from "../../lib/redis";
 import type { SourcePollJobInput } from "./sourcePollJob";
 
@@ -59,6 +65,94 @@ export async function closeSourcePollQueue(): Promise<void> {
     await cachedQueue.close().catch(() => undefined);
     cachedQueue = null;
   }
+}
+
+export interface ScheduleSourcePollDeps {
+  db?: typeof defaultDb;
+  queue?: Queue<SourcePollJobInput> | null;
+}
+
+export interface ScheduleSourcePollResult {
+  scheduled: number;
+  skipped: number;
+}
+
+/**
+ * Schedule one BullMQ repeatable job per enabled source, cadence driven
+ * by `ingestion_sources.fetch_interval_seconds`. Safe to call multiple
+ * times — BullMQ dedupes repeatable jobs by jobId. Returns
+ * `{ scheduled: 0, skipped: 0 }` when Redis is unavailable so server
+ * boot can log and continue.
+ *
+ * Per-source jobId is `repeat:poll:<slug>` — slug is unique per source
+ * (per the schema's UNIQUE constraint), so the dedup is well-defined.
+ *
+ * Cadence-change limitation: BullMQ's repeatable-job dedup is keyed on
+ * the (name + repeat-spec) pair, so changing `fetch_interval_seconds`
+ * between deploys creates a new repeatable schedule alongside the old
+ * one. 12e.5d will add a cleanup pass that removes stale schedules via
+ * `queue.removeRepeatableByKey`. For 12e.5c, cadences are expected to
+ * be stable across deploys and the leftover-schedule risk is accepted.
+ */
+export async function scheduleSourcePollRepeatable(
+  deps: ScheduleSourcePollDeps = {},
+): Promise<ScheduleSourcePollResult> {
+  const dbInstance = deps.db ?? defaultDb;
+  const queue = deps.queue ?? getSourcePollQueue();
+  if (!queue) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[signal-backend] source-poll scheduler not started (REDIS_URL not set)",
+    );
+    return { scheduled: 0, skipped: 0 };
+  }
+
+  const sources = await dbInstance
+    .select({
+      id: ingestionSources.id,
+      slug: ingestionSources.slug,
+      enabled: ingestionSources.enabled,
+      fetchIntervalSeconds: ingestionSources.fetchIntervalSeconds,
+    })
+    .from(ingestionSources);
+
+  let scheduled = 0;
+  let skipped = 0;
+
+  for (const source of sources) {
+    if (!source.enabled) {
+      skipped += 1;
+      continue;
+    }
+    // Defensive: schema declares fetch_interval_seconds NOT NULL with
+    // default 1800. A null or non-positive value is treated as
+    // "disabled-via-config" rather than scheduled at a degenerate
+    // interval.
+    if (
+      source.fetchIntervalSeconds == null ||
+      source.fetchIntervalSeconds <= 0
+    ) {
+      skipped += 1;
+      continue;
+    }
+    await queue.add(
+      SOURCE_POLL_JOB_NAME,
+      { sourceId: source.id, triggeredBy: "cron" },
+      {
+        jobId: `repeat:poll:${source.slug}`,
+        repeat: { every: source.fetchIntervalSeconds * 1000 },
+        removeOnComplete: { age: 86_400, count: 500 },
+        removeOnFail: { age: 604_800 },
+      },
+    );
+    scheduled += 1;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[signal-backend] source-poll scheduler started (sources=${scheduled}, skipped=${skipped})`,
+  );
+  return { scheduled, skipped };
 }
 
 // Test-only reset hook. Intentionally not exported from a barrel.

--- a/backend/src/jobs/ingestion/writeEvent.ts
+++ b/backend/src/jobs/ingestion/writeEvent.ts
@@ -177,35 +177,40 @@ export function computeContext(candidate: CandidateRowForWrite): string {
 }
 
 // Validate tier_outputs against TierTemplateSchema and stringify for
-// persistence. Returns null on validation failure (lenient at the
-// template field — events.why_it_matters covers the user-visible read
-// path via the always-non-null fallback chain). Logs a warning so
-// soak observability picks up the rare case. Exported for unit-testing
-// the validate-then-stringify pipeline in isolation.
+// persistence. STRICT-AT-WRITE: throws ZodError on null tier_outputs,
+// missing required keys, or any per-tier value failing TierOutputSchema.
+// Exported for unit-testing the validate-then-stringify pipeline in
+// isolation.
+//
+// The thrown error propagates out of writeEvent (computeWhyItMattersTemplate
+// is called before the db.transaction block, so no rollback is needed —
+// the transaction simply never starts) and into processEnrichmentJob's
+// try/catch around its writeEvent call, which surfaces it as
+// terminalStatus='failed' with 'write_event_error: <ZodError detail>'
+// in the result envelope. Sub-step 7 wires the BullMQ failed-handler
+// to capture the ZodError to Sentry for operator attention.
+//
+// Strict-at-write is the locked design (sub-step 3 correction): lenient-
+// at-write would silently land null templates for genuinely corrupted
+// tier_outputs, hiding data-quality failures from 12e.8 metrics until
+// the 12e.7 frontend integration surfaced them. The retry-stuck
+// disposition (per locked decision 4) is the right behavior for
+// genuinely corrupted state — forces operator attention rather than
+// silent data degradation.
+//
+// NOTE: events.why_it_matters_template uses the 12e.5b per-tier
+// {thesis, support} shape, asserted via assertTierTemplate. Existing
+// readers (v2/storiesController.ts, personalizationService.ts) parse
+// via parseWhyItMattersTemplate, which validates the legacy 12a
+// per-tier-string shape and returns null for this shape — so readers
+// currently fall back to events.why_it_matters. Reader-side migration
+// to parseTierTemplate is tracked separately (12e.7 frontend
+// event-rendering or earlier cleanup).
 export function computeWhyItMattersTemplate(
   candidate: CandidateRowForWrite,
-): string | null {
-  if (!candidate.tierOutputs) return null;
-  try {
-    const validated = assertTierTemplate(candidate.tierOutputs);
-    // NOTE: events.why_it_matters_template uses the 12e.5b per-tier
-    // {thesis, support} shape, asserted via assertTierTemplate above.
-    // Existing readers (v2/storiesController.ts, personalizationService.ts)
-    // parse via parseWhyItMattersTemplate, which validates the legacy
-    // 12a per-tier-string shape and returns null for this shape — so
-    // readers currently fall back to events.why_it_matters. Reader-side
-    // migration to parseTierTemplate is tracked separately (12e.7
-    // frontend event-rendering or earlier cleanup).
-    return JSON.stringify(validated);
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[ingestion-write-event] candidate=${candidate.id} tier_template_validation_failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-    return null;
-  }
+): string {
+  const validated = assertTierTemplate(candidate.tierOutputs);
+  return JSON.stringify(validated);
 }
 
 export async function writeEvent(

--- a/backend/src/jobs/ingestion/writeEvent.ts
+++ b/backend/src/jobs/ingestion/writeEvent.ts
@@ -1,0 +1,293 @@
+// Phase 12e.5c sub-step 3 — events row writer.
+//
+// Consumes one fully-extracted `ingestion_candidates` row (status =
+// 'tier_generated', `tier_outputs` complete with all three tiers) and
+// writes:
+//   1. One `events` row.
+//   2. One `event_sources` row with `role='primary'`.
+//   3. Updates the candidate's status to 'published', stamps
+//      `processed_at`, sets `resolved_event_id` to the new event's id.
+//
+// All three writes happen in a single Drizzle transaction so a partial-
+// success state is impossible: either all three land or none do.
+//
+// Field-mapping rules (locked in 12e.5c sub-step 3 brief):
+//   - `headline`            ← candidate.raw_title (truncated to 255 to
+//                             satisfy varchar constraint; real RSS
+//                             headlines don't approach this)
+//   - `context`             ← raw_summary if non-empty, else first 500
+//                             chars of body_text truncated at the last
+//                             whitespace boundary
+//   - `why_it_matters`      ← fallback chain: briefed.thesis →
+//                             accessible.thesis → technical.thesis →
+//                             synthesized floor (`raw_title: first fact`)
+//   - `why_it_matters_template` ← JSON.stringify(tier_outputs) after
+//                             assertTierTemplate validation. NULL only
+//                             if assertion fails (defensive — should
+//                             never happen if upstream tier orchestration
+//                             validated each tier's output via
+//                             TierOutputSchema before persisting).
+//   - `sector`              ← candidate.sector (NOT NULL on events;
+//                             populated by relevance gate upstream)
+//   - `primary_source_url`  ← candidate.url
+//   - `primary_source_name` ← linked source.display_name (always
+//                             non-null per ingestion_sources schema)
+//   - `author_id`           ← linked source.paired_writer_id (nullable)
+//   - `facts`               ← candidate.facts verbatim (NOT NULL,
+//                             default '{}'::jsonb on events; we always
+//                             write the validated facts blob)
+//   - `published_at`        ← candidate.raw_published_at, passed
+//                             through. Nullable on events; if the
+//                             article didn't carry a publication time,
+//                             leave null. Do NOT synthesize.
+//
+// Status semantics:
+//   - candidate.status: 'tier_generated' → 'published'
+//   - candidate.processed_at: now() (set inside the same transaction)
+//   - candidate.resolved_event_id: new events.id
+
+import { eq } from "drizzle-orm";
+
+import { db as defaultDb } from "../../db";
+import {
+  events,
+  eventSources,
+  ingestionCandidates,
+  ingestionSources,
+} from "../../db/schema";
+import { assertTierTemplate } from "../../utils/depthVariants";
+
+// Hard cap on events.headline length — the column is varchar(255) per
+// schema. Real RSS headlines almost never exceed ~150 chars; defensive
+// truncate handles edge cases without erroring on insert.
+const HEADLINE_MAX_CHARS = 255;
+
+// Soft cap on events.context length when synthesized from body_text.
+// 500 is a hand-picked balance between "enough for a reader to recognize
+// the story" and "small enough to avoid copy-pasting full articles."
+const CONTEXT_MAX_CHARS = 500;
+
+export interface WriteEventDeps {
+  db?: typeof defaultDb;
+  now?: () => Date;
+}
+
+export interface WriteEventResult {
+  eventId: string;
+}
+
+// Exported so unit tests of the pure helper functions can construct
+// minimal candidate rows without re-deriving the join shape.
+export interface CandidateRowForWrite {
+  id: string;
+  ingestionSourceId: string;
+  url: string;
+  rawTitle: string | null;
+  rawSummary: string | null;
+  rawPublishedAt: Date | null;
+  bodyText: string | null;
+  sector: string | null;
+  facts: Record<string, unknown> | null;
+  tierOutputs: Record<string, unknown> | null;
+  sourceDisplayName: string;
+  sourcePairedWriterId: string | null;
+}
+
+async function loadCandidateForWrite(
+  db: typeof defaultDb,
+  candidateId: string,
+): Promise<CandidateRowForWrite | null> {
+  const rows = await db
+    .select({
+      id: ingestionCandidates.id,
+      ingestionSourceId: ingestionCandidates.ingestionSourceId,
+      url: ingestionCandidates.url,
+      rawTitle: ingestionCandidates.rawTitle,
+      rawSummary: ingestionCandidates.rawSummary,
+      rawPublishedAt: ingestionCandidates.rawPublishedAt,
+      bodyText: ingestionCandidates.bodyText,
+      sector: ingestionCandidates.sector,
+      facts: ingestionCandidates.facts,
+      tierOutputs: ingestionCandidates.tierOutputs,
+      sourceDisplayName: ingestionSources.displayName,
+      sourcePairedWriterId: ingestionSources.pairedWriterId,
+    })
+    .from(ingestionCandidates)
+    .innerJoin(
+      ingestionSources,
+      eq(ingestionSources.id, ingestionCandidates.ingestionSourceId),
+    )
+    .where(eq(ingestionCandidates.id, candidateId))
+    .limit(1);
+  return (rows[0] as CandidateRowForWrite | undefined) ?? null;
+}
+
+// Locked fallback chain for events.why_it_matters (NOT NULL):
+// briefed.thesis → accessible.thesis → technical.thesis → synthesized
+// floor (`headline: first-fact-text`). The floor only fires when
+// tier_outputs is missing all thesis values AND facts has at least one
+// entry; otherwise we floor again to just `headline` (or "Untitled" if
+// that's also missing — last-ditch defensive value to satisfy NOT NULL).
+// Exported for unit-testing the fallback chain in isolation.
+export function computeWhyItMatters(candidate: CandidateRowForWrite): string {
+  const tiers = candidate.tierOutputs as
+    | { accessible?: { thesis?: string }; briefed?: { thesis?: string }; technical?: { thesis?: string } }
+    | null;
+  const briefed = tiers?.briefed?.thesis;
+  if (typeof briefed === "string" && briefed.length > 0) return briefed;
+  const accessible = tiers?.accessible?.thesis;
+  if (typeof accessible === "string" && accessible.length > 0) return accessible;
+  const technical = tiers?.technical?.thesis;
+  if (typeof technical === "string" && technical.length > 0) return technical;
+
+  // Floor: synthesize from headline + first fact text.
+  const headline = (candidate.rawTitle ?? "Untitled").trim();
+  const factsBlob = candidate.facts as
+    | { facts?: Array<{ text?: string }> }
+    | null;
+  const firstFactText = factsBlob?.facts?.[0]?.text?.trim();
+  if (firstFactText && firstFactText.length > 0) {
+    return `${headline}: ${firstFactText}`;
+  }
+  return headline;
+}
+
+// events.context (NOT NULL): raw_summary if non-empty, else first
+// CONTEXT_MAX_CHARS of body_text truncated at the last whitespace
+// boundary if possible. If body_text is also empty, fall back to
+// headline (defensive — schema requires non-null). Exported for
+// unit-testing the truncation logic in isolation.
+export function computeContext(candidate: CandidateRowForWrite): string {
+  const summary = candidate.rawSummary?.trim();
+  if (summary && summary.length > 0) return summary;
+  const body = candidate.bodyText?.trim();
+  if (body && body.length > 0) {
+    if (body.length <= CONTEXT_MAX_CHARS) return body;
+    const head = body.slice(0, CONTEXT_MAX_CHARS);
+    const lastSpace = head.lastIndexOf(" ");
+    // Only honor the word boundary if it falls in the latter half of
+    // the head — otherwise we'd chop off too much (rare but possible
+    // with very long single tokens).
+    if (lastSpace > CONTEXT_MAX_CHARS / 2) {
+      return head.slice(0, lastSpace);
+    }
+    return head;
+  }
+  return (candidate.rawTitle ?? "Untitled").trim();
+}
+
+// Validate tier_outputs against TierTemplateSchema and stringify for
+// persistence. Returns null on validation failure (lenient at the
+// template field — events.why_it_matters covers the user-visible read
+// path via the always-non-null fallback chain). Logs a warning so
+// soak observability picks up the rare case. Exported for unit-testing
+// the validate-then-stringify pipeline in isolation.
+export function computeWhyItMattersTemplate(
+  candidate: CandidateRowForWrite,
+): string | null {
+  if (!candidate.tierOutputs) return null;
+  try {
+    const validated = assertTierTemplate(candidate.tierOutputs);
+    // NOTE: events.why_it_matters_template uses the 12e.5b per-tier
+    // {thesis, support} shape, asserted via assertTierTemplate above.
+    // Existing readers (v2/storiesController.ts, personalizationService.ts)
+    // parse via parseWhyItMattersTemplate, which validates the legacy
+    // 12a per-tier-string shape and returns null for this shape — so
+    // readers currently fall back to events.why_it_matters. Reader-side
+    // migration to parseTierTemplate is tracked separately (12e.7
+    // frontend event-rendering or earlier cleanup).
+    return JSON.stringify(validated);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ingestion-write-event] candidate=${candidate.id} tier_template_validation_failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  }
+}
+
+export async function writeEvent(
+  candidateId: string,
+  deps: WriteEventDeps = {},
+): Promise<WriteEventResult> {
+  const db = deps.db ?? defaultDb;
+  const now = deps.now ?? ((): Date => new Date());
+
+  const candidate = await loadCandidateForWrite(db, candidateId);
+  if (!candidate) {
+    throw new Error(
+      `writeEvent: candidate ${candidateId} not found (or source join failed)`,
+    );
+  }
+  if (!candidate.sector) {
+    throw new Error(
+      `writeEvent: candidate ${candidateId} has null sector (relevance gate did not classify)`,
+    );
+  }
+
+  const headline = (candidate.rawTitle ?? "Untitled")
+    .trim()
+    .slice(0, HEADLINE_MAX_CHARS);
+  const context = computeContext(candidate);
+  const whyItMatters = computeWhyItMatters(candidate);
+  const whyItMattersTemplate = computeWhyItMattersTemplate(candidate);
+
+  // Validated facts blob (jsonb NOT NULL on events with default '{}').
+  // We pass through whatever upstream wrote to candidate.facts — the
+  // 12e.5a fact extraction path validates via ExtractedFactsSchema
+  // before persisting, so the shape is trustworthy by this point.
+  const factsBlob: Record<string, unknown> = candidate.facts ?? {};
+
+  return db.transaction(async (tx) => {
+    const insertedEvents = await tx
+      .insert(events)
+      .values({
+        sector: candidate.sector as string,
+        headline,
+        context,
+        whyItMatters,
+        whyItMattersTemplate,
+        primarySourceUrl: candidate.url,
+        primarySourceName: candidate.sourceDisplayName,
+        authorId: candidate.sourcePairedWriterId,
+        facts: factsBlob,
+        publishedAt: candidate.rawPublishedAt,
+      })
+      .returning({ id: events.id });
+
+    const inserted = insertedEvents[0];
+    if (!inserted) {
+      throw new Error(
+        `writeEvent: events insert returned no rows for candidate ${candidateId}`,
+      );
+    }
+    const eventId = inserted.id;
+
+    await tx.insert(eventSources).values({
+      eventId,
+      ingestionSourceId: candidate.ingestionSourceId,
+      url: candidate.url,
+      name: candidate.sourceDisplayName,
+      role: "primary",
+    });
+
+    await tx
+      .update(ingestionCandidates)
+      .set({
+        status: "published",
+        resolvedEventId: eventId,
+        statusReason: null,
+        processedAt: now(),
+      })
+      .where(eq(ingestionCandidates.id, candidateId));
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[ingestion-write-event] candidate=${candidateId} event=${eventId} sector=${candidate.sector} headline_len=${headline.length}`,
+    );
+
+    return { eventId };
+  });
+}

--- a/backend/src/lib/sentryHelpers.ts
+++ b/backend/src/lib/sentryHelpers.ts
@@ -1,0 +1,76 @@
+// Phase 12e.5c sub-step 6 — per-stage Sentry tagging convention for the
+// ingestion enrichment chain.
+//
+// Audit §6 found the codebase had essentially zero per-job Sentry
+// instrumentation (5 total call sites at audit time, none using
+// withScope/setTag). This helper establishes the convention: each
+// failure surfaced from a stage in `processEnrichmentJob` (relevance,
+// facts, tiers, write_event) goes through `captureIngestionStageFailure`,
+// which sets a uniform tag set so soak observability and 12e.8 metrics
+// can pivot by stage / candidate / source / rejection class.
+//
+// Scope isolation discipline:
+//   - The withScope callback runs SYNCHRONOUSLY. No `await` inside it.
+//     Concurrent ingestion jobs (BullMQ concurrency=2) would otherwise
+//     leak scope state across workers.
+//   - Callers do all `await`s BEFORE invoking this helper, then call it
+//     synchronously with the already-resolved rejection details.
+//   - The helper makes a single setTag-then-captureException pass and
+//     returns — nothing escapes the scope.
+//
+// The helper is a safe no-op when Sentry is not initialized (no
+// SENTRY_DSN). The Sentry SDK's calls already short-circuit in that
+// case; we don't need an explicit isSentryEnabled() guard.
+
+import * as Sentry from "@sentry/node";
+
+export type IngestionStage =
+  | "relevance"
+  | "facts"
+  | "tiers"
+  | "write_event";
+
+export interface IngestionStageFailureContext {
+  stage: IngestionStage;
+  candidateId: string;
+  // Slug of the ingestion source that produced the candidate. Optional —
+  // when the snapshot couldn't load (race condition, deleted candidate),
+  // the helper still captures with the stage + candidate_id tags but
+  // omits source_slug.
+  sourceSlug: string | null;
+  // Stable rejection-class string from the stage's *_REASONS taxonomy
+  // (e.g., "facts_parse_error", "TIER_TIMEOUT", "write_event_error").
+  // Used as a Sentry tag and as the captured-error message when no
+  // explicit error object is provided.
+  rejectionReason: string;
+  // Optional explicit error object to capture (e.g., a ZodError thrown
+  // by writeEvent's assertTierTemplate). When omitted, the helper
+  // synthesizes an Error from the rejection reason for capture.
+  err?: unknown;
+}
+
+/**
+ * Capture an ingestion-stage failure to Sentry with the canonical tag
+ * set. Synchronous; safe to call inside any branch that has already
+ * awaited the underlying stage call.
+ */
+export function captureIngestionStageFailure(
+  ctx: IngestionStageFailureContext,
+): void {
+  Sentry.withScope((scope) => {
+    scope.setTag("ingestion.stage", ctx.stage);
+    scope.setTag("ingestion.candidate_id", ctx.candidateId);
+    if (ctx.sourceSlug) {
+      scope.setTag("ingestion.source_slug", ctx.sourceSlug);
+    }
+    scope.setTag("ingestion.rejection_reason", ctx.rejectionReason);
+    const err =
+      ctx.err instanceof Error
+        ? ctx.err
+        : new Error(
+            `ingestion.${ctx.stage} failed: ${ctx.rejectionReason}` +
+              (ctx.err !== undefined ? ` (${String(ctx.err)})` : ""),
+          );
+    Sentry.captureException(err);
+  });
+}

--- a/backend/src/lib/sentryHelpers.ts
+++ b/backend/src/lib/sentryHelpers.ts
@@ -28,7 +28,15 @@ export type IngestionStage =
   | "relevance"
   | "facts"
   | "tiers"
-  | "write_event";
+  | "write_event"
+  // 12e.5c sub-step 7 — BullMQ-level failure, distinct from the
+  // orchestration-stage failures above. Fires from
+  // enrichmentWorker.ts's `failed` handler when a job throws past
+  // processEnrichmentJob's structured-envelope returns. Typically:
+  // unhandled exception in a seam, transient PG/Redis error during
+  // status writes, or any other error not caught and surfaced as a
+  // failed envelope upstream.
+  | "worker_failed";
 
 export interface IngestionStageFailureContext {
   stage: IngestionStage;
@@ -47,6 +55,12 @@ export interface IngestionStageFailureContext {
   // by writeEvent's assertTierTemplate). When omitted, the helper
   // synthesizes an Error from the rejection reason for capture.
   err?: unknown;
+  // Optional additional tags appended after the canonical four. Used by
+  // the worker's failed handler to surface BullMQ context (attempt
+  // count, queue name, etc.). Keys are forwarded verbatim — caller
+  // controls namespacing (recommend prefixing with the subsystem name,
+  // e.g., "bullmq.attempt").
+  extraTags?: Record<string, string>;
 }
 
 /**
@@ -64,6 +78,11 @@ export function captureIngestionStageFailure(
       scope.setTag("ingestion.source_slug", ctx.sourceSlug);
     }
     scope.setTag("ingestion.rejection_reason", ctx.rejectionReason);
+    if (ctx.extraTags) {
+      for (const [key, value] of Object.entries(ctx.extraTags)) {
+        scope.setTag(key, value);
+      }
+    }
     const err =
       ctx.err instanceof Error
         ? ctx.err

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -7,6 +7,7 @@ import { startEmailScheduler } from "./jobs/emailScheduler";
 import { startAggregationWorker } from "./jobs/aggregationWorker";
 import { scheduleAggregationRepeatable } from "./jobs/aggregationQueue";
 import { startSourcePollWorker } from "./jobs/ingestion/sourcePollWorker";
+import { scheduleSourcePollRepeatable } from "./jobs/ingestion/sourcePollQueue";
 import { startEnrichmentWorker } from "./jobs/ingestion/enrichmentWorker";
 
 initSentry();
@@ -28,11 +29,20 @@ void scheduleAggregationRepeatable().catch((err: unknown) => {
   console.error("[signal-backend] failed to schedule aggregation cron:", err);
 });
 
-// Phase 12e.1 — ingestion pipeline. Workers start as no-ops; live
-// adapter dispatch + enrichment land in 12e.2 onward. Both degrade
-// gracefully when REDIS_URL is unset (matches existing pattern).
+// Phase 12e.1 — ingestion pipeline. Both workers degrade gracefully
+// when REDIS_URL is unset (matches existing pattern). 12e.5c sub-step
+// 5 adds per-source cadence scheduling: scheduleSourcePollRepeatable
+// creates one BullMQ repeatable job per enabled source, cadence driven
+// by ingestion_sources.fetch_interval_seconds.
 startSourcePollWorker();
 startEnrichmentWorker();
+void scheduleSourcePollRepeatable().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(
+    "[signal-backend] failed to schedule source-poll cadences:",
+    err,
+  );
+});
 // eslint-disable-next-line no-console
 console.log("[signal-backend] ingestion workers online");
 

--- a/backend/src/utils/depthVariants.ts
+++ b/backend/src/utils/depthVariants.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { DEPTH_LEVELS, type WhyItMattersTemplate } from "../db/schema";
+import { TierOutputSchema } from "../jobs/ingestion/tierGenerationSeam";
 
 /**
  * Runtime validator for the depth-variant `why_it_matters_template` shape.
@@ -14,6 +15,26 @@ export const WhyItMattersTemplateSchema = z
     technical: z.string().min(1),
   })
   .strict();
+
+/**
+ * Runtime validator for the 12e.5b per-tier `{thesis, support}` shape.
+ * Distinct from `WhyItMattersTemplateSchema` (legacy 12a per-tier-string
+ * shape) — both shapes coexist in the codebase:
+ *   - `stories.why_it_matters_template` carries the legacy shape (12a).
+ *   - `events.why_it_matters_template` carries this new shape (12e.5b),
+ *     written by `writeEvent` in the ingestion pipeline.
+ * Reuses `TierOutputSchema` (single source of truth for the per-tier
+ * payload) from the tier-generation seam.
+ */
+export const TierTemplateSchema = z
+  .object({
+    accessible: TierOutputSchema,
+    briefed: TierOutputSchema,
+    technical: TierOutputSchema,
+  })
+  .strict();
+
+export type TierTemplate = z.infer<typeof TierTemplateSchema>;
 
 /**
  * Parses the JSON-encoded TEXT column. Returns `null` — not throwing — for
@@ -49,6 +70,43 @@ export function parseWhyItMattersTemplate(
  */
 export function assertWhyItMattersTemplate(raw: unknown): WhyItMattersTemplate {
   return WhyItMattersTemplateSchema.parse(raw);
+}
+
+/**
+ * Strict-at-write variant for the 12e.5b per-tier shape. Used by
+ * `writeEvent` (jobs/ingestion/writeEvent.ts) to validate the
+ * `tier_outputs` payload before stringifying it into
+ * `events.why_it_matters_template`. Throws on shape mismatch — by the
+ * time `writeEvent` runs, the payload has already been validated by
+ * `TierOutputSchema` per-tier inside `tierGenerationSeam.ts`, so a
+ * failure here is a real bug worth surfacing loudly.
+ */
+export function assertTierTemplate(raw: unknown): TierTemplate {
+  return TierTemplateSchema.parse(raw);
+}
+
+/**
+ * Lenient counterpart to `assertTierTemplate`. Returns `null` on the
+ * legacy 12a per-tier-string shape, malformed JSON, etc. Reader-side
+ * code paths that consume `events.why_it_matters_template` should use
+ * this; readers that still use `parseWhyItMattersTemplate` (legacy
+ * shape) will return null for the new shape and fall back to
+ * `events.why_it_matters` (the role-neutral string written alongside).
+ * Reader-side migration to this function is tracked separately.
+ */
+export function parseTierTemplate(
+  raw: string | null | undefined,
+): TierTemplate | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const result = TierTemplateSchema.safeParse(parsed);
+  if (!result.success) return null;
+  return result.data;
 }
 
 export { DEPTH_LEVELS };

--- a/backend/tests/helpers/mockDb.ts
+++ b/backend/tests/helpers/mockDb.ts
@@ -3,6 +3,11 @@
 interface MockDbState {
   selectResults: any[][];
   insertResults: any[][];
+  // Tracks the values payload passed to each `db.insert(table).values(...)`
+  // call, in invocation order. Lets tests assert on the precise insert
+  // shape (table-row contents) without re-deriving them from the
+  // returning() result.
+  insertedValues: any[];
   updatedRows: any[];
   deletes: unknown[];
   executes: unknown[];
@@ -35,7 +40,10 @@ function makeSelectChain(pullResult: () => any[]): any {
   return chain;
 }
 
-function makeInsertChain(pullResult: () => any[]): any {
+function makeInsertChain(
+  pullResult: () => any[],
+  trackInsert: (values: any) => void,
+): any {
   const valuesChain: any = {};
   valuesChain.returning = () => Promise.resolve(pullResult());
   valuesChain.onConflictDoNothing = () => valuesChain;
@@ -45,7 +53,10 @@ function makeInsertChain(pullResult: () => any[]): any {
   valuesChain.catch = (onRejected: any) => Promise.resolve(pullResult()).catch(onRejected);
 
   const chain: any = {};
-  chain.values = () => valuesChain;
+  chain.values = (values: any) => {
+    trackInsert(values);
+    return valuesChain;
+  };
   return chain;
 }
 
@@ -86,6 +97,7 @@ export function createMockDb(): MockDb {
   const state: MockDbState = {
     selectResults: [],
     insertResults: [],
+    insertedValues: [],
     updatedRows: [],
     deletes: [],
     executes: [],
@@ -93,6 +105,9 @@ export function createMockDb(): MockDb {
 
   const pullSelect = (): any[] => state.selectResults.shift() ?? [];
   const pullInsert = (): any[] => state.insertResults.shift() ?? [];
+  const trackInsert = (values: any): void => {
+    state.insertedValues.push(values);
+  };
   const trackUpdate = (row: any): void => {
     state.updatedRows.push(row);
   };
@@ -102,7 +117,7 @@ export function createMockDb(): MockDb {
 
   const db: any = {
     select: () => makeSelectChain(pullSelect),
-    insert: () => makeInsertChain(pullInsert),
+    insert: () => makeInsertChain(pullInsert, trackInsert),
     update: () => makeUpdateChain(trackUpdate, pullInsert),
     delete: () => makeDeleteChain(trackDelete),
     execute: async (stmt: unknown) => {
@@ -124,6 +139,7 @@ export function createMockDb(): MockDb {
     reset: () => {
       state.selectResults.length = 0;
       state.insertResults.length = 0;
+      state.insertedValues.length = 0;
       state.updatedRows.length = 0;
       state.deletes.length = 0;
       state.executes.length = 0;

--- a/backend/tests/ingestion/enrichmentJob.test.ts
+++ b/backend/tests/ingestion/enrichmentJob.test.ts
@@ -802,7 +802,14 @@ describe("processEnrichmentJob", () => {
       return { runHeuristic, runRelevanceGate, extractFacts };
     }
 
-    it("full chain on a fresh candidate produces terminalStatus=tier_generated", async () => {
+    it("full chain on a fresh candidate produces terminalStatus=published (post-sub-step-3 wiring)", async () => {
+      // Sub-step 2 originally asserted terminalStatus=tier_generated as
+      // the chain's terminal, but sub-step 3 extends the chain through
+      // writeEvent. With both wired, full happy-path lands at
+      // 'published'. We still verify the upstream seams + tier
+      // orchestration ran exactly once (sub-step 2's intent), and
+      // additionally that writeEvent is invoked on tier completion
+      // (sub-step 3's intent).
       const { runHeuristic, runRelevanceGate, extractFacts } = fullSeamSet();
       const processTier = jest.fn().mockResolvedValue({
         candidateId: CANDIDATE_ID,
@@ -811,17 +818,23 @@ describe("processEnrichmentJob", () => {
         failedTier: null,
         completed: true,
       });
+      const writeEventMock = jest
+        .fn()
+        .mockResolvedValue({ eventId: "55555555-5555-5555-5555-555555555555" });
       const result = await processEnrichmentJob(
         { candidateId: CANDIDATE_ID },
         {
           db: mock.db,
           seams: { runHeuristic, runRelevanceGate, extractFacts },
           processTier,
+          writeEvent: writeEventMock,
         },
       );
-      expect(result.terminalStatus).toBe("tier_generated");
+      expect(result.terminalStatus).toBe("published");
       expect(result.failureReason).toBeNull();
-      expect(result.resolvedEventId).toBeNull();
+      expect(result.resolvedEventId).toBe(
+        "55555555-5555-5555-5555-555555555555",
+      );
       // All upstream seams ran exactly once.
       expect(runHeuristic).toHaveBeenCalledTimes(1);
       expect(runRelevanceGate).toHaveBeenCalledTimes(1);
@@ -829,6 +842,8 @@ describe("processEnrichmentJob", () => {
       // Tier orchestrator invoked with the candidate id + db dep.
       expect(processTier).toHaveBeenCalledTimes(1);
       expect(processTier).toHaveBeenCalledWith(CANDIDATE_ID, { db: mock.db });
+      // writeEvent invoked after tier completion.
+      expect(writeEventMock).toHaveBeenCalledTimes(1);
     });
 
     it("tier-stage failure propagates as terminalStatus=failed with failed-tier reason", async () => {
@@ -899,19 +914,157 @@ describe("processEnrichmentJob", () => {
         failedTier: null,
         completed: true,
       });
+      // Without writeEvent injection, sub-step 3's wiring would call
+      // the real writeEvent which fails on the empty mock. Inject a
+      // succeeding mock so we can isolate the tier-orchestration cross-
+      // cut from the writeEvent path.
+      const writeEventMock = jest
+        .fn()
+        .mockResolvedValue({ eventId: "EVENT_ID" });
       const result = await processEnrichmentJob(
         { candidateId: CANDIDATE_ID },
         {
           db: mock.db,
           seams: { runHeuristic, runRelevanceGate, extractFacts },
           processTier,
+          writeEvent: writeEventMock,
         },
       );
       expect(runHeuristic).toHaveBeenCalledTimes(1);
       expect(runRelevanceGate).not.toHaveBeenCalled();
       expect(extractFacts).not.toHaveBeenCalled();
       expect(processTier).toHaveBeenCalledTimes(1);
-      expect(result.terminalStatus).toBe("tier_generated");
+      expect(writeEventMock).toHaveBeenCalledTimes(1);
+      // Now with sub-step 3 wired, the chain continues past tier_generated
+      // through writeEvent and lands at terminalStatus='published'.
+      expect(result.terminalStatus).toBe("published");
+    });
+  });
+
+  describe("12e.5c sub-step 3: writeEvent wiring", () => {
+    const passingHeuristic = {
+      pass: true,
+      body: { text: "article body for the test", truncated: false },
+    };
+
+    function fullSeams() {
+      return {
+        runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+        runRelevanceGate: jest.fn().mockResolvedValue({
+          relevant: true,
+          sector: "ai",
+          reason: "x",
+        }),
+        extractFacts: jest.fn().mockResolvedValue({
+          ok: true,
+          facts: { facts: [{ text: "fact text >=10 chars", category: "actor" }] },
+        }),
+      };
+    }
+
+    it("tier success → writeEvent called → terminalStatus=published with eventId", async () => {
+      const seams = fullSeams();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: ["accessible", "briefed", "technical"],
+        skippedTiers: [],
+        failedTier: null,
+        completed: true,
+      });
+      const writeEventMock = jest
+        .fn()
+        .mockResolvedValue({ eventId: "44444444-4444-4444-4444-444444444444" });
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams,
+          processTier,
+          writeEvent: writeEventMock,
+        },
+      );
+      expect(writeEventMock).toHaveBeenCalledTimes(1);
+      expect(writeEventMock).toHaveBeenCalledWith(CANDIDATE_ID, { db: mock.db });
+      expect(result.terminalStatus).toBe("published");
+      expect(result.failureReason).toBeNull();
+      expect(result.resolvedEventId).toBe(
+        "44444444-4444-4444-4444-444444444444",
+      );
+    });
+
+    it("writeEvent throw → caught and surfaced as terminalStatus=failed with write_event_error prefix", async () => {
+      const seams = fullSeams();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: ["accessible", "briefed", "technical"],
+        skippedTiers: [],
+        failedTier: null,
+        completed: true,
+      });
+      const writeEventMock = jest
+        .fn()
+        .mockRejectedValue(new Error("simulated DB error"));
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams,
+          processTier,
+          writeEvent: writeEventMock,
+        },
+      );
+      expect(writeEventMock).toHaveBeenCalledTimes(1);
+      expect(result.terminalStatus).toBe("failed");
+      expect(result.failureReason).toMatch(/^write_event_error: /);
+      expect(result.failureReason).toContain("simulated DB error");
+      expect(result.resolvedEventId).toBeNull();
+    });
+
+    it("writeEvent NOT called when tier orchestration fails", async () => {
+      const seams = fullSeams();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: ["accessible"],
+        skippedTiers: [],
+        failedTier: { tier: "briefed", reason: "TIER_TIMEOUT" },
+        completed: false,
+      });
+      const writeEventMock = jest.fn();
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams,
+          processTier,
+          writeEvent: writeEventMock,
+        },
+      );
+      expect(writeEventMock).not.toHaveBeenCalled();
+      expect(result.terminalStatus).toBe("failed");
+      expect(result.failureReason).toBe("TIER_TIMEOUT");
+    });
+
+    it("writeEvent NOT called when tier orchestration neither completed nor failed", async () => {
+      const seams = fullSeams();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: [],
+        skippedTiers: [],
+        failedTier: null,
+        completed: false,
+      });
+      const writeEventMock = jest.fn();
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams,
+          processTier,
+          writeEvent: writeEventMock,
+        },
+      );
+      expect(writeEventMock).not.toHaveBeenCalled();
+      expect(result.terminalStatus).toBe("facts_extracted");
     });
   });
 });

--- a/backend/tests/ingestion/enrichmentJob.test.ts
+++ b/backend/tests/ingestion/enrichmentJob.test.ts
@@ -516,4 +516,269 @@ describe("processEnrichmentJob", () => {
       expect(extractFacts).not.toHaveBeenCalled();
     });
   });
+
+  describe("12e.5c short-circuits (whole-job + per-stage)", () => {
+    // Helper: queue the snapshot-row select with the given persisted state.
+    // The snapshot read is the FIRST select in `processEnrichmentJob`; later
+    // selects (if any) are not used by the orchestration body itself.
+    function queueSnapshot(rows: Record<string, unknown>[]): void {
+      mock.queueSelect(rows);
+    }
+
+    function fullSeams(): {
+      seams: EnrichmentSeams;
+      runHeuristic: jest.Mock;
+      runRelevanceGate: jest.Mock;
+      extractFacts: jest.Mock;
+    } {
+      const runHeuristic = jest.fn();
+      const runRelevanceGate = jest.fn();
+      const extractFacts = jest.fn();
+      return {
+        seams: { runHeuristic, runRelevanceGate, extractFacts },
+        runHeuristic,
+        runRelevanceGate,
+        extractFacts,
+      };
+    }
+
+    describe("whole-job short-circuit on terminal-state snapshot", () => {
+      it.each([
+        ["heuristic_filtered", "recency_too_old"],
+        ["llm_rejected", "llm_rejected"],
+        ["failed", "facts_parse_error"],
+      ])(
+        "terminal-rejection %s — zero seam invocations, envelope echoes status_reason",
+        async (status, statusReason) => {
+          queueSnapshot([
+            {
+              status,
+              statusReason,
+              llmJudgmentRaw: null,
+              factsExtractedAt: null,
+              tierOutputs: null,
+              resolvedEventId: null,
+            },
+          ]);
+          const { seams, runHeuristic, runRelevanceGate, extractFacts } =
+            fullSeams();
+          const result = await processEnrichmentJob(
+            { candidateId: CANDIDATE_ID },
+            { db: mock.db, seams },
+          );
+          expect(result.terminalStatus).toBe(status);
+          expect(result.failureReason).toBe(statusReason);
+          expect(result.resolvedEventId).toBeNull();
+          // No seam ran.
+          expect(runHeuristic).not.toHaveBeenCalled();
+          expect(runRelevanceGate).not.toHaveBeenCalled();
+          expect(extractFacts).not.toHaveBeenCalled();
+          // No DB writes.
+          expect(mock.state.updatedRows.length).toBe(0);
+        },
+      );
+
+      it("terminal-success tier_generated — zero seam invocations, failureReason null", async () => {
+        queueSnapshot([
+          {
+            status: "tier_generated",
+            statusReason: null,
+            llmJudgmentRaw: { fake: true },
+            factsExtractedAt: new Date("2026-04-28T00:00:00Z"),
+            tierOutputs: { accessible: {}, briefed: {}, technical: {} },
+            resolvedEventId: null,
+          },
+        ]);
+        const { seams, runHeuristic, runRelevanceGate, extractFacts } =
+          fullSeams();
+        const result = await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          { db: mock.db, seams },
+        );
+        expect(result.terminalStatus).toBe("tier_generated");
+        expect(result.failureReason).toBeNull();
+        expect(runHeuristic).not.toHaveBeenCalled();
+        expect(runRelevanceGate).not.toHaveBeenCalled();
+        expect(extractFacts).not.toHaveBeenCalled();
+        expect(mock.state.updatedRows.length).toBe(0);
+      });
+
+      it("terminal-success published — envelope carries resolvedEventId from snapshot", async () => {
+        const eventId = "11111111-1111-1111-1111-111111111111";
+        queueSnapshot([
+          {
+            status: "published",
+            statusReason: null,
+            llmJudgmentRaw: { fake: true },
+            factsExtractedAt: new Date(),
+            tierOutputs: { accessible: {}, briefed: {}, technical: {} },
+            resolvedEventId: eventId,
+          },
+        ]);
+        const { seams, runHeuristic, runRelevanceGate, extractFacts } =
+          fullSeams();
+        const result = await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          { db: mock.db, seams },
+        );
+        expect(result.terminalStatus).toBe("published");
+        expect(result.failureReason).toBeNull();
+        expect(result.resolvedEventId).toBe(eventId);
+        expect(runHeuristic).not.toHaveBeenCalled();
+        expect(runRelevanceGate).not.toHaveBeenCalled();
+        expect(extractFacts).not.toHaveBeenCalled();
+      });
+
+      it("terminal-rejection with NULL status_reason falls back to 'unknown'", async () => {
+        queueSnapshot([
+          {
+            status: "failed",
+            statusReason: null,
+            llmJudgmentRaw: null,
+            factsExtractedAt: null,
+            tierOutputs: null,
+            resolvedEventId: null,
+          },
+        ]);
+        const { seams } = fullSeams();
+        const result = await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          { db: mock.db, seams },
+        );
+        expect(result.terminalStatus).toBe("failed");
+        expect(result.failureReason).toBe("unknown");
+      });
+    });
+
+    describe("per-stage short-circuit (relevance / facts already ran)", () => {
+      const passingHeuristic = {
+        pass: true,
+        body: { text: "article body for the test", truncated: false },
+      };
+
+      it("skips runRelevanceGate when llm_judgment_raw set + status past heuristic_passed", async () => {
+        queueSnapshot([
+          {
+            status: "llm_relevant",
+            statusReason: null,
+            llmJudgmentRaw: { fake: true },
+            factsExtractedAt: null,
+            tierOutputs: null,
+            resolvedEventId: null,
+          },
+        ]);
+        const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+        const runRelevanceGate = jest.fn();
+        const extractFacts = jest.fn().mockResolvedValue({
+          ok: true,
+          facts: { facts: [] },
+        });
+        const result = await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          {
+            db: mock.db,
+            seams: { runHeuristic, runRelevanceGate, extractFacts },
+          },
+        );
+        // Heuristic re-ran (idempotent re-pass), facts ran. Relevance was
+        // skipped because the snapshot showed it already produced a verdict.
+        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        expect(runRelevanceGate).not.toHaveBeenCalled();
+        expect(extractFacts).toHaveBeenCalledTimes(1);
+        expect(result.terminalStatus).toBe("facts_extracted");
+      });
+
+      it("skips extractFacts when facts_extracted_at set", async () => {
+        queueSnapshot([
+          {
+            status: "facts_extracted",
+            statusReason: null,
+            llmJudgmentRaw: { fake: true },
+            factsExtractedAt: new Date("2026-04-28T00:00:00Z"),
+            tierOutputs: null,
+            resolvedEventId: null,
+          },
+        ]);
+        const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+        const runRelevanceGate = jest.fn();
+        const extractFacts = jest.fn();
+        const result = await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          {
+            db: mock.db,
+            seams: { runHeuristic, runRelevanceGate, extractFacts },
+          },
+        );
+        // Heuristic re-ran. Both relevance + facts skipped (snapshot showed
+        // them done). Result envelope echoes the fall-through facts_extracted.
+        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        expect(runRelevanceGate).not.toHaveBeenCalled();
+        expect(extractFacts).not.toHaveBeenCalled();
+        expect(result.terminalStatus).toBe("facts_extracted");
+        expect(result.failureReason).toBeNull();
+      });
+
+      it("does NOT short-circuit relevance on heuristic_passed snapshot (no llm_judgment_raw yet)", async () => {
+        queueSnapshot([
+          {
+            status: "heuristic_passed",
+            statusReason: null,
+            llmJudgmentRaw: null,
+            factsExtractedAt: null,
+            tierOutputs: null,
+            resolvedEventId: null,
+          },
+        ]);
+        const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+        const runRelevanceGate = jest.fn().mockResolvedValue({
+          relevant: true,
+          sector: "ai",
+          reason: "x",
+        });
+        const extractFacts = jest.fn().mockResolvedValue({
+          ok: true,
+          facts: { facts: [] },
+        });
+        await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          {
+            db: mock.db,
+            seams: { runHeuristic, runRelevanceGate, extractFacts },
+          },
+        );
+        // All three stages ran — no short-circuit fires for a fresh
+        // 'heuristic_passed' candidate that hasn't seen relevance.
+        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        expect(runRelevanceGate).toHaveBeenCalledTimes(1);
+        expect(extractFacts).toHaveBeenCalledTimes(1);
+      });
+
+      it("does NOT short-circuit when snapshot is null (e.g., row not found)", async () => {
+        // Empty select result → snapshot is null → all stages run as
+        // before (preserves backward compatibility with existing tests
+        // that never queued a snapshot).
+        queueSnapshot([]);
+        const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+        const runRelevanceGate = jest.fn().mockResolvedValue({
+          relevant: true,
+          sector: "ai",
+          reason: "x",
+        });
+        const extractFacts = jest.fn().mockResolvedValue({
+          ok: true,
+          facts: { facts: [] },
+        });
+        await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          {
+            db: mock.db,
+            seams: { runHeuristic, runRelevanceGate, extractFacts },
+          },
+        );
+        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        expect(runRelevanceGate).toHaveBeenCalledTimes(1);
+        expect(extractFacts).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
 });

--- a/backend/tests/ingestion/enrichmentJob.test.ts
+++ b/backend/tests/ingestion/enrichmentJob.test.ts
@@ -1067,4 +1067,284 @@ describe("processEnrichmentJob", () => {
       expect(result.terminalStatus).toBe("facts_extracted");
     });
   });
+
+  describe("12e.5c sub-step 6: per-stage Sentry capture", () => {
+    const passingHeuristic = {
+      pass: true,
+      body: { text: "article body for the test", truncated: false },
+    };
+
+    function snapshotWithSlug(slug: string | null): Record<string, unknown> {
+      return {
+        status: "discovered",
+        statusReason: null,
+        llmJudgmentRaw: null,
+        factsExtractedAt: null,
+        tierOutputs: null,
+        resolvedEventId: null,
+        sourceSlug: slug,
+      };
+    }
+
+    it("relevance rejection → captureFailure called with stage='relevance' + sourceSlug", async () => {
+      mock.queueSelect([snapshotWithSlug("cnbc-markets")]);
+      const captureFailure = jest.fn();
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: false,
+              rejectionReason: "llm_rejected",
+              reason: "sports content",
+            }),
+          },
+          captureFailure,
+        },
+      );
+      expect(result.terminalStatus).toBe("llm_rejected");
+      expect(captureFailure).toHaveBeenCalledTimes(1);
+      expect(captureFailure).toHaveBeenCalledWith({
+        stage: "relevance",
+        candidateId: CANDIDATE_ID,
+        sourceSlug: "cnbc-markets",
+        rejectionReason: "llm_rejected",
+      });
+    });
+
+    it("facts rejection → captureFailure called with stage='facts'", async () => {
+      mock.queueSelect([snapshotWithSlug("import-ai")]);
+      const captureFailure = jest.fn();
+      await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: true,
+              sector: "ai",
+              reason: "x",
+            }),
+            extractFacts: jest.fn().mockResolvedValue({
+              ok: false,
+              rejectionReason: "facts_timeout",
+            }),
+          },
+          captureFailure,
+        },
+      );
+      expect(captureFailure).toHaveBeenCalledTimes(1);
+      expect(captureFailure).toHaveBeenCalledWith({
+        stage: "facts",
+        candidateId: CANDIDATE_ID,
+        sourceSlug: "import-ai",
+        rejectionReason: "facts_timeout",
+      });
+    });
+
+    it("tier rejection → captureFailure called with stage='tiers' + tier:reason composite", async () => {
+      mock.queueSelect([snapshotWithSlug("bloomberg-markets")]);
+      const captureFailure = jest.fn();
+      await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: true,
+              sector: "finance",
+              reason: "x",
+            }),
+            extractFacts: jest.fn().mockResolvedValue({
+              ok: true,
+              facts: { facts: [] },
+            }),
+          },
+          processTier: jest.fn().mockResolvedValue({
+            candidateId: CANDIDATE_ID,
+            ranTiers: ["accessible"],
+            skippedTiers: [],
+            failedTier: { tier: "briefed", reason: "TIER_RATE_LIMITED" },
+            completed: false,
+          }),
+          captureFailure,
+        },
+      );
+      expect(captureFailure).toHaveBeenCalledTimes(1);
+      expect(captureFailure).toHaveBeenCalledWith({
+        stage: "tiers",
+        candidateId: CANDIDATE_ID,
+        sourceSlug: "bloomberg-markets",
+        rejectionReason: "briefed:TIER_RATE_LIMITED",
+      });
+    });
+
+    it("writeEvent throw → captureFailure called with stage='write_event' and original Error", async () => {
+      mock.queueSelect([snapshotWithSlug("arstechnica-ai")]);
+      const captureFailure = jest.fn();
+      const originalError = new Error("PG constraint violation");
+      await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: true,
+              sector: "ai",
+              reason: "x",
+            }),
+            extractFacts: jest.fn().mockResolvedValue({
+              ok: true,
+              facts: { facts: [] },
+            }),
+          },
+          processTier: jest.fn().mockResolvedValue({
+            candidateId: CANDIDATE_ID,
+            ranTiers: ["accessible", "briefed", "technical"],
+            skippedTiers: [],
+            failedTier: null,
+            completed: true,
+          }),
+          writeEvent: jest.fn().mockRejectedValue(originalError),
+          captureFailure,
+        },
+      );
+      expect(captureFailure).toHaveBeenCalledTimes(1);
+      const call = captureFailure.mock.calls[0][0];
+      expect(call.stage).toBe("write_event");
+      expect(call.candidateId).toBe(CANDIDATE_ID);
+      expect(call.sourceSlug).toBe("arstechnica-ai");
+      expect(call.rejectionReason).toMatch(/^write_event_error: PG constraint/);
+      expect(call.err).toBe(originalError);
+    });
+
+    it("tier indeterminate (defensive) → captureFailure called with tier_orchestration_indeterminate", async () => {
+      mock.queueSelect([snapshotWithSlug("semianalysis")]);
+      const captureFailure = jest.fn();
+      await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: true,
+              sector: "semiconductors",
+              reason: "x",
+            }),
+            extractFacts: jest.fn().mockResolvedValue({
+              ok: true,
+              facts: { facts: [] },
+            }),
+          },
+          processTier: jest.fn().mockResolvedValue({
+            candidateId: CANDIDATE_ID,
+            ranTiers: [],
+            skippedTiers: [],
+            failedTier: null,
+            completed: false,
+          }),
+          captureFailure,
+        },
+      );
+      expect(captureFailure).toHaveBeenCalledTimes(1);
+      expect(captureFailure).toHaveBeenCalledWith({
+        stage: "tiers",
+        candidateId: CANDIDATE_ID,
+        sourceSlug: "semianalysis",
+        rejectionReason: "tier_orchestration_indeterminate",
+      });
+    });
+
+    it("happy-path success → captureFailure NOT called", async () => {
+      mock.queueSelect([snapshotWithSlug("cnbc-markets")]);
+      const captureFailure = jest.fn();
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: true,
+              sector: "finance",
+              reason: "x",
+            }),
+            extractFacts: jest.fn().mockResolvedValue({
+              ok: true,
+              facts: { facts: [] },
+            }),
+          },
+          processTier: jest.fn().mockResolvedValue({
+            candidateId: CANDIDATE_ID,
+            ranTiers: ["accessible", "briefed", "technical"],
+            skippedTiers: [],
+            failedTier: null,
+            completed: true,
+          }),
+          writeEvent: jest.fn().mockResolvedValue({ eventId: "EVENT_ID" }),
+          captureFailure,
+        },
+      );
+      expect(result.terminalStatus).toBe("published");
+      expect(captureFailure).not.toHaveBeenCalled();
+    });
+
+    it("sourceSlug=null (snapshot join couldn't resolve) → captureFailure called with sourceSlug=null", async () => {
+      mock.queueSelect([snapshotWithSlug(null)]);
+      const captureFailure = jest.fn();
+      await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: false,
+              rejectionReason: "llm_rejected",
+            }),
+          },
+          captureFailure,
+        },
+      );
+      expect(captureFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceSlug: null }),
+      );
+    });
+
+    it("snapshot=null (row missing) → captureFailure still fires with sourceSlug=null", async () => {
+      // No snapshot queued → mockDb returns [] → snapshot=null. The
+      // captureFailure call must still fire for any stage rejection
+      // and gracefully omit/null the slug.
+      mock.queueSelect([]);
+      const captureFailure = jest.fn();
+      await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: {
+            runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+            runRelevanceGate: jest.fn().mockResolvedValue({
+              relevant: false,
+              rejectionReason: "llm_timeout",
+            }),
+          },
+          captureFailure,
+        },
+      );
+      expect(captureFailure).toHaveBeenCalledTimes(1);
+      expect(captureFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stage: "relevance",
+          sourceSlug: null,
+          rejectionReason: "llm_timeout",
+        }),
+      );
+    });
+  });
 });

--- a/backend/tests/ingestion/enrichmentJob.test.ts
+++ b/backend/tests/ingestion/enrichmentJob.test.ts
@@ -781,4 +781,137 @@ describe("processEnrichmentJob", () => {
       });
     });
   });
+
+  describe("12e.5c sub-step 2: tier-orchestration wiring", () => {
+    const passingHeuristic = {
+      pass: true,
+      body: { text: "article body for the test", truncated: false },
+    };
+
+    function fullSeamSet() {
+      const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+      const runRelevanceGate = jest.fn().mockResolvedValue({
+        relevant: true,
+        sector: "ai",
+        reason: "x",
+      });
+      const extractFacts = jest.fn().mockResolvedValue({
+        ok: true,
+        facts: { facts: [{ text: "fact text >=10 chars", category: "actor" }] },
+      });
+      return { runHeuristic, runRelevanceGate, extractFacts };
+    }
+
+    it("full chain on a fresh candidate produces terminalStatus=tier_generated", async () => {
+      const { runHeuristic, runRelevanceGate, extractFacts } = fullSeamSet();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: ["accessible", "briefed", "technical"],
+        skippedTiers: [],
+        failedTier: null,
+        completed: true,
+      });
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { runHeuristic, runRelevanceGate, extractFacts },
+          processTier,
+        },
+      );
+      expect(result.terminalStatus).toBe("tier_generated");
+      expect(result.failureReason).toBeNull();
+      expect(result.resolvedEventId).toBeNull();
+      // All upstream seams ran exactly once.
+      expect(runHeuristic).toHaveBeenCalledTimes(1);
+      expect(runRelevanceGate).toHaveBeenCalledTimes(1);
+      expect(extractFacts).toHaveBeenCalledTimes(1);
+      // Tier orchestrator invoked with the candidate id + db dep.
+      expect(processTier).toHaveBeenCalledTimes(1);
+      expect(processTier).toHaveBeenCalledWith(CANDIDATE_ID, { db: mock.db });
+    });
+
+    it("tier-stage failure propagates as terminalStatus=failed with failed-tier reason", async () => {
+      const { runHeuristic, runRelevanceGate, extractFacts } = fullSeamSet();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: ["accessible", "briefed"],
+        skippedTiers: [],
+        failedTier: { tier: "technical", reason: "TIER_PARSE_ERROR" },
+        completed: false,
+      });
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { runHeuristic, runRelevanceGate, extractFacts },
+          processTier,
+        },
+      );
+      expect(result.terminalStatus).toBe("failed");
+      expect(result.failureReason).toBe("TIER_PARSE_ERROR");
+      // The orchestrator owns the DB write that sets status_reason; this
+      // mock-injected version doesn't write, so we only assert the
+      // envelope here.
+    });
+
+    it("tier orchestration neither completed nor failed → fall-through terminal facts_extracted", async () => {
+      const { runHeuristic, runRelevanceGate, extractFacts } = fullSeamSet();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: [],
+        skippedTiers: [],
+        failedTier: null,
+        completed: false,
+      });
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { runHeuristic, runRelevanceGate, extractFacts },
+          processTier,
+        },
+      );
+      expect(result.terminalStatus).toBe("facts_extracted");
+      expect(result.failureReason).toBeNull();
+    });
+
+    it("tier-stage runs even when relevance + facts short-circuit from snapshot", async () => {
+      // Snapshot at facts_extracted: relevance + facts skip; tier
+      // orchestration is the only LLM-bearing stage that runs.
+      mock.queueSelect([
+        {
+          status: "facts_extracted",
+          statusReason: null,
+          llmJudgmentRaw: { fake: true },
+          factsExtractedAt: new Date("2026-04-28T00:00:00Z"),
+          tierOutputs: null,
+          resolvedEventId: null,
+        },
+      ]);
+      const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+      const runRelevanceGate = jest.fn();
+      const extractFacts = jest.fn();
+      const processTier = jest.fn().mockResolvedValue({
+        candidateId: CANDIDATE_ID,
+        ranTiers: ["accessible", "briefed", "technical"],
+        skippedTiers: [],
+        failedTier: null,
+        completed: true,
+      });
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { runHeuristic, runRelevanceGate, extractFacts },
+          processTier,
+        },
+      );
+      expect(runHeuristic).toHaveBeenCalledTimes(1);
+      expect(runRelevanceGate).not.toHaveBeenCalled();
+      expect(extractFacts).not.toHaveBeenCalled();
+      expect(processTier).toHaveBeenCalledTimes(1);
+      expect(result.terminalStatus).toBe("tier_generated");
+    });
+  });
 });

--- a/backend/tests/ingestion/enrichmentWorkerFailure.test.ts
+++ b/backend/tests/ingestion/enrichmentWorkerFailure.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createMockDb, type MockDb } from "../helpers/mockDb";
+import { handleWorkerFailure } from "../../src/jobs/ingestion/enrichmentWorkerFailure";
+
+const CANDIDATE_ID = "00000000-0000-0000-0000-0000000000cc";
+
+let mock: MockDb;
+
+beforeEach(() => {
+  mock = createMockDb();
+});
+
+function fakeJob(
+  data: { candidateId?: string } = {},
+  attemptsMade = 0,
+): any {
+  return {
+    data: { candidateId: data.candidateId ?? CANDIDATE_ID },
+    attemptsMade,
+  };
+}
+
+describe("handleWorkerFailure (12e.5c sub-step 7)", () => {
+  it("captures to Sentry with worker_failed stage + canonical tags + bullmq extras", async () => {
+    mock.queueSelect([{ slug: "cnbc-markets" }]); // sourceSlug lookup
+    const captureFailure = jest.fn();
+    const err = new Error("Worker boom");
+    await handleWorkerFailure(fakeJob({}, 1), err, {
+      db: mock.db,
+      captureFailure,
+    });
+    expect(captureFailure).toHaveBeenCalledTimes(1);
+    expect(captureFailure).toHaveBeenCalledWith({
+      stage: "worker_failed",
+      candidateId: CANDIDATE_ID,
+      sourceSlug: "cnbc-markets",
+      rejectionReason: "Worker boom",
+      err,
+      extraTags: {
+        "bullmq.attempt": "1",
+        "bullmq.queue": "signal-ingestion-enrich",
+      },
+    });
+  });
+
+  it("propagates the original Error object to capture (preserves stack)", async () => {
+    mock.queueSelect([{ slug: "import-ai" }]);
+    const captureFailure = jest.fn();
+    const err = new Error("typed boom");
+    await handleWorkerFailure(fakeJob({}, 0), err, {
+      db: mock.db,
+      captureFailure,
+    });
+    const call = captureFailure.mock.calls[0][0];
+    expect(call.err).toBe(err);
+  });
+
+  it("handles undefined job (BullMQ may pass undefined for orphaned failures)", async () => {
+    const captureFailure = jest.fn();
+    const err = new Error("orphan");
+    await handleWorkerFailure(undefined, err, {
+      db: mock.db,
+      captureFailure,
+    });
+    expect(captureFailure).toHaveBeenCalledTimes(1);
+    const call = captureFailure.mock.calls[0][0];
+    expect(call.candidateId).toBe("unknown");
+    expect(call.sourceSlug).toBeNull();
+    expect(call.extraTags["bullmq.attempt"]).toBe("0");
+  });
+
+  it("uses 'unknown_error' fallback when err.message is empty", async () => {
+    mock.queueSelect([{ slug: "src-1" }]);
+    const captureFailure = jest.fn();
+    const err = new Error("");
+    await handleWorkerFailure(fakeJob({}, 0), err, {
+      db: mock.db,
+      captureFailure,
+    });
+    const call = captureFailure.mock.calls[0][0];
+    expect(call.rejectionReason).toBe("unknown_error");
+  });
+
+  it("captures with sourceSlug=null when source lookup returns no rows", async () => {
+    // Empty select result.
+    mock.queueSelect([]);
+    const captureFailure = jest.fn();
+    const err = new Error("boom");
+    await handleWorkerFailure(fakeJob({}, 0), err, {
+      db: mock.db,
+      captureFailure,
+    });
+    const call = captureFailure.mock.calls[0][0];
+    expect(call.sourceSlug).toBeNull();
+    // Capture still fires.
+    expect(captureFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures with sourceSlug=null when DB lookup throws (best-effort, no compounded failure)", async () => {
+    const captureFailure = jest.fn();
+    const err = new Error("orig");
+    // Override db.select to throw.
+    const throwingDb = {
+      select: () => {
+        throw new Error("DB lookup blew up mid-failure handler");
+      },
+    } as any;
+    await handleWorkerFailure(fakeJob({}, 2), err, {
+      db: throwingDb,
+      captureFailure,
+    });
+    // Capture still fires with the ORIGINAL error (not the lookup error).
+    expect(captureFailure).toHaveBeenCalledTimes(1);
+    const call = captureFailure.mock.calls[0][0];
+    expect(call.err).toBe(err);
+    expect(call.rejectionReason).toBe("orig");
+    expect(call.sourceSlug).toBeNull();
+    expect(call.extraTags["bullmq.attempt"]).toBe("2");
+  });
+
+  it("emits the existing console.error log line (preserves observability)", async () => {
+    mock.queueSelect([{ slug: "src" }]);
+    const captureFailure = jest.fn();
+    const errSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const err = new Error("logged-error");
+    await handleWorkerFailure(fakeJob({}, 0), err, {
+      db: mock.db,
+      captureFailure,
+    });
+    expect(errSpy).toHaveBeenCalled();
+    const logged = errSpy.mock.calls[0][0] as string;
+    expect(logged).toContain("[ingestion-enrich:failed]");
+    expect(logged).toContain(CANDIDATE_ID);
+    expect(logged).toContain("logged-error");
+    errSpy.mockRestore();
+  });
+});

--- a/backend/tests/ingestion/sourcePollQueue.test.ts
+++ b/backend/tests/ingestion/sourcePollQueue.test.ts
@@ -1,0 +1,178 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createMockDb, type MockDb } from "../helpers/mockDb";
+import { scheduleSourcePollRepeatable } from "../../src/jobs/ingestion/sourcePollQueue";
+
+let mock: MockDb;
+let queueAddCalls: Array<{ name: string; data: any; opts: any }>;
+let mockQueue: any;
+
+beforeEach(() => {
+  mock = createMockDb();
+  queueAddCalls = [];
+  mockQueue = {
+    add: jest.fn((name: string, data: any, opts: any) => {
+      queueAddCalls.push({ name, data, opts });
+      return Promise.resolve({ id: `job-${queueAddCalls.length}` });
+    }),
+  };
+});
+
+describe("scheduleSourcePollRepeatable", () => {
+  it("creates one repeatable job per enabled source with the source's cadence", async () => {
+    mock.queueSelect([
+      {
+        id: "src-1",
+        slug: "cnbc-markets",
+        enabled: true,
+        fetchIntervalSeconds: 1800, // 30 min
+      },
+      {
+        id: "src-2",
+        slug: "import-ai",
+        enabled: true,
+        fetchIntervalSeconds: 86400, // 24 hr
+      },
+      {
+        id: "src-3",
+        slug: "bloomberg-markets",
+        enabled: true,
+        fetchIntervalSeconds: 600, // 10 min
+      },
+    ]);
+
+    const result = await scheduleSourcePollRepeatable({
+      db: mock.db,
+      queue: mockQueue,
+    });
+
+    expect(result.scheduled).toBe(3);
+    expect(result.skipped).toBe(0);
+    expect(queueAddCalls).toHaveLength(3);
+
+    const calls = Object.fromEntries(
+      queueAddCalls.map((c) => [c.opts.jobId, c]),
+    );
+
+    expect(calls["repeat:poll:cnbc-markets"].opts.repeat.every).toBe(
+      1800 * 1000,
+    );
+    expect(calls["repeat:poll:cnbc-markets"].data).toEqual({
+      sourceId: "src-1",
+      triggeredBy: "cron",
+    });
+
+    expect(calls["repeat:poll:import-ai"].opts.repeat.every).toBe(86400 * 1000);
+    expect(calls["repeat:poll:import-ai"].data).toEqual({
+      sourceId: "src-2",
+      triggeredBy: "cron",
+    });
+
+    expect(calls["repeat:poll:bloomberg-markets"].opts.repeat.every).toBe(
+      600 * 1000,
+    );
+  });
+
+  it("skips disabled sources", async () => {
+    mock.queueSelect([
+      {
+        id: "src-1",
+        slug: "active",
+        enabled: true,
+        fetchIntervalSeconds: 1800,
+      },
+      {
+        id: "src-2",
+        slug: "disabled",
+        enabled: false,
+        fetchIntervalSeconds: 1800,
+      },
+    ]);
+
+    const result = await scheduleSourcePollRepeatable({
+      db: mock.db,
+      queue: mockQueue,
+    });
+
+    expect(result.scheduled).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(queueAddCalls).toHaveLength(1);
+    expect(queueAddCalls[0].opts.jobId).toBe("repeat:poll:active");
+  });
+
+  it("skips sources with null or non-positive fetch_interval_seconds (defensive)", async () => {
+    // Schema declares fetchIntervalSeconds NOT NULL with default 1800, so
+    // these cases shouldn't fire in production — but the guard prevents
+    // a degenerate `every: 0` schedule if the constraint is ever relaxed.
+    mock.queueSelect([
+      {
+        id: "src-1",
+        slug: "ok",
+        enabled: true,
+        fetchIntervalSeconds: 1800,
+      },
+      {
+        id: "src-2",
+        slug: "null-interval",
+        enabled: true,
+        fetchIntervalSeconds: null,
+      },
+      {
+        id: "src-3",
+        slug: "zero-interval",
+        enabled: true,
+        fetchIntervalSeconds: 0,
+      },
+      {
+        id: "src-4",
+        slug: "negative-interval",
+        enabled: true,
+        fetchIntervalSeconds: -60,
+      },
+    ]);
+
+    const result = await scheduleSourcePollRepeatable({
+      db: mock.db,
+      queue: mockQueue,
+    });
+
+    expect(result.scheduled).toBe(1);
+    expect(result.skipped).toBe(3);
+    expect(queueAddCalls).toHaveLength(1);
+    expect(queueAddCalls[0].opts.jobId).toBe("repeat:poll:ok");
+  });
+
+  it("attaches removeOnComplete + removeOnFail to the repeatable job opts", async () => {
+    mock.queueSelect([
+      { id: "src-1", slug: "one", enabled: true, fetchIntervalSeconds: 60 },
+    ]);
+    await scheduleSourcePollRepeatable({ db: mock.db, queue: mockQueue });
+    const opts = queueAddCalls[0].opts;
+    expect(opts.removeOnComplete).toEqual({ age: 86_400, count: 500 });
+    expect(opts.removeOnFail).toEqual({ age: 604_800 });
+  });
+
+  it("returns {scheduled: 0, skipped: 0} when queue is unavailable (Redis unset)", async () => {
+    // Don't queue any select; queue=null short-circuits before the select.
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const result = await scheduleSourcePollRepeatable({
+      db: mock.db,
+      queue: null,
+    });
+    expect(result).toEqual({ scheduled: 0, skipped: 0 });
+    expect(queueAddCalls).toHaveLength(0);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns {scheduled: 0, skipped: 0} when no sources exist", async () => {
+    mock.queueSelect([]);
+    const result = await scheduleSourcePollRepeatable({
+      db: mock.db,
+      queue: mockQueue,
+    });
+    expect(result).toEqual({ scheduled: 0, skipped: 0 });
+    expect(queueAddCalls).toHaveLength(0);
+  });
+});

--- a/backend/tests/ingestion/writeEvent.test.ts
+++ b/backend/tests/ingestion/writeEvent.test.ts
@@ -1,0 +1,386 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createMockDb, type MockDb } from "../helpers/mockDb";
+import {
+  writeEvent,
+  computeWhyItMatters,
+  computeContext,
+  computeWhyItMattersTemplate,
+  type CandidateRowForWrite,
+} from "../../src/jobs/ingestion/writeEvent";
+
+const CANDIDATE_ID = "00000000-0000-0000-0000-0000000000cc";
+const EVENT_ID = "11111111-1111-1111-1111-111111111111";
+const SOURCE_ID = "22222222-2222-2222-2222-222222222222";
+const WRITER_ID = "33333333-3333-3333-3333-333333333333";
+
+let mock: MockDb;
+
+beforeEach(() => {
+  mock = createMockDb();
+});
+
+function fullCandidate(
+  overrides: Partial<CandidateRowForWrite> = {},
+): CandidateRowForWrite {
+  return {
+    id: CANDIDATE_ID,
+    ingestionSourceId: SOURCE_ID,
+    url: "https://example.com/story-123",
+    rawTitle: "TSMC pulls in 2nm production by Q3 2026",
+    rawSummary: "TSMC announced an earlier 2nm timeline.",
+    rawPublishedAt: new Date("2026-04-28T10:00:00Z"),
+    bodyText: "Full article body for the test.",
+    sector: "semiconductors",
+    facts: { facts: [{ text: "TSMC moved 2nm to Q3 2026.", category: "action" }] },
+    tierOutputs: {
+      accessible: {
+        thesis: "Accessible thesis text passing TierOutputSchema bounds.",
+        support: "Accessible support text passing TierOutputSchema bounds.",
+      },
+      briefed: {
+        thesis: "Briefed thesis text passing TierOutputSchema bounds.",
+        support: "Briefed support text passing TierOutputSchema bounds.",
+      },
+      technical: {
+        thesis: "Technical thesis text passing TierOutputSchema bounds.",
+        support: "Technical support text passing TierOutputSchema bounds.",
+      },
+    },
+    sourceDisplayName: "Example Source",
+    sourcePairedWriterId: WRITER_ID,
+    ...overrides,
+  };
+}
+
+describe("computeWhyItMatters fallback chain", () => {
+  it("level 1: prefers briefed.thesis when present", () => {
+    const result = computeWhyItMatters(fullCandidate());
+    expect(result).toBe("Briefed thesis text passing TierOutputSchema bounds.");
+  });
+
+  it("level 2: falls back to accessible.thesis when briefed missing", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: {
+          accessible: { thesis: "A", support: "AS" },
+          technical: { thesis: "T", support: "TS" },
+          // briefed omitted
+        },
+      }),
+    );
+    expect(result).toBe("A");
+  });
+
+  it("level 2: falls back to accessible.thesis when briefed.thesis is empty string", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: {
+          accessible: { thesis: "A2", support: "AS" },
+          briefed: { thesis: "", support: "BS" },
+          technical: { thesis: "T", support: "TS" },
+        },
+      }),
+    );
+    expect(result).toBe("A2");
+  });
+
+  it("level 3: falls back to technical.thesis when briefed + accessible missing", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: {
+          technical: { thesis: "Tech-only thesis", support: "TS" },
+        },
+      }),
+    );
+    expect(result).toBe("Tech-only thesis");
+  });
+
+  it("level 4 (floor): synthesizes from headline + first fact when no tier theses present", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: null,
+        rawTitle: "Headline",
+        facts: { facts: [{ text: "First fact text.", category: "action" }] },
+      }),
+    );
+    expect(result).toBe("Headline: First fact text.");
+  });
+
+  it("level 4 (floor): falls back to headline alone when facts is also empty", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: null,
+        rawTitle: "Headline only",
+        facts: null,
+      }),
+    );
+    expect(result).toBe("Headline only");
+  });
+
+  it("level 4 (floor): defensive 'Untitled' when both headline and facts absent", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: null,
+        rawTitle: null,
+        facts: null,
+      }),
+    );
+    expect(result).toBe("Untitled");
+  });
+
+  it("falls through empty briefed.thesis to next tier (treats whitespace-empty consistently)", () => {
+    const result = computeWhyItMatters(
+      fullCandidate({
+        tierOutputs: {
+          accessible: { thesis: "", support: "" },
+          briefed: { thesis: "", support: "" },
+          technical: { thesis: "Tech wins", support: "TS" },
+        },
+      }),
+    );
+    expect(result).toBe("Tech wins");
+  });
+});
+
+describe("computeContext", () => {
+  it("uses raw_summary verbatim when non-empty", () => {
+    const result = computeContext(fullCandidate({ rawSummary: "Short summary." }));
+    expect(result).toBe("Short summary.");
+  });
+
+  it("falls back to body_text when summary is empty/whitespace", () => {
+    const result = computeContext(
+      fullCandidate({ rawSummary: "   ", bodyText: "Body content here." }),
+    );
+    expect(result).toBe("Body content here.");
+  });
+
+  it("truncates body_text to ≤500 chars at last whitespace boundary", () => {
+    const longBody = "word ".repeat(200); // ~1000 chars
+    const result = computeContext(
+      fullCandidate({ rawSummary: null, bodyText: longBody }),
+    );
+    expect(result.length).toBeLessThanOrEqual(500);
+    // Truncation lands on a word boundary (no trailing partial word).
+    expect(result.endsWith(" ")).toBe(false);
+    expect(result.endsWith("word")).toBe(true);
+  });
+
+  it("does not truncate at very-early space (uses hard cut if no late-half boundary)", () => {
+    // Construct a body where the only space is in the first 50 chars,
+    // then a long single token. Truncation should hard-cut at 500
+    // rather than producing a tiny prefix.
+    const body = "early " + "a".repeat(800);
+    const result = computeContext(
+      fullCandidate({ rawSummary: null, bodyText: body }),
+    );
+    expect(result.length).toBe(500);
+  });
+
+  it("falls back to headline when both summary and body are empty", () => {
+    const result = computeContext(
+      fullCandidate({ rawSummary: null, bodyText: null, rawTitle: "Title" }),
+    );
+    expect(result).toBe("Title");
+  });
+
+  it("respects body_text shorter than the cap (no truncation)", () => {
+    const body = "Short body.";
+    const result = computeContext(
+      fullCandidate({ rawSummary: null, bodyText: body }),
+    );
+    expect(result).toBe(body);
+  });
+});
+
+describe("computeWhyItMattersTemplate", () => {
+  it("validates and stringifies a well-formed tier_outputs blob", () => {
+    const result = computeWhyItMattersTemplate(fullCandidate());
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result as string);
+    expect(parsed.briefed.thesis).toBe(
+      "Briefed thesis text passing TierOutputSchema bounds.",
+    );
+    expect(parsed.accessible.thesis).toBe(
+      "Accessible thesis text passing TierOutputSchema bounds.",
+    );
+    expect(parsed.technical.thesis).toBe(
+      "Technical thesis text passing TierOutputSchema bounds.",
+    );
+  });
+
+  it("returns null on validation failure (missing tier key)", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const result = computeWhyItMattersTemplate(
+      fullCandidate({
+        tierOutputs: {
+          accessible: { thesis: "A", support: "AS" },
+          briefed: { thesis: "B", support: "BS" },
+          // technical omitted — schema strict requires it
+        },
+      }),
+    );
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns null when tier_outputs is null", () => {
+    const result = computeWhyItMattersTemplate(
+      fullCandidate({ tierOutputs: null }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null on shape mismatch (legacy 12a per-tier-string shape)", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const result = computeWhyItMattersTemplate(
+      fullCandidate({
+        tierOutputs: {
+          accessible: "string instead of object",
+          briefed: "string",
+          technical: "string",
+        } as unknown as Record<string, unknown>,
+      }),
+    );
+    expect(result).toBeNull();
+    warn.mockRestore();
+  });
+});
+
+describe("writeEvent integration", () => {
+  function queueLoadCandidate(row: Partial<CandidateRowForWrite>): void {
+    mock.queueSelect([{ ...fullCandidate(), ...row }]);
+  }
+
+  it("happy path: inserts events row + event_sources row + updates candidate to published", async () => {
+    queueLoadCandidate({});
+    mock.queueInsert([{ id: EVENT_ID }]); // events insert returning
+    // event_sources insert returning result not pulled (no .returning() call).
+    const fakeNow = new Date("2026-04-28T12:00:00Z");
+    const result = await writeEvent(CANDIDATE_ID, {
+      db: mock.db,
+      now: () => fakeNow,
+    });
+    expect(result).toEqual({ eventId: EVENT_ID });
+
+    // Two inserts captured (events, event_sources).
+    expect(mock.state.insertedValues.length).toBe(2);
+    const eventInsert = mock.state.insertedValues[0];
+    expect(eventInsert.sector).toBe("semiconductors");
+    expect(eventInsert.headline).toBe("TSMC pulls in 2nm production by Q3 2026");
+    expect(eventInsert.context).toBe("TSMC announced an earlier 2nm timeline.");
+    expect(eventInsert.whyItMatters).toBe(
+      "Briefed thesis text passing TierOutputSchema bounds.",
+    );
+    expect(typeof eventInsert.whyItMattersTemplate).toBe("string");
+    expect(JSON.parse(eventInsert.whyItMattersTemplate).briefed.thesis).toBe(
+      "Briefed thesis text passing TierOutputSchema bounds.",
+    );
+    expect(eventInsert.primarySourceUrl).toBe("https://example.com/story-123");
+    expect(eventInsert.primarySourceName).toBe("Example Source");
+    expect(eventInsert.authorId).toBe(WRITER_ID);
+    expect(eventInsert.facts).toEqual({
+      facts: [{ text: "TSMC moved 2nm to Q3 2026.", category: "action" }],
+    });
+    expect(eventInsert.publishedAt).toEqual(new Date("2026-04-28T10:00:00Z"));
+
+    const eventSourceInsert = mock.state.insertedValues[1];
+    expect(eventSourceInsert.eventId).toBe(EVENT_ID);
+    expect(eventSourceInsert.ingestionSourceId).toBe(SOURCE_ID);
+    expect(eventSourceInsert.url).toBe("https://example.com/story-123");
+    expect(eventSourceInsert.name).toBe("Example Source");
+    expect(eventSourceInsert.role).toBe("primary");
+
+    // Candidate updated to published with resolved_event_id + processed_at.
+    expect(mock.state.updatedRows.length).toBe(1);
+    const candidateUpdate = mock.state.updatedRows[0];
+    expect(candidateUpdate.status).toBe("published");
+    expect(candidateUpdate.resolvedEventId).toBe(EVENT_ID);
+    expect(candidateUpdate.processedAt).toEqual(fakeNow);
+    expect(candidateUpdate.statusReason).toBeNull();
+  });
+
+  it("passes raw_published_at through to events.published_at (no synthesis)", async () => {
+    const articleTime = new Date("2026-04-15T08:30:00Z");
+    queueLoadCandidate({ rawPublishedAt: articleTime });
+    mock.queueInsert([{ id: EVENT_ID }]);
+    await writeEvent(CANDIDATE_ID, { db: mock.db });
+    expect(mock.state.insertedValues[0].publishedAt).toEqual(articleTime);
+  });
+
+  it("leaves events.published_at null when raw_published_at is null", async () => {
+    queueLoadCandidate({ rawPublishedAt: null });
+    mock.queueInsert([{ id: EVENT_ID }]);
+    await writeEvent(CANDIDATE_ID, { db: mock.db });
+    expect(mock.state.insertedValues[0].publishedAt).toBeNull();
+  });
+
+  it("truncates headline at 255 chars", async () => {
+    const longTitle = "A".repeat(400);
+    queueLoadCandidate({ rawTitle: longTitle });
+    mock.queueInsert([{ id: EVENT_ID }]);
+    await writeEvent(CANDIDATE_ID, { db: mock.db });
+    expect(mock.state.insertedValues[0].headline.length).toBe(255);
+  });
+
+  it("writes whyItMattersTemplate=null when tier_outputs fails assertTierTemplate", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    queueLoadCandidate({
+      tierOutputs: {
+        accessible: { thesis: "A", support: "AS" },
+        briefed: { thesis: "B", support: "BS" },
+        // technical omitted
+      },
+    });
+    mock.queueInsert([{ id: EVENT_ID }]);
+    await writeEvent(CANDIDATE_ID, { db: mock.db });
+    expect(mock.state.insertedValues[0].whyItMattersTemplate).toBeNull();
+    // why_it_matters still uses the fallback chain (briefed wins).
+    expect(mock.state.insertedValues[0].whyItMatters).toBe("B");
+    warn.mockRestore();
+  });
+
+  it("throws when candidate row not found", async () => {
+    // Empty select result.
+    mock.queueSelect([]);
+    await expect(writeEvent(CANDIDATE_ID, { db: mock.db })).rejects.toThrow(
+      /candidate .* not found/,
+    );
+  });
+
+  it("throws when sector is null (relevance gate didn't classify)", async () => {
+    queueLoadCandidate({ sector: null });
+    await expect(writeEvent(CANDIDATE_ID, { db: mock.db })).rejects.toThrow(
+      /null sector/,
+    );
+  });
+
+  it("transaction rollback: event_sources insert failure propagates and skips candidate update", async () => {
+    queueLoadCandidate({});
+    mock.queueInsert([{ id: EVENT_ID }]); // events insert succeeds
+
+    // Replace mock.db.insert to throw on the second call (event_sources).
+    let insertCalls = 0;
+    const originalInsert = mock.db.insert;
+    mock.db.insert = (table: any) => {
+      insertCalls += 1;
+      if (insertCalls === 2) {
+        // Simulate a constraint violation / connection error mid-transaction.
+        throw new Error("simulated event_sources insert failure");
+      }
+      return originalInsert(table);
+    };
+
+    await expect(writeEvent(CANDIDATE_ID, { db: mock.db })).rejects.toThrow(
+      /simulated event_sources insert failure/,
+    );
+
+    // events insert was attempted (1 captured), event_sources insert
+    // threw before .values() was reached so insertedValues[1] is absent.
+    expect(mock.state.insertedValues.length).toBe(1);
+    // Critically: candidate update did NOT run — caught by the throw
+    // propagating out of the transaction callback.
+    expect(mock.state.updatedRows.length).toBe(0);
+  });
+});

--- a/backend/tests/ingestion/writeEvent.test.ts
+++ b/backend/tests/ingestion/writeEvent.test.ts
@@ -209,42 +209,47 @@ describe("computeWhyItMattersTemplate", () => {
     );
   });
 
-  it("returns null on validation failure (missing tier key)", () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    const result = computeWhyItMattersTemplate(
-      fullCandidate({
-        tierOutputs: {
-          accessible: { thesis: "A", support: "AS" },
-          briefed: { thesis: "B", support: "BS" },
-          // technical omitted — schema strict requires it
-        },
-      }),
-    );
-    expect(result).toBeNull();
-    expect(warn).toHaveBeenCalled();
-    warn.mockRestore();
+  it("throws on validation failure (missing tier key)", () => {
+    // Strict-at-write per locked sub-step-3 spec correction: missing
+    // required key throws ZodError instead of silently returning null.
+    expect(() =>
+      computeWhyItMattersTemplate(
+        fullCandidate({
+          tierOutputs: {
+            accessible: { thesis: "A", support: "AS" },
+            briefed: { thesis: "B", support: "BS" },
+            // technical omitted — schema strict requires it
+          },
+        }),
+      ),
+    ).toThrow();
   });
 
-  it("returns null when tier_outputs is null", () => {
-    const result = computeWhyItMattersTemplate(
-      fullCandidate({ tierOutputs: null }),
-    );
-    expect(result).toBeNull();
+  it("throws when tier_outputs is null (no silent skip)", () => {
+    // Strict-at-write: a null tier_outputs at writeEvent time means
+    // upstream tier orchestration fired markTierGeneratedComplete
+    // without populating the JSONB column — a real bug worth surfacing
+    // loudly. assertTierTemplate(null) throws ZodError.
+    expect(() =>
+      computeWhyItMattersTemplate(fullCandidate({ tierOutputs: null })),
+    ).toThrow();
   });
 
-  it("returns null on shape mismatch (legacy 12a per-tier-string shape)", () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
-    const result = computeWhyItMattersTemplate(
-      fullCandidate({
-        tierOutputs: {
-          accessible: "string instead of object",
-          briefed: "string",
-          technical: "string",
-        } as unknown as Record<string, unknown>,
-      }),
-    );
-    expect(result).toBeNull();
-    warn.mockRestore();
+  it("throws on shape mismatch (legacy 12a per-tier-string shape)", () => {
+    // Legacy {accessible: string, briefed: string, technical: string}
+    // shape is rejected by TierTemplateSchema (which requires the new
+    // per-tier {thesis, support} shape). Strict-at-write throws.
+    expect(() =>
+      computeWhyItMattersTemplate(
+        fullCandidate({
+          tierOutputs: {
+            accessible: "string instead of object",
+            briefed: "string",
+            technical: "string",
+          } as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).toThrow();
   });
 });
 
@@ -324,8 +329,13 @@ describe("writeEvent integration", () => {
     expect(mock.state.insertedValues[0].headline.length).toBe(255);
   });
 
-  it("writes whyItMattersTemplate=null when tier_outputs fails assertTierTemplate", async () => {
-    const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  it("throws (does NOT write null) when tier_outputs fails assertTierTemplate", async () => {
+    // Strict-at-write per locked sub-step-3 correction: tier_outputs
+    // missing a required key causes computeWhyItMattersTemplate to
+    // throw ZodError BEFORE the db.transaction starts, so no events
+    // row is inserted. processEnrichmentJob's wiring catches the throw
+    // and surfaces as terminalStatus='failed' with 'write_event_error:'
+    // prefix (covered separately in enrichmentJob.test.ts).
     queueLoadCandidate({
       tierOutputs: {
         accessible: { thesis: "A", support: "AS" },
@@ -333,12 +343,12 @@ describe("writeEvent integration", () => {
         // technical omitted
       },
     });
-    mock.queueInsert([{ id: EVENT_ID }]);
-    await writeEvent(CANDIDATE_ID, { db: mock.db });
-    expect(mock.state.insertedValues[0].whyItMattersTemplate).toBeNull();
-    // why_it_matters still uses the fallback chain (briefed wins).
-    expect(mock.state.insertedValues[0].whyItMatters).toBe("B");
-    warn.mockRestore();
+    await expect(
+      writeEvent(CANDIDATE_ID, { db: mock.db }),
+    ).rejects.toThrow();
+    // No events insert was attempted (throw fires before db.transaction).
+    expect(mock.state.insertedValues.length).toBe(0);
+    expect(mock.state.updatedRows.length).toBe(0);
   });
 
   it("throws when candidate row not found", async () => {

--- a/backend/tests/lib/sentryHelpers.test.ts
+++ b/backend/tests/lib/sentryHelpers.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Mock @sentry/node BEFORE importing the helper so the helper's
+// `import * as Sentry from "@sentry/node"` binds to the mocked module.
+
+const setTagMock = jest.fn();
+const captureExceptionMock = jest.fn();
+const withScopeMock = jest.fn((cb: (scope: { setTag: jest.Mock }) => void) => {
+  cb({ setTag: setTagMock });
+});
+
+jest.mock("@sentry/node", () => ({
+  withScope: (cb: any) => withScopeMock(cb),
+  captureException: (err: any) => captureExceptionMock(err),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const { captureIngestionStageFailure } = require("../../src/lib/sentryHelpers");
+
+beforeEach(() => {
+  setTagMock.mockClear();
+  captureExceptionMock.mockClear();
+  withScopeMock.mockClear();
+});
+
+describe("captureIngestionStageFailure", () => {
+  it("sets the canonical tag set and captures via Sentry.captureException", () => {
+    captureIngestionStageFailure({
+      stage: "facts",
+      candidateId: "cand-1",
+      sourceSlug: "cnbc-markets",
+      rejectionReason: "facts_parse_error",
+    });
+
+    expect(withScopeMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+
+    // All four tags set in the same scope.
+    const tagCalls = setTagMock.mock.calls;
+    expect(tagCalls).toEqual(
+      expect.arrayContaining([
+        ["ingestion.stage", "facts"],
+        ["ingestion.candidate_id", "cand-1"],
+        ["ingestion.source_slug", "cnbc-markets"],
+        ["ingestion.rejection_reason", "facts_parse_error"],
+      ]),
+    );
+    // No extra tags beyond the four canonical ones.
+    expect(tagCalls.length).toBe(4);
+  });
+
+  it("synthesizes an Error from the rejection reason when err is undefined", () => {
+    captureIngestionStageFailure({
+      stage: "relevance",
+      candidateId: "cand-2",
+      sourceSlug: "import-ai",
+      rejectionReason: "llm_timeout",
+    });
+    const captured = captureExceptionMock.mock.calls[0][0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toContain("ingestion.relevance failed: llm_timeout");
+  });
+
+  it("propagates an explicit Error object verbatim (preserves stack)", () => {
+    const original = new Error("PG connection refused");
+    captureIngestionStageFailure({
+      stage: "write_event",
+      candidateId: "cand-3",
+      sourceSlug: "bloomberg-markets",
+      rejectionReason: "write_event_error: PG connection refused",
+      err: original,
+    });
+    const captured = captureExceptionMock.mock.calls[0][0];
+    expect(captured).toBe(original);
+  });
+
+  it("wraps a non-Error err value in a synthetic Error with both reason and detail", () => {
+    captureIngestionStageFailure({
+      stage: "tiers",
+      candidateId: "cand-4",
+      sourceSlug: "arstechnica-ai",
+      rejectionReason: "tier_orchestration_indeterminate",
+      err: "raw-string-thrown-by-something",
+    });
+    const captured = captureExceptionMock.mock.calls[0][0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toContain("tier_orchestration_indeterminate");
+    expect(captured.message).toContain("raw-string-thrown-by-something");
+  });
+
+  it("omits the source_slug tag when sourceSlug is null", () => {
+    captureIngestionStageFailure({
+      stage: "tiers",
+      candidateId: "cand-5",
+      sourceSlug: null,
+      rejectionReason: "TIER_TIMEOUT",
+    });
+    const tagKeys = setTagMock.mock.calls.map((c) => c[0]);
+    expect(tagKeys).toContain("ingestion.stage");
+    expect(tagKeys).toContain("ingestion.candidate_id");
+    expect(tagKeys).toContain("ingestion.rejection_reason");
+    expect(tagKeys).not.toContain("ingestion.source_slug");
+    expect(tagKeys.length).toBe(3);
+  });
+
+  it("each call gets its own scope (concurrency isolation)", () => {
+    captureIngestionStageFailure({
+      stage: "facts",
+      candidateId: "a",
+      sourceSlug: "src-a",
+      rejectionReason: "facts_timeout",
+    });
+    captureIngestionStageFailure({
+      stage: "tiers",
+      candidateId: "b",
+      sourceSlug: "src-b",
+      rejectionReason: "TIER_PARSE_ERROR",
+    });
+    // Two separate withScope invocations — no shared scope between
+    // concurrent worker calls. captureException fires once per call.
+    expect(withScopeMock).toHaveBeenCalledTimes(2);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/tests/lib/sentryHelpers.test.ts
+++ b/backend/tests/lib/sentryHelpers.test.ts
@@ -120,4 +120,41 @@ describe("captureIngestionStageFailure", () => {
     expect(withScopeMock).toHaveBeenCalledTimes(2);
     expect(captureExceptionMock).toHaveBeenCalledTimes(2);
   });
+
+  it("appends extraTags after the canonical tag set (sub-step 7)", () => {
+    captureIngestionStageFailure({
+      stage: "worker_failed",
+      candidateId: "cand-7",
+      sourceSlug: "cnbc-markets",
+      rejectionReason: "Connection refused",
+      extraTags: {
+        "bullmq.attempt": "2",
+        "bullmq.queue": "signal-ingestion-enrich",
+      },
+    });
+    const tagCalls = setTagMock.mock.calls;
+    // 4 canonical tags + 2 extra = 6 setTag calls.
+    expect(tagCalls.length).toBe(6);
+    expect(tagCalls).toEqual(
+      expect.arrayContaining([
+        ["ingestion.stage", "worker_failed"],
+        ["ingestion.candidate_id", "cand-7"],
+        ["ingestion.source_slug", "cnbc-markets"],
+        ["ingestion.rejection_reason", "Connection refused"],
+        ["bullmq.attempt", "2"],
+        ["bullmq.queue", "signal-ingestion-enrich"],
+      ]),
+    );
+  });
+
+  it("works with empty extraTags object (no extra setTag calls)", () => {
+    captureIngestionStageFailure({
+      stage: "facts",
+      candidateId: "cand-8",
+      sourceSlug: "src",
+      rejectionReason: "facts_timeout",
+      extraTags: {},
+    });
+    expect(setTagMock.mock.calls.length).toBe(4);
+  });
 });

--- a/docs/discovery/phase-12e5c-audit.md
+++ b/docs/discovery/phase-12e5c-audit.md
@@ -1,0 +1,377 @@
+# Phase 12e.5c — Stage 1 discovery audit
+
+**Date:** 2026-05-01
+**HEAD at start:** `d05dea0 chore(housekeeping): OneDrive cleanup — sibling dirs, stale branches, project-state dirs, CLAUDE.md note (#61)` on `discovery/phase-12e5c` (worktree spawned canonical-rooted at `C:/dev/signal-app/.claude/worktrees/phase-12e5c-discovery`)
+**Scope:** read-only audit of the four-seam pipeline state, queue config, retry patterns, event-row write semantics, and Sentry precedents — to inform Stage 2's wire-up of the chain into `enrichmentWorker.handle()` plus dead-letter handling and Sentry tagging. No clustering work (12e.6 owns that).
+
+---
+
+## 1. Current `enrichmentWorker.handle()` state
+
+The worker shell is **62 lines, 5 lines of business logic**. The actual chain orchestration lives in `enrichmentJob.ts:processEnrichmentJob()` (289 lines). The worker is a thin BullMQ-callable wrapper around the job body.
+
+### `enrichmentWorker.ts:handle()` (verbatim)
+
+```ts
+async function handle(job: Job<EnrichmentJobInput>): Promise<void> {
+  // 12e.5c: wire seams here (runHeuristic, runRelevanceGate, etc.).
+  // Until then, this worker returns terminalStatus: "failed" for any
+  // drained job because seams are not injected. The CLI
+  // (runIngestionEnrich.ts) is the documented dev surface for 12e.3
+  // and 12e.4 — it injects the heuristic + relevance seams directly.
+  // No DB corruption: the orchestration body's missing-seam guard
+  // returns the structured result without writing to the DB.
+  const result = await processEnrichmentJob(job.data);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[signal-backend] [ingestion-enrich:done] candidate=${result.candidateId} terminal=${result.terminalStatus} event=${result.resolvedEventId ?? "none"} failure=${result.failureReason ?? "none"}`,
+  );
+}
+```
+
+### Four-seam wire-up status (in `processEnrichmentJob`)
+
+| seam | wired? | terminal status when missing | line range in `enrichmentJob.ts` |
+|---|---|---|---|
+| `runHeuristic` | ✓ wired | hard-fails with `"runHeuristic seam not provided"` (L105–112) | 105–154 |
+| `runRelevanceGate` | ✓ wired | early-returns `terminalStatus: "heuristic_passed"` if missing (L160–167) | 156–218 |
+| `extractFacts` | ✓ wired | early-returns `terminalStatus: "llm_relevant"` if missing (L224–231) | 220–281 |
+| `generateTier` | **✗ missing** — no call site at all | n/a | n/a (function ends at L289) |
+| `resolveCluster` | **✗ missing** — no call site, no event-write | n/a | n/a (12e.6a target) |
+
+### Chain shape today
+
+The worker drains a job, calls `processEnrichmentJob`, and the orchestration walks the three wired stages, terminating at `facts_extracted`. **No tier-generation call. No event-row write.** The `EnrichmentJobResult.terminalStatus` union (L44–52 of enrichmentJob.ts) does not include `"tier_generated"` — it stops at `"facts_extracted"`. The TypeScript type would need extending in Stage 2 to add `"tier_generated"`.
+
+The worker has zero seam injection — `processEnrichmentJob(job.data)` is called with no `deps` argument, so all seams default to `{}`. Per the missing-seam guards, the worker hits the `runHeuristic` guard immediately and returns `terminalStatus: "failed", failureReason: "runHeuristic seam not provided"`. **Every drained BullMQ job currently fails at L105–112 of enrichmentJob.ts.** The CLI (`scripts/runIngestionEnrich.ts`) is the documented dev surface and injects the seams directly — that's the only path that exercises the chain end-to-end today.
+
+---
+
+## 2. BullMQ queue config inventory
+
+### `signal-ingestion-enrich` (verbatim from `enrichmentQueue.ts:19–27`)
+
+```ts
+defaultJobOptions: {
+  attempts: 2,
+  backoff: { type: "exponential", delay: 60_000 },
+  removeOnComplete: { age: 86_400, count: 1000 },
+  removeOnFail: { age: 604_800 },
+}
+```
+
+### Comparison with sibling queues
+
+| queue | attempts | backoff delay | removeOnComplete count | removeOnFail age |
+|---|---|---|---|---|
+| `signal-emails` | 3 | 30s exp | 1000 | 7d |
+| `signal-aggregation` | 3 | 30s exp | 100 | 7d |
+| `signal-ingestion-enrich` | **2** | **60s exp** | 1000 | 7d |
+
+**Divergence is intentional.** `enrichmentWorker.ts:42–43` says the lower retry count + longer backoff is for "Haiku rate limits + spend governance per CLAUDE.md / roadmap §5.4 cost notes." The deliberate ~½× retry budget vs the other queues prevents a flaky stage from re-firing 5 LLM calls per attempt × 3 attempts = 15 LLM calls per failed job.
+
+### DLQ pattern
+
+**No separate DLQ.** Both `signal-emails` and `signal-aggregation` rely on BullMQ's failed-state as the implicit DLQ — `removeOnFail: { age: 604_800 }` keeps failed jobs queryable for 7 days. `signal-ingestion-enrich` follows the same pattern. There is no failed-jobs queue defined anywhere in `backend/src/jobs/`. Stage 2 should not invent one — the BullMQ-failed-state-as-DLQ pattern is the established convention.
+
+The worker's `cachedWorker.on("failed", ...)` handler (enrichmentWorker.ts:46–51) only logs to console. It does NOT write to a DLQ table, does NOT emit a Sentry event, does NOT enqueue a retry. The "dead-letter handling" the brief asks for in Stage 2 is genuinely greenfield — there is no existing pattern to extend, only console-log on `failed`.
+
+---
+
+## 3. Per-seam retry pattern inventory
+
+All four seams follow the **same shape**: at-most-2-attempts, no exponential backoff, fail-fast to a typed `*_REASONS` rejection class. Idempotency lives at the row-selection layer (CLI WHERE clause), not in the seam itself.
+
+| seam | attempts | retry trigger | terminal-on-failure? | idempotency layer |
+|---|---|---|---|---|
+| `runHeuristicSeam` (heuristicSeam.ts:94–143) | 1 | n/a (deterministic, no LLM) | yes — returns `{pass: false, reason}` | none in seam; CLI filters `status='discovered'` |
+| `runRelevanceGate` (relevanceSeam.ts) | 2 | parse failure / missing sector → stricter prefill | yes — terminal `RELEVANCE_*` reason | none in seam; CLI filters `status='heuristic_passed' AND llm_judgment_raw IS NULL` |
+| `runFactsSeam` (factsSeam.ts:218–341) | 2 | JSON parse / Zod fail → stricter prefill `{"facts":` | yes — terminal `FACTS_PARSE_ERROR` | none in seam; CLI filters `status='llm_relevant' AND facts_extracted_at IS NULL` |
+| `runTierGenerationSeam` (tierGenerationSeam.ts) | 2 | JSON parse / Zod fail → stricter prefill `{"thesis":` | yes — terminal `TIER_PARSE_ERROR` | none in seam; orchestrator (`tierOrchestration.ts:181–198`) checks `tier_outputs->>tier IS NOT NULL` per tier |
+
+**Key observation: NO seam cascades.** Every seam fail-fasts at terminal rejection class. No exponential backoff inside a seam. No re-enqueue from a seam. The only retry in the entire ingestion pipeline is the BullMQ queue-level `attempts: 2`, which would re-run the **whole `processEnrichmentJob`** body — re-firing every wired seam upstream of the failure. Since 12e.5a/12e.5b seams write to DB before returning success, queue-level re-runs of an already-extracted candidate would be double-charged unless idempotency markers gate them.
+
+Specifically: the row-selection idempotency markers protect the **CLI** path (which reads the cohort first), but the **worker** path receives a `candidateId` directly from the job payload. **A queue-level retry on a job whose facts already extracted would re-fire `extractFacts` and double-charge a Haiku call** — unless `processEnrichmentJob` adds short-circuit checks based on candidate state. This is a Stage 2 design concern surfaced for the planner.
+
+Idempotency mechanisms by stage:
+- **Heuristic** — `status` is checked nowhere; orchestration would re-run on retry. Cost: free (no LLM).
+- **Relevance** — `llm_judgment_raw IS NULL` is the CLI filter; orchestration's `processEnrichmentJob` does NOT re-check before calling. Cost on retry: 1 Haiku call.
+- **Facts** — `facts_extracted_at IS NULL` is the CLI filter; same gap as relevance. Cost on retry: 1–2 Haiku calls.
+- **Tier** — `tier_outputs->>tier IS NOT NULL` is per-tier gated INSIDE `tierOrchestration.ts:181–198` (Strategy B). Cost on retry: only missing tiers; per-tier idempotency already correct.
+
+Tier orchestration's per-tier idempotency is the only stage where retry-cost is bounded by missing work. Stages 1–3 would re-fire on full-job retry.
+
+---
+
+## 4. Tier-call sequencing (informs decision 1: sequential vs parallel)
+
+### Verbatim from `tierOrchestration.ts:181–198`
+
+```ts
+for (const tier of TIER_ORDER) {
+  if (existingTiers.has(tier)) {
+    summary.skippedTiers.push(tier);
+    continue;
+  }
+  const result = await runTier(candidateId, tier);
+  summary.ranTiers.push(tier);
+  if (result.ok) {
+    await persistTierSuccess(db, candidateId, tier, result);
+    existingTiers.add(tier);
+  } else {
+    await persistTierFailureRaw(db, candidateId, tier, result);
+    summary.failedTier = { tier, reason: result.rejectionReason };
+    // Stop on first failure — partial-state retry picks up missing
+    // tiers on next invocation.
+    break;
+  }
+}
+```
+
+`TIER_ORDER` (line 31): `["accessible", "briefed", "technical"]`.
+
+### Classification
+
+**Sequential**, **stop-on-first-failure**, with per-tier persistence between calls. Already pattern-applied from the 12e.5b audit's recommendation (audit §8 — "Default sequential unless the soak shows wall-clock latency is a real problem"). The 12e.5b smoke (`docs/discovery/phase-12e5b-smoke.md` §3) showed per-trio wall-clock latency of ~12.5s p50 (3.3 + 4.0 + 5.0s p50 per tier), which is acceptable.
+
+### Other multi-Haiku-call patterns in the codebase
+
+`grep -n "getOrGenerateCommentary"` in `services/commentaryService.ts:151` is single-call (one Haiku call per request, with cache-first lookup). It's NOT a multi-call orchestration — it's a fan-out-of-one. So `tierOrchestration.ts` is the **only** existing multi-call orchestration precedent.
+
+The historical 12a `regenerateDepthVariants.ts` script is also single-call-per-row. No `Promise.all` over multiple Haiku calls anywhere.
+
+### Recommendation surfaced (planner decides)
+
+Stay sequential for 12e.5c wire-up. Parallel via `Promise.all` is a 12e.8 (post-soak) optimization at most. Three reasons:
+- Wall-clock savings from parallel are ~7s per candidate at observed latencies — meaningful, but at modest cohort sizes (9 candidates per smoke run) this is ~60s total savings, not load-bearing.
+- Sequential-with-stop-on-failure preserves the cost discipline: if `accessible` (cheapest tier) fails on a systemic prompt bug, the trio aborts after 1 call, not 3.
+- Debugging is simpler; one tier's failure can't race another's success in logs.
+
+---
+
+## 5. Event-row write semantics (informs decision 3: partial-failure write semantics)
+
+### Current state of `writeEvent`
+
+**Does not exist.** Grep for `INSERT INTO events`, `.insert(events)`, `writeEvent`, `createEvent` returns ZERO matches across `backend/src/`. There is no event-row write code path anywhere — not in `enrichmentJob.ts`, not in the seams, not in any service. The seed script (`db/seed.ts`) and `seedStories.ts` write to `stories`, not `events`. **12e.5c builds the writer from scratch.**
+
+### `events` table NOT NULL constraints (from `db/schema.ts:579–601`)
+
+| column | type | nullable? | default |
+|---|---|---|---|
+| `id` | uuid | NOT NULL | `defaultRandom()` |
+| `sector` | varchar(50) | **NOT NULL** | none |
+| `headline` | varchar(255) | **NOT NULL** | none |
+| `context` | text | **NOT NULL** | none |
+| `why_it_matters` | text | **NOT NULL** | none |
+| `why_it_matters_template` | text | nullable | none |
+| `primary_source_url` | text | **NOT NULL** | none |
+| `primary_source_name` | varchar(255) | nullable | none |
+| `author_id` | uuid (FK to writers) | nullable | none |
+| `facts` | jsonb | **NOT NULL** | `'{}'::jsonb` |
+| `embedding` | bytea | nullable | none |
+| `published_at` | timestamptz | nullable | none |
+| `created_at` | timestamptz | NOT NULL | `defaultNow()` |
+| `updated_at` | timestamptz | NOT NULL | `defaultNow()` |
+
+**Critical finding for Stage 2:** **`why_it_matters` is NOT NULL** on events. It's the role-neutral fallback string that the lenient parser returns to clients when `why_it_matters_template` is null. 12e.5c's writer needs SOMETHING for that field — current candidate state (post-12e.5b) does not have a `why_it_matters` field anywhere. Options to surface to planner:
+
+1. **Use one tier's thesis as the fallback** (probably `briefed.thesis` — it's the middle-register thesis most readable to a generic audience).
+2. **Generate a separate role-neutral thesis** — additional Haiku call per event.
+3. **Use the candidate's headline + first fact** — synthesize a 1–2 sentence string mechanically.
+4. **Make `why_it_matters` nullable with a `0021` migration** — semantic change to the schema; would require updating every reader that assumes non-null.
+
+This is a **load-bearing decision the brief did not flag** — adding to §10.
+
+`headline`, `context`, `primary_source_url` are also NOT NULL. These map to candidate fields:
+- `headline` ← `ingestion_candidates.raw_title`
+- `context` ← need to choose: full body, summary, or new field
+- `primary_source_url` ← `ingestion_candidates.url`
+
+`context` (NOT NULL) is the second under-spec'd field. The candidate's `body_text` is the obvious source but it can be 200KB; events table `context` is `text` with no length cap declared. Probably want a truncated/summary version. Another planner decision.
+
+### Inventory of every `why_it_matters_template` reader
+
+| file:line | usage | classification |
+|---|---|---|
+| `backend/src/controllers/storyController.ts:44, 70, 114` | reads as `string \| null` directly into response JSON | **lenient** (passes null through) |
+| `backend/src/controllers/v2/storiesController.ts:121–153` | calls `parseWhyItMattersTemplate(r.whyItMattersTemplate)` | **lenient** (returns `null` on parse failure) |
+| `backend/src/services/personalizationService.ts:17, 28` | reads as `string \| null`, falls back to `whyItMatters` if template is null | **lenient with explicit fallback** |
+| `backend/src/scripts/regenerateDepthVariants.ts:125` | writes `whyItMattersTemplate: JSON.stringify(template)` after `assertWhyItMattersTemplate()` | **strict at write boundary** (asserts before stringifying) |
+| `backend/src/scripts/seedStories.ts:73, 270, 271` | writes via `WhyItMattersTemplateSchema` parse + JSON.stringify | **strict at write boundary** |
+| `backend/src/utils/depthVariants.ts` | exports both `parseWhyItMattersTemplate` (lenient) and `assertWhyItMattersTemplate` (strict) | source of truth |
+| `backend/src/db/seed.ts:603` | sets `whyItMattersTemplate: null` on a seed row | confirms NULL is a valid persisted value |
+
+**No code path asserts `tier_outputs IS NOT NULL` before reading an event.** All readers tolerate null `whyItMattersTemplate`. **Writing events with `whyItMattersTemplate = null` is permanently supported per CLAUDE.md §8** ("the permanent contract, not a migration-window hack — some rows may never get a template").
+
+### Implication for partial-failure write decision
+
+- **Writing the event row with `whyItMattersTemplate = null` if all 3 tiers fail** → safe per the lenient contract. The `why_it_matters` (NOT NULL) string stays as the fallback. Reader paths handle this gracefully.
+- **Blocking the write until all 3 tiers complete** → also safe but more conservative. Would require persisting `tier_generated` status before writing event, OR keeping the candidate row at `facts_extracted` with `tier_outputs` partial.
+
+The schema permits both. Recommendation surfaced (planner decides): **block the event-write until trio completes**, because:
+1. Once an event row exists, downstream readers consume it. Writing an event with NULL template means the user immediately sees the role-neutral fallback — possibly forever if tier retries never complete.
+2. The candidate-side staging already supports partial state (per 12e.5b's Strategy B). Keep the partial state on `ingestion_candidates`, not on `events`.
+3. The status enum already supports the gating: status advances `facts_extracted → tier_generated → published`, so the event-write naturally sits at the `tier_generated → published` transition.
+
+---
+
+## 6. Sentry wiring precedents
+
+### Top 5 (only 5) Sentry call sites in the codebase
+
+```
+backend/src/lib/sentry.ts:11       → Sentry.init(...)
+backend/src/lib/sentry.ts:37       → Sentry.setupExpressErrorHandler(app)
+backend/src/lib/envCheck.ts:77     → Sentry.captureMessage(...)
+backend/src/middleware/apiKeyRateLimit.ts:97 → Sentry.captureMessage("Rate limiter fail-open: Redis unavailable", {...})
+```
+
+**That's it. Five total references, three of which are import/init.** The codebase has essentially zero per-request or per-job Sentry instrumentation. There is no `Sentry.setTag`, no `Sentry.withScope`, no `Sentry.captureException`, no `Sentry.startSpan`. The 12c personalization pipeline does not use Sentry tags. The aggregation worker does not use Sentry tags. The email worker does not use Sentry tags.
+
+### Pattern grouping
+
+| pattern | sites | example |
+|---|---|---|
+| init-and-forget | `lib/sentry.ts:11` | Boots Sentry once at server start. |
+| Express handler delegation | `lib/sentry.ts:37` | Lets Sentry catch unhandled Express errors. |
+| capture-and-continue (no tag) | `lib/envCheck.ts:77`, `middleware/apiKeyRateLimit.ts:97` | Single `captureMessage` call with no scoped tags or breadcrumbs. |
+
+**No `withScope` or `setTag` precedent exists.** The "Sentry tags through" goal of 12e.5c is genuinely greenfield — Stage 2 has to invent the per-stage tagging convention from scratch.
+
+### `lib/sentry.ts` init config (verbatim)
+
+```ts
+Sentry.init({
+  dsn,
+  environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV ?? "development",
+  release: process.env.SENTRY_RELEASE,
+  tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.1),
+  beforeSend(event) {
+    if (event.request?.headers) {
+      const h = event.request.headers as Record<string, unknown>;
+      delete h.authorization;
+      delete h.cookie;
+      delete h["x-api-key"];
+    }
+    return event;
+  },
+});
+```
+
+`tracesSampleRate: 0.1` is set. `beforeSend` strips auth headers. The `isSentryEnabled()` guard returns true only if `SENTRY_DSN` is set — same fail-open pattern as Redis. This is good — Stage 2 can safely call `Sentry.setTag` etc. without a guard, since calls are no-ops if `init` never ran.
+
+### Recommended pattern for 12e.5c per-stage tagging (planner confirms)
+
+`Sentry.withScope(scope => { scope.setTag("ingestion.stage", "facts"); scope.setTag("ingestion.candidate_id", candidateId); ... })` around each stage's call site, with `Sentry.captureException(err)` on terminal-rejection rather than success. This composes with the existing `init-and-forget + capture-and-continue` pattern. Alternative: BullMQ middleware or a Sentry `scope` wrapping the whole `processEnrichmentJob` invocation. The latter requires more thought about scope-leakage between concurrent jobs (concurrency=2 means two scopes can be active at once).
+
+---
+
+## 7. FUTURE / TODO / 12e.5c comments
+
+Verbatim list of every match for `12e\.5c|TODO.*12e|FUTURE` under `backend/src/jobs/ingestion/`:
+
+| file:line | comment |
+|---|---|
+| `enrichmentJob.ts:9` | `← 12e.5b ADDS the seam definitions; 12e.5c owns wiring into` |
+| `enrichmentJob.ts:12` | `event (12e.6b)` |
+| `enrichmentJob.ts:17` | `wire them into the orchestration body — that lands in 12e.5c, which` |
+| `enrichmentJob.ts:58` | `extractFacts; 12e.5b fills generateTier; 12e.6a fills resolveCluster.` |
+| `enrichmentJob.ts:83` | `` `enrichmentWorker.handle()` is 12e.5c's responsibility. `` |
+| `enrichmentWorker.ts:14` | `// 12e.5c: wire seams here (runHeuristic, runRelevanceGate, etc.).` |
+| `factsSeam.ts:156` | `upgrade to FACTS_RATE_LIMITED so soak observability + 12e.5c` |
+| `relevanceSeam.ts:135` | `upgrade to LLM_RATE_LIMITED so soak observability + 12e.5c` |
+| `sourcePollJob.ts:159` | `scanner / 12e.5c orchestration sweeps any missed candidates.` |
+| `sourcePollQueue.ts:6` | `12e.5c wires it to actual per-source cadences (RSS hourly, EDGAR` |
+| `sourcePollQueue.ts:9` | `` `ingestion_sources.fetch_interval_seconds` are introduced in 12e.5c. `` |
+| `tierGenerationSeam.ts:6` | `orchestration body (CLI in 12e.5b, worker in 12e.5c) owns the DB` |
+| `tierGenerationSeam.ts:186` | `upgrade to TIER_RATE_LIMITED so soak observability + 12e.5c` |
+| `tierOrchestration.ts:17` | `are unchanged from the CLI's prior in-line implementation. 12e.5c` |
+
+Plus migration comments:
+- `0019_phase12e5a_fact_extraction.sql:11` — `12e.5c orchestration copies this blob to events.facts at`
+- `0020_phase12e5b_tier_outputs.sql:6` — `and are awaiting event-write (12e.5c). Symmetric with 12e.4`
+- `0020_phase12e5b_tier_outputs.sql:15` — `12e.5c copies this blob to events.why_it_matters_template at`
+
+### Cross-cutting deferred work surfaced
+
+The `sourcePollQueue.ts:6,9` markers reveal **a second 12e.5c scope expansion** the brief did not mention: **per-source cadence configuration**. The poll queue currently doesn't read `ingestion_sources.fetch_interval_seconds`. That comment says 12e.5c should wire it. Two interpretations:
+- (a) Original 12e plan included per-source cadences inside 12e.5c's scope.
+- (b) The planner has since narrowed 12e.5c to just chain orchestration + dead-letter + Sentry, and the poll-cadence work is deferred elsewhere.
+
+The brief's stated scope is (b) — chain orchestration only. So poll-cadence appears to be out of scope but **flagged for planner**: the in-tree comments expect 12e.5c to land it. Stage 2 should either pick it up or explicitly defer to 12e.6+ with a comment-update.
+
+---
+
+## 8. CLAUDE.md operational contract excerpts
+
+### §7 JOBS & SCHEDULERS — verbatim
+
+> Two BullMQ queues, both backed by the shared Redis connection:
+>
+> | queue                | producer                          | worker                  | cadence                  |
+> |----------------------|-----------------------------------|-------------------------|--------------------------|
+> | `signal-email`       | `emailQueue.enqueue()`            | `emailWorker`           | on-demand + weekly trigger |
+> | `signal-aggregation` | `scheduleAggregationRepeatable()` | `aggregationWorker`     | `0 2 * * *` UTC, configurable via `AGGREGATION_CRON` |
+>
+> Plus one **in-process** scheduler:
+>
+> - `emailScheduler` — node-cron, default `0 8 * * 1` (Monday 08:00 UTC), overridable via `WEEKLY_DIGEST_CRON`; disable with `DISABLE_EMAIL_SCHEDULER=1` for local dev.
+
+**Stale.** §7 lists 2 queues; the codebase has **4** (`signal-email`, `signal-aggregation`, `signal-ingestion-poll`, `signal-ingestion-enrich`). The 2 ingestion queues from 12e.1 have not been added to §7. Out of scope for 12e.5c stage 2 to fix this, but flag it.
+
+### §8 — relevant constraints
+
+- **Lenient-on-read confirmed:** `parseWhyItMattersTemplate(raw)` returns `null` on null/empty/invalid (utils/depthVariants.ts).
+- **Two Haiku models, two pins:** depth-variant offline regeneration uses `claude-haiku-4-5` alias (`DEPTH_VARIANT_MODEL`); per-user request-path uses dated string `claude-haiku-4-5-20251001` (`COMMENTARY_MODEL`).
+- **Client contract for null template:** "When the template is `null`, the client falls back to `why_it_matters`. This is the permanent contract, not a migration-window hack — some rows may never get a template."
+
+The 12e.5c writer for events should follow the same pattern as the existing `stories` schema: `whyItMatters` NOT NULL (the role-neutral fallback), `whyItMattersTemplate` nullable (the depth-aware structured payload). Per-fact field discipline (Zod-validated, `assertWhyItMattersTemplate` at write boundary) should mirror what `regenerateDepthVariants.ts` does.
+
+### §15 phase status — relevant
+
+12e.5c position in the roadmap is mid-12e (post-12e.5b, pre-12e.6 clustering). No clustering work in scope.
+
+---
+
+## 9. Proposed sub-step sequencing (NOT a Stage 2 plan — just an order)
+
+Given the inventory, minimum-coupling order to ship 12e.5c chain orchestration:
+
+| step | scope | validation gate |
+|---|---|---|
+| **9.1** | Wire `extractFacts` short-circuit (skip if `facts_extracted_at IS NOT NULL`) inside `processEnrichmentJob`. Same for `runRelevanceGate` (skip if `llm_judgment_raw IS NOT NULL` AND status is past `heuristic_passed`). Closes the queue-retry double-charge gap surfaced in §3. | unit test: re-run on already-extracted candidate produces 0 LLM calls |
+| **9.2** | Wire `processTierGeneration` from `tierOrchestration.ts` into `processEnrichmentJob` after the facts stage. Extend `EnrichmentJobResult.terminalStatus` union to include `"tier_generated"`. | unit test mirroring `tierOrchestration.test.ts` patterns; CLI smoke against 1 candidate |
+| **9.3** | Resolve the `why_it_matters` fallback decision (planner). Build `writeEvent` (insert into `events` + `event_sources`). Wire as the post-trio terminal step. Status advances `tier_generated → published`. | unit test: writeEvent with mock DB; integration test: full chain on 1 candidate produces 1 event row + 1 event_source row |
+| **9.4** | Wire seams into `enrichmentWorker.handle()` — this is the brief's central deliverable. The worker now drains real BullMQ jobs through the full chain. | manual: enqueue 1 job, observe terminal status `published` |
+| **9.5** | Sentry per-stage tagging (`withScope` + `setTag` per stage). Capture exceptions on terminal-rejection, not on success. | manual: trigger a forced rejection, verify Sentry event arrives with stage tag |
+| **9.6** | Dead-letter wiring on the `failed` BullMQ event. Decision per planner: write to a `dead_letter` Postgres table, or rely on BullMQ failed-state for 7 days, or both. The brief said "dead-letter handling" — current state is just `console.error`. | manual: force a job to fail twice (exhaust attempts), verify it lands in BullMQ failed state + Sentry capture |
+| **9.7** | Live smoke against ephemeral local stack (12e.5b smoke pattern). N=5 candidates end-to-end. Emit smoke report. | smoke doc with per-candidate event-row contents |
+
+**Estimated session count: 5–6.** 9.1–9.4 are the chain wire-up — likely 2–3 sessions. 9.5–9.6 are observability — 1–2 sessions. 9.7 is the smoke — 1 session. The original 12e plan said 5–8 sessions for 12e.5c; this estimate fits the lower bound.
+
+The `sourcePollQueue` cadence work (per-source `fetch_interval_seconds`) is left out of this sequencing per brief scope — flagged for planner clarification.
+
+---
+
+## 10. Open questions / flags for planner
+
+### Critical / load-bearing
+
+- **`why_it_matters` is NOT NULL on `events` — Stage 2 cannot write an event without filling it.** The brief did not flag this. Four candidate strategies surfaced in §5: (a) use `briefed.thesis` as fallback, (b) extra Haiku call for role-neutral thesis, (c) synthesize from headline+facts, (d) make column nullable in 0021. **Resolve before Stage 2 starts.** Strongest recommendation: (a) use `briefed.thesis` as the role-neutral fallback — zero extra cost, semantically appropriate, the `briefed` register is closest to "general professional" framing.
+- **Queue-level retry on `signal-ingestion-enrich` would re-fire upstream stages and double-charge Haiku calls.** Per §3, `processEnrichmentJob` does NOT short-circuit on already-extracted state; it calls `runRelevanceGate` and `extractFacts` unconditionally if the seams are wired. With `attempts: 2`, a tier-stage failure triggers a full re-run that re-pays for relevance + facts. Step 9.1 in the proposed sequencing closes this gap, but it's a real bug today (latent — only fires when worker is wired). **Surface explicitly to planner so it gets the priority it deserves.**
+- **`context` field on `events` is NOT NULL with no obvious source.** Candidate has `body_text` (potentially 200KB) and `raw_summary`. Stage 2 needs a planner decision on what to write here — likely `raw_summary` if non-empty, else first 500 chars of `body_text`. Surface for explicit decision.
+
+### Brief framing inaccuracies
+
+- **The brief named `factsExtractionSeam.ts` — actual file is `factsSeam.ts`.** Same trap as the 12e.5a brief naming `cli/runIngestionEnrich.ts` instead of `scripts/runIngestionEnrich.ts`. Verified the actual filename via `ls`.
+- **§7 of CLAUDE.md is stale w.r.t. ingestion queues** (lists 2 queues; codebase has 4). Out of scope for 12e.5c stage 2 to fix, but worth flagging for a separate housekeeping pass.
+
+### Surprises / non-obvious findings
+
+- **Sentry instrumentation is essentially zero today.** 5 total call sites in the codebase, none in any worker or service that 12e.5c will touch. The "Sentry tags through" goal is greenfield. Stage 2 invents the per-stage tagging convention. The 12c personalization pipeline has no Sentry tagging precedent to copy.
+- **No `writeEvent` exists.** Stage 2 builds the events writer from scratch. It needs to also write to `event_sources` (per the schema's `INSERT INTO event_sources` requirement that exactly one `role='primary'` row exists per event; partial unique index from migration 0015 enforces this).
+- **The current worker is a 100% no-op for production traffic.** Every BullMQ-drained job hits the missing-seam guard at `enrichmentJob.ts:105–112` and returns `terminalStatus: "failed"`. The CLI is the only path that exercises the chain. Stage 2's wire-up is the first time the worker actually does work.
+- **The `sourcePollQueue.ts:6,9` markers say 12e.5c should wire per-source cadences** (`ingestion_sources.fetch_interval_seconds`). The brief's scope statement does NOT include cadence work. **Planner clarification needed:** is the cadence work (a) part of 12e.5c (brief omitted it), (b) deferred to 12e.6+ (comment-updates needed in source files), or (c) deferred but with a follow-up issue?
+- **Retry strategy is uniformly fail-fast across all four seams** (§3). 12e.5c does not need to invent a per-stage retry policy — it can adopt the "BullMQ attempts:2 + per-seam fail-fast at terminal class" pattern that already exists, just with the upstream-re-fire gap closed (§9.1). Decision 2 from the brief's scoping turn (per-row failure ceiling / DLQ) collapses to: **inherit existing seam discipline; don't add cross-stage retry policy**.
+- **`tierOrchestration.ts` is already perfectly shaped for plug-in to `processEnrichmentJob`** — accepts `candidateId` + `deps`, returns a structured `TierProcessSummary`, owns its own DB writes. Step 9.2 is mostly a 5-line call-site addition.


### PR DESCRIPTION
## Cluster scope

Phase 12e.5c — chain orchestration. Wires the four enrichment seams into `enrichmentWorker.handle()`, adds whole-job + per-stage short-circuits to prevent retry-driven double-charging and status-overwrite, builds the greenfield `writeEvent` writer with locked four-level `why_it_matters` fallback chain, wires per-source cadences via `scheduleSourcePollRepeatable`, establishes per-stage Sentry tagging convention (greenfield per Stage 1 audit §6), and replaces the worker `failed` console.error with proper DLQ + Sentry capture.

## Sub-step inventory (8 commits, includes 1 sub-step-3 correction)

| sub-step | commit | scope |
|---|---|---|
| 1 | `2a34ced` | whole-job + per-stage short-circuits in `processEnrichmentJob` |
| 2 | `980f6bc` | wire tier orchestration |
| 3 | `43c19fc` | `writeEvent` writer + locked fallback chain |
| 3-fix | `2046c38` | flip `computeWhyItMattersTemplate` to strict-at-write |
| 4 | `2f16c33` | wire seams into `enrichmentWorker.handle()` |
| 5 | `6107aeb` | per-source cadence via `scheduleSourcePollRepeatable` |
| 6 | `fd4deac` | per-stage Sentry tagging |
| 7 | `0d9b9eb` | DLQ wiring on BullMQ failed event |

Plus Stage 1 audit doc at `docs/discovery/phase-12e5c-audit.md` riding along from the `discovery/phase-12e5c` parent.

## Locked design decisions (planner-confirmed before Stage 2 began)

1. **Sequential tier calls** — preserves cost discipline (cheapest tier fails first → trio aborts after 1 call); simpler observability.
2. **Fail-fast inherit** — no new cross-stage retry policy. BullMQ `attempts: 2` + per-seam fail-fast at terminal class. Whole-job short-circuit closes the upstream-re-fire gap.
3. **`events.why_it_matters` fallback chain** — `briefed.thesis → accessible.thesis → technical.thesis → headline + first fact synthesis` (floor; column is NOT NULL).
4. **Block event-write until trio completes** — partial state lives on `ingestion_candidates`, never `events`. Status advances `tier_generated → published`.
5. **`events.context` source** — `raw_summary` if non-empty, else first 500 chars of `body_text` truncated at word boundary.
6. **Per-source cadence wiring included** — addresses in-tree markers at `sourcePollQueue.ts:6,9` flagging this for 12e.5c.

## Stage 1 audit findings addressed

- Latent queue-retry double-charge gap (audit §10) — closed by sub-step 1's whole-job + per-stage short-circuits.
- `events.why_it_matters` NOT NULL surprise (audit §10) — fallback chain locked and tested per fallback level.
- `events.context` NOT NULL surprise (audit §10) — `raw_summary`/`body_text` source locked.
- Sentry instrumentation greenfield (audit §6) — per-stage convention established with concurrency-2 scope isolation discipline.
- `writeEvent` did not exist (audit §5) — built from scratch with transactional `events` + `event_sources` insert.
- `assertWhyItMattersTemplate` shape mismatch (surfaced by CC mid-sub-step-3) — resolved by adding `assertTierTemplate` for the new 12e.5b shape; legacy asserter unchanged for `regenerateDepthVariants.ts` and `seedStories.ts`.

## What's NOT in this PR

- **Live smoke** (sub-step 8) — separate CC turn after merge. Validates end-to-end against ephemeral Docker Postgres + Redis per the 12e.5b smoke pattern.
- **Reader-side migration** to `parseTierTemplate` (`v2/storiesController`, `personalizationService`) — tracked as a follow-up issue (#63). Existing readers fall back to `events.why_it_matters` for events written by this PR until migration lands.
- **`writeEvent` retry mechanism** — under the locked design, writeEvent failure leaves the candidate at `status='tier_generated'` with `resolved_event_id=null`; the whole-job short-circuit blocks BullMQ auto-retry. Manual re-enqueue / CLI sweep is the only retry mechanism today. Tracked as a follow-up issue (#64).
- **Adapter-specific scheduling** (SEC EDGAR business-hours, arXiv daily-at-fixed-time) — 12e.5d concern. Simple `every: ms` is correct for all currently-shipped adapters.
- **`removeRepeatableByKey` cleanup pass** for `fetch_interval_seconds` mid-deploy changes — 12e.5d concern. Cadences are stable across deploys for 12e.5c.

## Verification

- `npm test --workspace=backend`: **798/798 passing** (725 baseline + 73 new tests across 5 new test files + edits to 1 existing). 2 pre-existing jsdom suite failures unchanged (`heuristicSeam.test.ts`, `bodyExtractor.test.ts` — documented in audit §10).
- `npm run type-check --workspace=backend`: clean.
- `npm run lint --workspace=backend`: clean.

## References

- Stage 1 audit: `docs/discovery/phase-12e5c-audit.md`
- 12e.5b smoke (canonical reference for the 12e.x ephemeral-Docker pattern): `docs/discovery/phase-12e5b-smoke.md`
- Locked design rationale: planner conversation prior to Stage 2 implementation prompt.
