### PR TITLE
fix(ingestion): add heuristic short-circuit to prevent status overwrite on re-enqueue (closes #65)

### DIFF
--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -157,6 +157,27 @@ const PAST_HEURISTIC_PASSED: ReadonlySet<string> = new Set([
   "published",
 ]);
 
+// Statuses that imply the heuristic stage has already produced a verdict
+// (passed, since heuristic_filtered is caught upstream by TERMINAL_STATES).
+// Used by the per-stage short-circuit before `runHeuristic` to skip the
+// re-run that would otherwise transiently overwrite a downstream status
+// (e.g., reverting 'facts_extracted' to 'heuristic_passed'), which the
+// tier seam's precondition would observe as a stage-mismatch and reject.
+// `duplicate` is included for consistency — a duplicate candidate has by
+// definition cleared the heuristic stage. `heuristic_filtered` and
+// `failed` are absent because TERMINAL_STATES catches them; `discovered`
+// is absent because first-run candidates must execute the heuristic.
+const HEURISTIC_ALREADY_RAN: ReadonlySet<string> = new Set([
+  "heuristic_passed",
+  "llm_rejected",
+  "llm_relevant",
+  "facts_extracted",
+  "tier_generated",
+  "enriching",
+  "published",
+  "duplicate",
+]);
+
 interface CandidateSnapshot {
   status: string;
   statusReason: string | null;
@@ -247,47 +268,59 @@ export async function processEnrichmentJob(
     };
   }
 
-  const result = await seams.runHeuristic(input.candidateId);
+  // Per-stage short-circuit (fix #65): skip the heuristic re-run when the
+  // snapshot shows the candidate has already cleared the heuristic stage
+  // on a prior invocation. Mirrors the relevance + facts pattern below.
+  // Without this guard, the heuristic would re-run on a re-enqueued
+  // facts_extracted candidate and transiently overwrite status to
+  // 'heuristic_passed', which the tier seam's precondition reads from
+  // current DB state and rejects as a stage mismatch.
+  const heuristicAlreadyRan =
+    snapshot !== null && HEURISTIC_ALREADY_RAN.has(snapshot.status);
 
-  if (!result.pass) {
+  if (!heuristicAlreadyRan) {
+    const result = await seams.runHeuristic(input.candidateId);
+
+    if (!result.pass) {
+      await db
+        .update(ingestionCandidates)
+        .set({
+          status: "heuristic_filtered",
+          statusReason: result.reason ?? "unknown",
+          processedAt: new Date(),
+        })
+        .where(eq(ingestionCandidates.id, input.candidateId));
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: null,
+        terminalStatus: "heuristic_filtered",
+        failureReason: result.reason ?? "unknown",
+      };
+    }
+
+    // Pass — persist body if present, advance status. Truncation is
+    // recorded informationally in status_reason but the candidate still
+    // moves forward (status='heuristic_passed').
+    const updates: {
+      status: "heuristic_passed";
+      processedAt: Date;
+      bodyText?: string;
+      statusReason?: string;
+    } = {
+      status: "heuristic_passed",
+      processedAt: new Date(),
+    };
+    if (result.body) {
+      updates.bodyText = result.body.text;
+      if (result.body.truncated) {
+        updates.statusReason = HEURISTIC_REASONS.BODY_TRUNCATED;
+      }
+    }
     await db
       .update(ingestionCandidates)
-      .set({
-        status: "heuristic_filtered",
-        statusReason: result.reason ?? "unknown",
-        processedAt: new Date(),
-      })
+      .set(updates)
       .where(eq(ingestionCandidates.id, input.candidateId));
-    return {
-      candidateId: input.candidateId,
-      resolvedEventId: null,
-      terminalStatus: "heuristic_filtered",
-      failureReason: result.reason ?? "unknown",
-    };
   }
-
-  // Pass — persist body if present, advance status. Truncation is
-  // recorded informationally in status_reason but the candidate still
-  // moves forward (status='heuristic_passed').
-  const updates: {
-    status: "heuristic_passed";
-    processedAt: Date;
-    bodyText?: string;
-    statusReason?: string;
-  } = {
-    status: "heuristic_passed",
-    processedAt: new Date(),
-  };
-  if (result.body) {
-    updates.bodyText = result.body.text;
-    if (result.body.truncated) {
-      updates.statusReason = HEURISTIC_REASONS.BODY_TRUNCATED;
-    }
-  }
-  await db
-    .update(ingestionCandidates)
-    .set(updates)
-    .where(eq(ingestionCandidates.id, input.candidateId));
 
   // ---- Relevance gate (12e.4) ----
   // Per-stage short-circuit (12e.5c sub-step 1): skip if a prior job

--- a/backend/tests/ingestion/enrichmentJob.test.ts
+++ b/backend/tests/ingestion/enrichmentJob.test.ts
@@ -680,9 +680,10 @@ describe("processEnrichmentJob", () => {
             seams: { runHeuristic, runRelevanceGate, extractFacts },
           },
         );
-        // Heuristic re-ran (idempotent re-pass), facts ran. Relevance was
-        // skipped because the snapshot showed it already produced a verdict.
-        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        // Heuristic skipped (snapshot status='llm_relevant' is in
+        // HEURISTIC_ALREADY_RAN — fix #65), relevance skipped (verdict
+        // already persisted), facts ran.
+        expect(runHeuristic).not.toHaveBeenCalled();
         expect(runRelevanceGate).not.toHaveBeenCalled();
         expect(extractFacts).toHaveBeenCalledTimes(1);
         expect(result.terminalStatus).toBe("facts_extracted");
@@ -709,9 +710,10 @@ describe("processEnrichmentJob", () => {
             seams: { runHeuristic, runRelevanceGate, extractFacts },
           },
         );
-        // Heuristic re-ran. Both relevance + facts skipped (snapshot showed
-        // them done). Result envelope echoes the fall-through facts_extracted.
-        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        // All three stages skipped (snapshot status='facts_extracted' is in
+        // HEURISTIC_ALREADY_RAN — fix #65; relevance + facts already done).
+        // Result envelope echoes the fall-through facts_extracted.
+        expect(runHeuristic).not.toHaveBeenCalled();
         expect(runRelevanceGate).not.toHaveBeenCalled();
         expect(extractFacts).not.toHaveBeenCalled();
         expect(result.terminalStatus).toBe("facts_extracted");
@@ -746,9 +748,11 @@ describe("processEnrichmentJob", () => {
             seams: { runHeuristic, runRelevanceGate, extractFacts },
           },
         );
-        // All three stages ran — no short-circuit fires for a fresh
-        // 'heuristic_passed' candidate that hasn't seen relevance.
-        expect(runHeuristic).toHaveBeenCalledTimes(1);
+        // Heuristic skipped (snapshot status='heuristic_passed' is in
+        // HEURISTIC_ALREADY_RAN — fix #65). Relevance + facts still run
+        // because their per-stage short-circuit predicates require
+        // llmJudgmentRaw / factsExtractedAt to be persisted.
+        expect(runHeuristic).not.toHaveBeenCalled();
         expect(runRelevanceGate).toHaveBeenCalledTimes(1);
         expect(extractFacts).toHaveBeenCalledTimes(1);
       });
