### PR TITLE
fix(ingestion): copy candidate.embedding to events on writeEvent

### DIFF
--- a/backend/src/jobs/ingestion/reenrichEvent.ts
+++ b/backend/src/jobs/ingestion/reenrichEvent.ts
@@ -188,6 +188,7 @@ export async function reenrichEvent(
     sector: null,
     facts: refreshed.facts,
     tierOutputs: refreshed.tierOutputs,
+    embedding: null,
     sourceDisplayName: "",
     sourcePairedWriterId: null,
   };

--- a/backend/src/jobs/ingestion/writeEvent.ts
+++ b/backend/src/jobs/ingestion/writeEvent.ts
@@ -89,6 +89,7 @@ export interface CandidateRowForWrite {
   sector: string | null;
   facts: Record<string, unknown> | null;
   tierOutputs: Record<string, unknown> | null;
+  embedding: number[] | null;
   sourceDisplayName: string;
   sourcePairedWriterId: string | null;
 }
@@ -109,6 +110,7 @@ async function loadCandidateForWrite(
       sector: ingestionCandidates.sector,
       facts: ingestionCandidates.facts,
       tierOutputs: ingestionCandidates.tierOutputs,
+      embedding: ingestionCandidates.embedding,
       sourceDisplayName: ingestionSources.displayName,
       sourcePairedWriterId: ingestionSources.pairedWriterId,
     })
@@ -259,6 +261,7 @@ export async function writeEvent(
         authorId: candidate.sourcePairedWriterId,
         facts: factsBlob,
         publishedAt: candidate.rawPublishedAt,
+        embedding: candidate.embedding,
       })
       .returning({ id: events.id });
 

--- a/backend/src/scripts/smoke12e5c.ts
+++ b/backend/src/scripts/smoke12e5c.ts
@@ -232,6 +232,7 @@ async function waitForDrain(
   if (!queue) throw new Error("queue unavailable");
   const start = Date.now();
   let lastLog = 0;
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const counts = await queue.getJobCounts(
       "active",

--- a/backend/src/scripts/smoke12e6.ts
+++ b/backend/src/scripts/smoke12e6.ts
@@ -205,6 +205,7 @@ async function waitForDrain(label: string, timeoutMs = 25 * 60 * 1000): Promise<
   if (!queue) throw new Error("queue unavailable");
   const start = Date.now();
   let lastLog = 0;
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const counts = await queue.getJobCounts("active", "waiting", "delayed");
     const remaining = counts.active + counts.waiting + counts.delayed;

--- a/backend/tests/ingestion/writeEvent.test.ts
+++ b/backend/tests/ingestion/writeEvent.test.ts
@@ -46,6 +46,7 @@ function fullCandidate(
         support: "Technical support text passing TierOutputSchema bounds.",
       },
     },
+    embedding: [0.1, 0.2, 0.3],
     sourceDisplayName: "Example Source",
     sourcePairedWriterId: WRITER_ID,
     ...overrides,
@@ -364,6 +365,22 @@ describe("writeEvent integration", () => {
     await expect(writeEvent(CANDIDATE_ID, { db: mock.db })).rejects.toThrow(
       /null sector/,
     );
+  });
+
+  it("copies candidate.embedding into events.embedding (cluster-match prerequisite, fixes #73)", async () => {
+    const sampleEmbedding = [0.41, -0.02, 0.31, 0.21, 0.28];
+    queueLoadCandidate({ embedding: sampleEmbedding });
+    mock.queueInsert([{ id: EVENT_ID }]);
+    await writeEvent(CANDIDATE_ID, { db: mock.db });
+    expect(mock.state.insertedValues[0].embedding).toEqual(sampleEmbedding);
+  });
+
+  it("passes null embedding through (soft-fail path) without crashing", async () => {
+    queueLoadCandidate({ embedding: null });
+    mock.queueInsert([{ id: EVENT_ID }]);
+    const result = await writeEvent(CANDIDATE_ID, { db: mock.db });
+    expect(result).toEqual({ eventId: EVENT_ID });
+    expect(mock.state.insertedValues[0].embedding).toBeNull();
   });
 
   it("transaction rollback: event_sources insert failure propagates and skips candidate update", async () => {


### PR DESCRIPTION
Closes #73 — surfaced by the Phase 12e.6 smoke (PR #74).

## Summary

- writeEvent now copies candidate.embedding → events.embedding via `loadCandidateForWrite` SELECT + INSERT pass-through.
- reenrichEvent updated to pass `embedding: null` in its CandidateRowForWrite construction (helpers don't read embedding; type-only change).
- Two new tests in writeEvent.test.ts: happy-path embedding copy + null-embedding soft-fail.

## Test count
- Baseline (canonical main, openai missing from canonical node_modules — 4 suites failed to compile): `Tests: 772 passed, Test Suites: 4 failed, 59 passed, 63 total`
- Worktree post-fix (fresh `npm ci`, openai installed): `Tests: 876 passed, Test Suites: 63 passed`
- writeEvent.test.ts specifically: 26 → 28 tests (**+2** as expected)

## Why this fix is small
Schema (events.embedding vector(1536) from migration 0021), dispatch (12e.6b), and seams (12e.6a–c) already exist. Only the writeEvent INSERT was missing the column.

## Verification path
The smoke harness in PR #74 contained a wrappedWriteEvent that performs this exact copy post-INSERT. With that workaround in place, the cluster-check seam queried real vectors successfully (zero matches in that cohort, but the path was wired). This fix moves that copy into production code; the smoke wrapper remains as a historical artifact (idempotent — writes the same value).

## Pre-existing issues incidentally fixed

Lint failed on canonical main with two `no-constant-condition` errors in pre-existing smoke harnesses (`smoke12e5c.ts:235`, `smoke12e6.ts:208` — both `while (true)` drain-wait loops). These pre-date this branch and were not caught when their smoke PRs (#62, #74) merged — the smoke PRs likely ran typecheck only. Added minimal `eslint-disable-next-line no-constant-condition` comments to both. No behavioral change. Surfacing this so future planner can investigate why prior PRs merged with broken lint gates (suggests the local-gates discipline in CLAUDE.md §13 has a hole).

## Known stale state on canonical (not addressed here)
`C:\dev\signal-app\node_modules` is stale relative to `package.json` — missing `openai`. Out of scope for this PR; running `npm ci` at canonical would fix. Worth flagging because the 4-suite baseline failure made the test count delta less straightforward to compute than expected.