### PR TITLE
feat(ingestion): Phase 12e.6b — two-branch event write-path dispatch + source priority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,11 @@ Manual triggers for ops:
 
 **⚠️ pgvector deployment gate (Phase 12e.6a).** Migration `0021_phase12e6a_embeddings.sql` requires the `vector` extension (`CREATE EXTENSION IF NOT EXISTS vector;`). Railway's standard PostgreSQL service does NOT include pgvector; the next prod deploy after 12e.6a lands will fail at the migration step unless the database is provisioned from a pgvector-enabled service (Railway pgvector template or equivalent) before deploy. Dev / smoke environments use the `pgvector/pgvector:pg16` image (replaces `postgres:16-alpine` from prior smoke writeups). This gate is intentional — the 12e.6a branch can ship without prod risk because Railway prod migration is deferred until the pgvector-enabled service is in place.
 
+**12e.6b dispatch.** After tier orchestration completes, the chain dispatches on `clusterResult` from 12e.6a's embedding stage:
+- `clusterResult.matched=true` → `attachEventSource`: insert into `event_sources` with `role='alternate'`, or promote to `'primary'` (and demote the existing primary in the same transaction) when the incoming source's `priority` outranks the matched event's current primary. Lower `ingestion_sources.priority` value = higher rank (1=lab/SEC, 2=analyst, 3=news, 4=community).
+- `clusterResult.matched=false` (or `clusterResult` absent — embedding soft-failed) → existing `writeEvent`: new `events` row + primary `event_sources` row.
+- Re-enrichment when a higher-quality alternate later joins is **12e.6c scope**; the seam is marked with a `TODO(12e.6c)` in `attachEventSource.ts`.
+
 ---
 
 ## 8. DEPTH-VARIANT COMMENTARY (Phase 12a)