@@ -778,6 +782,93 @@ describe("processEnrichmentJob", () => {
         expect(runHeuristic).toHaveBeenCalledTimes(1);
         expect(runRelevanceGate).toHaveBeenCalledTimes(1);
         expect(extractFacts).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("heuristic short-circuit (fix #65)", () => {
+      const passingHeuristic = {
+        pass: true,
+        body: { text: "article body for the test", truncated: false },
+      };
+
+      it("re-enqueue of facts_extracted candidate: heuristic skips, tier orchestration runs, reaches published", async () => {
+        // Reproducer for #65 — sub-step 8 smoke caught a re-enqueued
+        // facts_extracted candidate stuck at tier_parse_error because the
+        // unconditional heuristic re-run transiently overwrote status to
+        // 'heuristic_passed', which the tier seam's precondition rejected
+        // as a stage mismatch. Post-fix, heuristic skips on this snapshot
+        // and the chain proceeds straight to tier orchestration.
+        queueSnapshot([
+          {
+            status: "facts_extracted",
+            statusReason: null,
+            llmJudgmentRaw: { fake: true },
+            factsExtractedAt: new Date("2026-04-28T00:00:00Z"),
+            tierOutputs: null,
+            resolvedEventId: null,
+          },
+        ]);
+        const runHeuristic = jest.fn();
+        const runRelevanceGate = jest.fn();
+        const extractFacts = jest.fn();
+        const processTier = jest.fn().mockResolvedValue({
+          candidateId: CANDIDATE_ID,
+          ranTiers: ["accessible", "briefed", "technical"],
+          skippedTiers: [],
+          failedTier: null,
+          completed: true,
+        });
+        const writeEventMock = jest
+          .fn()
+          .mockResolvedValue({ eventId: "EVENT_ID" });
+        const result = await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          {
+            db: mock.db,
+            seams: { runHeuristic, runRelevanceGate, extractFacts },
+            processTier,
+            writeEvent: writeEventMock,
+          },
+        );
+        expect(runHeuristic).not.toHaveBeenCalled();
+        expect(runRelevanceGate).not.toHaveBeenCalled();
+        expect(extractFacts).not.toHaveBeenCalled();
+        expect(processTier).toHaveBeenCalledTimes(1);
+        expect(result.terminalStatus).toBe("published");
+      });
+
+      it("first-run candidate at discovered: heuristic runs normally", async () => {
+        // Regression guard — the short-circuit must NOT fire for a fresh
+        // candidate at status='discovered'. Anchors the negative side of
+        // HEURISTIC_ALREADY_RAN's membership.
+        queueSnapshot([
+          {
+            status: "discovered",
+            statusReason: null,
+            llmJudgmentRaw: null,
+            factsExtractedAt: null,
+            tierOutputs: null,
+            resolvedEventId: null,
+          },
+        ]);
+        const runHeuristic = jest.fn().mockResolvedValue(passingHeuristic);
+        const runRelevanceGate = jest.fn().mockResolvedValue({
+          relevant: true,
+          sector: "ai",
+          reason: "x",
+        });
+        const extractFacts = jest.fn().mockResolvedValue({
+          ok: true,
+          facts: { facts: [] },
+        });
+        await processEnrichmentJob(
+          { candidateId: CANDIDATE_ID },
+          {
+            db: mock.db,
+            seams: { runHeuristic, runRelevanceGate, extractFacts },
+          },
+        );
+        expect(runHeuristic).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -930,7 +1021,10 @@ describe("processEnrichmentJob", () => {
           writeEvent: writeEventMock,
         },
       );
-      expect(runHeuristic).toHaveBeenCalledTimes(1);
+      // Heuristic also skipped (fix #65 — snapshot status='facts_extracted'
+      // is in HEURISTIC_ALREADY_RAN). Tier orchestration is the only
+      // LLM-bearing stage that runs.
+      expect(runHeuristic).not.toHaveBeenCalled();
       expect(runRelevanceGate).not.toHaveBeenCalled();
       expect(extractFacts).not.toHaveBeenCalled();
       expect(processTier).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixes #65. Adds `HEURISTIC_ALREADY_RAN` set and a `heuristicAlreadyRan` guard in `processEnrichmentJob` mirroring the existing relevance + facts short-circuit pattern. When a candidate's snapshot status is already past heuristic (e.g. `facts_extracted`, `llm_relevant`, `tier_generated`), the heuristic seam call and its post-pass DB write are skipped — preventing the transient `status='heuristic_passed'` overwrite that broke the tier seam precondition on re-enqueue.

## Changes
- `enrichmentJob.ts`: `HEURISTIC_ALREADY_RAN` set + guard
- `enrichmentJob.test.ts`: 2 new tests (reproducer + negative case); 4 pre-existing assertions updated (they encoded the bug)

## Gates
- 800/800 tests pass
- tsc clean
- `tierGenerationSeam.ts` untouched (verified via git diff)