--- a/backend/src/db/migrations/0022_phase12e6b_source_priority.sql
+++ b/backend/src/db/migrations/0022_phase12e6b_source_priority.sql
@@ -1,0 +1,64 @@
+-- 0022 — Phase 12e.6b: source priority for primary-source promotion on cluster match.
+--
+-- Lower value = higher priority. Used by the 12e.6b dispatch when an
+-- incoming candidate clusters onto an existing event: if its source's
+-- priority outranks the current primary's source, the incoming source
+-- promotes to role='primary' and the existing primary demotes to
+-- role='alternate'. Otherwise the incoming attaches as 'alternate' and
+-- the existing primary stands.
+--
+-- Tier rubric:
+--   1: lab blogs, primary research (arXiv, HF Papers), regulators
+--      (SEC EDGAR, Federal Reserve, BLS, BIS), first-party newsroom
+--   2: analyst newsletters and curated digests
+--   3: news outlets and trade press                 (DEFAULT)
+--   4: community / aggregators (Hacker News, Reddit)
+
+ALTER TABLE ingestion_sources
+  ADD COLUMN priority integer NOT NULL DEFAULT 3;--> statement-breakpoint
+
+-- Tier 1: first-party labs, primary research, regulators, first-party newsroom.
+UPDATE ingestion_sources SET priority = 1 WHERE slug IN (
+  'anthropic-news',
+  'openai-news',
+  'deepmind-blog',
+  'google-research',
+  'meta-ai-blog',
+  'arxiv-ai-cl-lg',
+  'huggingface-papers',
+  'nvidia-newsroom',
+  'amd-newsroom',
+  'tsmc-newsroom',
+  'asml-news',
+  'intel-newsroom',
+  'bis-press',
+  'sec-edgar-semis',
+  'sec-edgar-full',
+  'fed-press',
+  'bls-press'
+);--> statement-breakpoint
+
+-- Tier 2: analyst newsletters and curated digests.
+UPDATE ingestion_sources SET priority = 2 WHERE slug IN (
+  'import-ai',
+  'interconnects',
+  'simonwillison',
+  'the-batch',
+  'semianalysis',
+  'fabricated-knowledge',
+  'asianometry',
+  'money-stuff',
+  'the-diff',
+  'net-interest',
+  'apricitas',
+  'marginal-revolution',
+  'stratechery-free'
+);--> statement-breakpoint
+
+-- Tier 4: community / aggregators. (fred-api stays at the DEFAULT 3 — it
+-- is currently disabled and would be repriced if/when re-enabled, since
+-- it's a first-party data feed if enabled in production.)
+UPDATE ingestion_sources SET priority = 4 WHERE slug IN (
+  'hackernews',
+  'reddit-finance'
+);

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -542,6 +542,9 @@ export const ingestionSources = pgTable(
     sectors: text("sectors").array().notNull(),
     fetchIntervalSeconds: integer("fetch_interval_seconds").notNull().default(1800),
     qualityScore: smallint("quality_score").notNull().default(5),
+    // Phase 12e.6b: lower = higher priority. Drives primary-source
+    // promotion on cluster match. 1=lab/SEC, 2=analyst, 3=news, 4=community.
+    priority: integer("priority").notNull().default(3),
     enabled: boolean("enabled").notNull().default(true),
     pairedWriterId: uuid("paired_writer_id").references(() => writers.id, {
       onDelete: "set null",

--- a/backend/src/jobs/ingestion/attachEventSource.ts
+++ b/backend/src/jobs/ingestion/attachEventSource.ts
@@ -1,0 +1,194 @@
+// Phase 12e.6b — cluster-match attach path. Consumed by enrichmentJob's
+// two-branch dispatch when the embedding seam reports a cluster hit
+// against an existing event in the trailing-72h window.
+//
+// Behavior:
+//   1. Load incoming candidate + its source (priority + name).
+//   2. Load the matched event's current role='primary' row + that
+//      source's priority.
+//   3. If incoming.priority < currentPrimary.priority (lower = higher
+//      priority), promote: demote existing primary to 'alternate',
+//      insert new row as 'primary'. Otherwise insert as 'alternate'.
+//   4. Mark candidate as published with resolved_event_id pointing at
+//      the matched event.
+//
+// All writes happen inside a single Drizzle transaction so a partial
+// state — new alternate row landed but candidate status not advanced,
+// or promotion's demote landed but new primary insert violates the
+// partial unique index — is impossible.
+//
+// Re-enrichment (12e.6c) is NOT triggered here — see the TODO inside
+// loadCandidateForAttach where bodyText is loaded so the seam will be
+// 12e.6c-ready without a second DB query at that time.
+
+import { and, eq } from "drizzle-orm";
+
+import { db as defaultDb } from "../../db";
+import {
+  eventSources,
+  ingestionCandidates,
+  ingestionSources,
+} from "../../db/schema";
+
+export interface AttachEventSourceInput {
+  candidateId: string;
+  matchedEventId: string;
+  similarity: number;
+}
+
+export type AttachFailureReason =
+  | "attach_db_error"
+  | "attach_source_missing";
+
+export type AttachEventSourceResult =
+  | { ok: true; promoted: boolean }
+  | { ok: false; rejectionReason: AttachFailureReason; error?: unknown };
+
+export interface AttachEventSourceDeps {
+  db?: typeof defaultDb;
+  now?: () => Date;
+}
+
+interface CandidateRowForAttach {
+  ingestionSourceId: string | null;
+  url: string;
+  rawTitle: string | null;
+  bodyText: string | null;
+  sourcePriority: number | null;
+  sourceDisplayName: string | null;
+}
+
+async function loadCandidateForAttach(
+  db: typeof defaultDb,
+  candidateId: string,
+): Promise<CandidateRowForAttach | null> {
+  const rows = await db
+    .select({
+      ingestionSourceId: ingestionCandidates.ingestionSourceId,
+      url: ingestionCandidates.url,
+      rawTitle: ingestionCandidates.rawTitle,
+      // TODO(12e.6c): bodyText loaded here for re-enrichment trigger check.
+      // When 12e.6c lands, add: if (wordCount(bodyText) > wordCount(primary.bodyText))
+      // → trigger re-enrich pipeline against the matched event.
+      bodyText: ingestionCandidates.bodyText,
+      sourcePriority: ingestionSources.priority,
+      sourceDisplayName: ingestionSources.displayName,
+    })
+    .from(ingestionCandidates)
+    .leftJoin(
+      ingestionSources,
+      eq(ingestionSources.id, ingestionCandidates.ingestionSourceId),
+    )
+    .where(eq(ingestionCandidates.id, candidateId))
+    .limit(1);
+  return (rows[0] as CandidateRowForAttach | undefined) ?? null;
+}
+
+interface CurrentPrimaryRow {
+  id: string;
+  ingestionSourceId: string | null;
+  priority: number | null;
+}
+
+async function loadCurrentPrimary(
+  db: typeof defaultDb,
+  matchedEventId: string,
+): Promise<CurrentPrimaryRow | null> {
+  const rows = await db
+    .select({
+      id: eventSources.id,
+      ingestionSourceId: eventSources.ingestionSourceId,
+      priority: ingestionSources.priority,
+    })
+    .from(eventSources)
+    .leftJoin(
+      ingestionSources,
+      eq(ingestionSources.id, eventSources.ingestionSourceId),
+    )
+    .where(
+      and(
+        eq(eventSources.eventId, matchedEventId),
+        eq(eventSources.role, "primary"),
+      ),
+    )
+    .limit(1);
+  return (rows[0] as CurrentPrimaryRow | undefined) ?? null;
+}
+
+export async function attachEventSource(
+  input: AttachEventSourceInput,
+  deps: AttachEventSourceDeps = {},
+): Promise<AttachEventSourceResult> {
+  const db = deps.db ?? defaultDb;
+  const now = deps.now ?? ((): Date => new Date());
+
+  const candidate = await loadCandidateForAttach(db, input.candidateId);
+  if (!candidate || !candidate.ingestionSourceId) {
+    return { ok: false, rejectionReason: "attach_source_missing" };
+  }
+
+  const incomingPriority = candidate.sourcePriority ?? 3;
+  const currentPrimary = await loadCurrentPrimary(db, input.matchedEventId);
+
+  // Promotion fires only when:
+  //   - a current primary row exists
+  //   - its source FK and priority are resolvable (not NULL from a
+  //     deleted ingestion_sources row — null FK/priority means we can't
+  //     compare, so keep the existing primary)
+  //   - the incoming candidate's priority strictly outranks (lower wins)
+  // Equal priority keeps the existing primary (first-mover wins on ties).
+  const promote =
+    currentPrimary !== null &&
+    currentPrimary.priority !== null &&
+    incomingPriority < currentPrimary.priority;
+
+  try {
+    return await db.transaction(async (tx) => {
+      if (promote && currentPrimary) {
+        // Demote first to free the partial unique index
+        // (event_sources_one_primary_per_event ON event_sources (event_id)
+        // WHERE role = 'primary'). Inserting the new primary before this
+        // demote would violate the constraint.
+        await tx
+          .update(eventSources)
+          .set({ role: "alternate" })
+          .where(eq(eventSources.id, currentPrimary.id));
+
+        await tx.insert(eventSources).values({
+          eventId: input.matchedEventId,
+          ingestionSourceId: candidate.ingestionSourceId,
+          url: candidate.url,
+          name: candidate.sourceDisplayName,
+          role: "primary",
+        });
+      } else {
+        await tx.insert(eventSources).values({
+          eventId: input.matchedEventId,
+          ingestionSourceId: candidate.ingestionSourceId,
+          url: candidate.url,
+          name: candidate.sourceDisplayName,
+          role: "alternate",
+        });
+      }
+
+      await tx
+        .update(ingestionCandidates)
+        .set({
+          status: "published",
+          resolvedEventId: input.matchedEventId,
+          statusReason: null,
+          processedAt: now(),
+        })
+        .where(eq(ingestionCandidates.id, input.candidateId));
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[ingestion-attach] candidate=${input.candidateId} event=${input.matchedEventId} similarity=${input.similarity.toFixed(4)} promoted=${promote}`,
+      );
+
+      return { ok: true as const, promoted: promote };
+    });
+  } catch (error) {
+    return { ok: false, rejectionReason: "attach_db_error", error };
+  }
+}

--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -35,6 +35,7 @@ import {
   checkCluster as defaultCheckCluster,
   type ClusterCheckResult,
 } from "./clusterCheckSeam";
+import { attachEventSource as defaultAttachEventSource } from "./attachEventSource";
 import { getOpenAIClient } from "../../lib/openaiClient";
 
 export interface EnrichmentJobInput {
@@ -67,6 +68,11 @@ export interface EnrichmentJobResult {
   // reads this to dispatch new-event vs. attach-as-alternate without a
   // second DB roundtrip.
   clusterResult?: ClusterCheckResult;
+  // 12e.6b: present when the cluster-match attach path ran. true when
+  // the incoming source's priority outranked the matched event's current
+  // primary and the new row was promoted to role='primary'. Absent on
+  // the no-match (writeEvent) branch and on attach failures.
+  promoted?: boolean;
 }
 
 // Seam interface — each method is filled in by a downstream sub-session.
@@ -125,6 +131,11 @@ export interface EnrichmentJobDeps {
   // to assert the call shape without exercising the full transactional
   // events + event_sources + candidate-status update chain.
   writeEvent?: typeof defaultWriteEvent;
+  // Phase 12e.6b — optional override for the cluster-match attach path.
+  // Defaults to `attachEventSource` from attachEventSource.ts. Tests
+  // inject a mock to assert dispatch behavior without exercising the
+  // full priority-comparison + transaction logic of the seam.
+  attachEventSource?: typeof defaultAttachEventSource;
   // Optional override for the per-stage Sentry capture helper (12e.5c
   // sub-step 6). Defaults to `captureIngestionStageFailure` from
   // lib/sentryHelpers.ts. Tests inject a mock to assert per-stage tag
@@ -612,9 +623,56 @@ export async function processEnrichmentJob(
 
   if (tierSummary.completed) {
     // markTierGeneratedComplete has written status='tier_generated' +
-    // tier_generated_at. Sub-step 3 wires the chain through to
-    // writeEvent: insert events + event_sources, advance candidate to
-    // 'published', set resolved_event_id.
+    // tier_generated_at. The chain now dispatches into one of two
+    // event-write paths based on 12e.6a's clusterResult:
+    //
+    //   matched   → 12e.6b attachEventSource: row added to event_sources
+    //               (role='alternate', or 'primary' if the incoming
+    //               source's priority outranks the current primary and
+    //               the existing primary is demoted in the same txn).
+    //               Candidate published with resolved_event_id pointing
+    //               at the matched event.
+    //   no match  → 12e.5c writeEvent: insert new events row + primary
+    //               event_sources row + advance candidate to published.
+    //   absent    → embedding seam soft-failed; treat as no-match and
+    //               fall through to writeEvent (avoids losing a candidate
+    //               on an embedding outage).
+    if (clusterResult?.matched) {
+      const runAttach = deps.attachEventSource ?? defaultAttachEventSource;
+      const attachResult = await runAttach(
+        {
+          candidateId: input.candidateId,
+          matchedEventId: clusterResult.matchedEventId,
+          similarity: clusterResult.similarity,
+        },
+        { db },
+      );
+      if (!attachResult.ok) {
+        captureFailure({
+          stage: "attach_event_source",
+          candidateId: input.candidateId,
+          sourceSlug: snapshot?.sourceSlug ?? null,
+          rejectionReason: attachResult.rejectionReason,
+          err: attachResult.error,
+        });
+        return {
+          candidateId: input.candidateId,
+          resolvedEventId: null,
+          terminalStatus: "failed",
+          failureReason: `attach_error: ${attachResult.rejectionReason}`,
+          clusterResult,
+        };
+      }
+      return {
+        candidateId: input.candidateId,
+        resolvedEventId: clusterResult.matchedEventId,
+        terminalStatus: "published",
+        failureReason: null,
+        clusterResult,
+        promoted: attachResult.promoted,
+      };
+    }
+
     const runWriteEvent = deps.writeEvent ?? defaultWriteEvent;
     try {
       const { eventId } = await runWriteEvent(input.candidateId, { db });

--- a/backend/src/lib/sentryHelpers.ts
+++ b/backend/src/lib/sentryHelpers.ts
@@ -32,6 +32,11 @@ export type IngestionStage =
   // 12e.6a — embedding seam soft-failure. The chain continues past an
   // embedding failure; clusterResult stays absent on the result envelope.
   | "embedding"
+  // 12e.6b — cluster-match attach failure. Distinct from write_event
+  // (which fires on the no-match branch only). Captured when attaching
+  // to an existing event fails with a DB-level error or when the
+  // candidate's ingestion_source_id is null.
+  | "attach_event_source"
   // 12e.5c sub-step 7 — BullMQ-level failure, distinct from the
   // orchestration-stage failures above. Fires from
   // enrichmentWorker.ts's `failed` handler when a job throws past

--- a/backend/tests/ingestion/attachEventSource.test.ts
+++ b/backend/tests/ingestion/attachEventSource.test.ts
@@ -1,0 +1,163 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { createMockDb, type MockDb } from "../helpers/mockDb";
+import { attachEventSource } from "../../src/jobs/ingestion/attachEventSource";
+
+const CANDIDATE_ID = "00000000-0000-0000-0000-0000000000aa";
+const EVENT_ID = "11111111-1111-1111-1111-111111111111";
+
+let mock: MockDb;
+
+beforeEach(() => {
+  mock = createMockDb();
+});
+
+// Two queueSelect calls per attach: candidate-for-attach, then current-primary.
+function queueAttachReads(
+  candidate: {
+    ingestionSourceId: string | null;
+    sourcePriority: number | null;
+    sourceDisplayName?: string | null;
+  },
+  currentPrimary:
+    | { id: string; ingestionSourceId: string | null; priority: number | null }
+    | null,
+): void {
+  mock.queueSelect([
+    {
+      ingestionSourceId: candidate.ingestionSourceId,
+      url: "https://example.test/article",
+      rawTitle: "Title",
+      bodyText: "body of the article",
+      sourcePriority: candidate.sourcePriority,
+      sourceDisplayName: candidate.sourceDisplayName ?? "Test Source",
+    },
+  ]);
+  mock.queueSelect(currentPrimary ? [currentPrimary] : []);
+}
+
+describe("attachEventSource", () => {
+  it("equal priority → role='alternate', promoted=false, candidate published", async () => {
+    queueAttachReads(
+      { ingestionSourceId: "src-incoming", sourcePriority: 3 },
+      { id: "es-existing", ingestionSourceId: "src-existing", priority: 3 },
+    );
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.9 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.promoted).toBe(false);
+    // One INSERT (alternate row), no UPDATE on existing primary, one UPDATE
+    // on candidate row.
+    const inserted = mock.state.insertedValues[0];
+    expect(inserted).toMatchObject({
+      eventId: EVENT_ID,
+      ingestionSourceId: "src-incoming",
+      role: "alternate",
+    });
+    const candidatePatch = mock.state.updatedRows.find(
+      (r: any) => r.status === "published",
+    );
+    expect(candidatePatch).toMatchObject({
+      status: "published",
+      resolvedEventId: EVENT_ID,
+    });
+  });
+
+  it("lower priority value (higher rank) → existing primary demoted, new row inserted as primary, promoted=true", async () => {
+    queueAttachReads(
+      { ingestionSourceId: "src-incoming", sourcePriority: 1 },
+      { id: "es-existing", ingestionSourceId: "src-existing", priority: 3 },
+    );
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.91 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.promoted).toBe(true);
+    // First UPDATE demotes existing primary to alternate.
+    const demote = mock.state.updatedRows[0];
+    expect(demote).toMatchObject({ role: "alternate" });
+    // INSERT then advances candidate.
+    const inserted = mock.state.insertedValues[0];
+    expect(inserted).toMatchObject({ role: "primary" });
+  });
+
+  it("higher priority value (lower rank) incoming → role='alternate', promoted=false", async () => {
+    queueAttachReads(
+      { ingestionSourceId: "src-incoming", sourcePriority: 4 },
+      { id: "es-existing", ingestionSourceId: "src-existing", priority: 2 },
+    );
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.88 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.promoted).toBe(false);
+    expect(mock.state.insertedValues[0]).toMatchObject({ role: "alternate" });
+  });
+
+  it("null candidate ingestionSourceId → returns attach_source_missing without writes", async () => {
+    queueAttachReads(
+      { ingestionSourceId: null, sourcePriority: null },
+      { id: "es-existing", ingestionSourceId: "src-existing", priority: 3 },
+    );
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.9 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.rejectionReason).toBe("attach_source_missing");
+    expect(mock.state.insertedValues).toHaveLength(0);
+    expect(mock.state.updatedRows).toHaveLength(0);
+  });
+
+  it("DB transaction throws → returns attach_db_error wrapping the error", async () => {
+    queueAttachReads(
+      { ingestionSourceId: "src-incoming", sourcePriority: 3 },
+      { id: "es-existing", ingestionSourceId: "src-existing", priority: 3 },
+    );
+    const txError = new Error("simulated unique-violation");
+    mock.db.transaction = jest.fn().mockRejectedValue(txError);
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.9 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.rejectionReason).toBe("attach_db_error");
+      expect(result.error).toBe(txError);
+    }
+  });
+
+  it("current primary missing FK / null priority → keeps existing primary, attaches as alternate", async () => {
+    // Defensive: deleted ingestion_sources row leaves event_sources.ingestion_source_id
+    // null via ON DELETE SET NULL. Without a comparable priority, promotion can't
+    // run safely — first-mover wins.
+    queueAttachReads(
+      { ingestionSourceId: "src-incoming", sourcePriority: 1 },
+      { id: "es-existing", ingestionSourceId: null, priority: null },
+    );
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.9 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.promoted).toBe(false);
+    expect(mock.state.insertedValues[0]).toMatchObject({ role: "alternate" });
+  });
+
+  it("no current primary at all (matched event has none) → attaches as alternate, no promotion", async () => {
+    queueAttachReads(
+      { ingestionSourceId: "src-incoming", sourcePriority: 1 },
+      null,
+    );
+    const result = await attachEventSource(
+      { candidateId: CANDIDATE_ID, matchedEventId: EVENT_ID, similarity: 0.9 },
+      { db: mock.db },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.promoted).toBe(false);
+    expect(mock.state.insertedValues[0]).toMatchObject({ role: "alternate" });
+  });
+});

--- a/backend/tests/ingestion/enrichmentJob.test.ts
+++ b/backend/tests/ingestion/enrichmentJob.test.ts
@@ -1632,4 +1632,188 @@ describe("processEnrichmentJob", () => {
       expect(embeddingCalls).toHaveLength(0);
     });
   });
+
+  describe("12e.6b two-branch dispatch (cluster match → attach; no match → writeEvent)", () => {
+    const passingHeuristic = {
+      pass: true,
+      body: { text: "article body for the test", truncated: false },
+    };
+
+    function fullSeams(): {
+      runHeuristic: jest.Mock;
+      runRelevanceGate: jest.Mock;
+      extractFacts: jest.Mock;
+    } {
+      return {
+        runHeuristic: jest.fn().mockResolvedValue(passingHeuristic),
+        runRelevanceGate: jest.fn().mockResolvedValue({
+          relevant: true,
+          sector: "ai",
+          reason: "x",
+        }),
+        extractFacts: jest.fn().mockResolvedValue({
+          ok: true,
+          facts: { facts: [{ text: "fact text >=10 chars", category: "actor" }] },
+        }),
+      };
+    }
+
+    const completedTier = {
+      candidateId: CANDIDATE_ID,
+      ranTiers: ["accessible", "briefed", "technical"],
+      skippedTiers: [],
+      failedTier: null,
+      completed: true,
+    };
+
+    function fakeEmbedding(): number[] {
+      return Array(1536).fill(0.5);
+    }
+
+    it("cluster match → attachEventSource called, writeEvent NOT called, terminalStatus=published, promoted forwarded", async () => {
+      mock.queueSelect([]); // snapshot
+      const seams = fullSeams();
+      const computeEmbedding = jest
+        .fn()
+        .mockResolvedValue({ ok: true, embedding: fakeEmbedding() });
+      const checkCluster = jest.fn().mockResolvedValue({
+        matched: true,
+        matchedEventId: "evt-cluster-99",
+        similarity: 0.93,
+      });
+      const attachEventSourceMock = jest
+        .fn()
+        .mockResolvedValue({ ok: true, promoted: true });
+      const writeEventMock = jest.fn();
+      const processTier = jest.fn().mockResolvedValue(completedTier);
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { ...seams, computeEmbedding, checkCluster },
+          processTier,
+          writeEvent: writeEventMock,
+          attachEventSource: attachEventSourceMock,
+        },
+      );
+      expect(attachEventSourceMock).toHaveBeenCalledTimes(1);
+      expect(attachEventSourceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidateId: CANDIDATE_ID,
+          matchedEventId: "evt-cluster-99",
+          similarity: 0.93,
+        }),
+        expect.any(Object),
+      );
+      expect(writeEventMock).not.toHaveBeenCalled();
+      expect(result.terminalStatus).toBe("published");
+      expect(result.resolvedEventId).toBe("evt-cluster-99");
+      expect(result.promoted).toBe(true);
+    });
+
+    it("cluster match + attach failure → captureFailure with stage='attach_event_source', terminalStatus=failed", async () => {
+      mock.queueSelect([]);
+      const seams = fullSeams();
+      const computeEmbedding = jest
+        .fn()
+        .mockResolvedValue({ ok: true, embedding: fakeEmbedding() });
+      const checkCluster = jest.fn().mockResolvedValue({
+        matched: true,
+        matchedEventId: "evt-cluster-99",
+        similarity: 0.93,
+      });
+      const attachError = new Error("simulated unique-violation");
+      const attachEventSourceMock = jest.fn().mockResolvedValue({
+        ok: false,
+        rejectionReason: "attach_db_error",
+        error: attachError,
+      });
+      const writeEventMock = jest.fn();
+      const captureFailure = jest.fn();
+      const processTier = jest.fn().mockResolvedValue(completedTier);
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { ...seams, computeEmbedding, checkCluster },
+          processTier,
+          writeEvent: writeEventMock,
+          attachEventSource: attachEventSourceMock,
+          captureFailure,
+        },
+      );
+      expect(writeEventMock).not.toHaveBeenCalled();
+      expect(captureFailure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stage: "attach_event_source",
+          rejectionReason: "attach_db_error",
+          err: attachError,
+        }),
+      );
+      expect(result.terminalStatus).toBe("failed");
+      expect(result.failureReason).toMatch(/^attach_error: /);
+    });
+
+    it("no cluster match → writeEvent called (existing path), attach NOT called", async () => {
+      mock.queueSelect([]);
+      const seams = fullSeams();
+      const computeEmbedding = jest
+        .fn()
+        .mockResolvedValue({ ok: true, embedding: fakeEmbedding() });
+      const checkCluster = jest.fn().mockResolvedValue({ matched: false });
+      const attachEventSourceMock = jest.fn();
+      const writeEventMock = jest
+        .fn()
+        .mockResolvedValue({ eventId: "evt-new-100" });
+      const processTier = jest.fn().mockResolvedValue(completedTier);
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { ...seams, computeEmbedding, checkCluster },
+          processTier,
+          writeEvent: writeEventMock,
+          attachEventSource: attachEventSourceMock,
+        },
+      );
+      expect(writeEventMock).toHaveBeenCalledTimes(1);
+      expect(attachEventSourceMock).not.toHaveBeenCalled();
+      expect(result.terminalStatus).toBe("published");
+      expect(result.resolvedEventId).toBe("evt-new-100");
+      expect(result.promoted).toBeUndefined();
+    });
+
+    it("clusterResult absent (embedding soft-failed) → writeEvent called, treated as no-match", async () => {
+      mock.queueSelect([]);
+      const seams = fullSeams();
+      // Embedding seam fails soft → clusterResult never populated.
+      const computeEmbedding = jest.fn().mockResolvedValue({
+        ok: false,
+        rejectionReason: "embedding_api_error",
+      });
+      const checkCluster = jest.fn();
+      const attachEventSourceMock = jest.fn();
+      const writeEventMock = jest
+        .fn()
+        .mockResolvedValue({ eventId: "evt-new-101" });
+      const processTier = jest.fn().mockResolvedValue(completedTier);
+      const captureFailure = jest.fn();
+      const result = await processEnrichmentJob(
+        { candidateId: CANDIDATE_ID },
+        {
+          db: mock.db,
+          seams: { ...seams, computeEmbedding, checkCluster },
+          processTier,
+          writeEvent: writeEventMock,
+          attachEventSource: attachEventSourceMock,
+          captureFailure,
+        },
+      );
+      expect(checkCluster).not.toHaveBeenCalled();
+      expect(attachEventSourceMock).not.toHaveBeenCalled();
+      expect(writeEventMock).toHaveBeenCalledTimes(1);
+      expect(result.terminalStatus).toBe("published");
+      expect(result.clusterResult).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Phase 12e.6b. Implements the two-branch dispatch on clusterResult from 12e.6a: cluster match → attachEventSource (role=alternate, with priority-based promotion to primary); no match → existing writeEvent path (new event, candidate = primary).

## Changes
- Migration 0022: ingestion_sources.priority integer column (DEFAULT 3), priority assignments for all 42 sources
- attachEventSource.ts: transactional attach with demote-then-insert ordering (respects event_sources_one_primary_per_event partial unique index)
- enrichmentJob.ts: two-branch dispatch reading clusterResult
- sentryHelpers.ts: attach_event_source added to IngestionStage union
- CLAUDE.md §7: dispatch description updated

## Test count
860/860 with `--runInBand` (parallel run has pre-existing flaky timeouts on unrelated integration suites)

## Notes
- `clusterResult.matched=false` and `clusterResult=undefined` both route to writeEvent (no-match treatment)
- TODO(12e.6c) marker in attachEventSource.ts at bodyText load site — seam is 12e.6c-ready
- writeEvent.ts, tierOrchestration.ts, enrichmentWorkerFailure.ts untouched (verified)