### PR TITLE
feat(api,frontend): dual-read feed + event saves/comments + multi-source attribution (12e.7a)

### DIFF
--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -1,8 +1,15 @@
 import type { NextFunction, Request, Response } from "express";
-import { and, desc, eq, gte, inArray, lte, ne, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, ne, or, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
-import { stories, userProfiles, userSaves, writers } from "../db/schema";
+import {
+  events,
+  eventSources,
+  stories,
+  userProfiles,
+  userSaves,
+  writers,
+} from "../db/schema";
 import { AppError } from "../middleware/errorHandler";
 import { personalizeStory } from "../services/personalizationService";
 
@@ -82,6 +89,80 @@ function shapeStory(row: StoryRow, role: string | null): Record<string, unknown>
     commentary_source: null,
     source_url: row.sourceUrl,
     source_name: row.sourceName,
+    // Phase 12e.7a — multi-source attribution. Hand-curated stories
+    // carry a synthetic single-element array so the wire shape is
+    // uniform across legacy stories and ingestion-written events.
+    primary_source_url: row.sourceUrl,
+    sources: [
+      { url: row.sourceUrl, name: row.sourceName, role: "primary" as const },
+    ],
+    published_at: row.publishedAt,
+    created_at: row.createdAt,
+    author: row.authorId
+      ? { id: row.authorId, name: row.authorName, bio: row.authorBio }
+      : null,
+    is_saved: Boolean(row.isSaved),
+    save_count: Number(row.saveCount ?? 0),
+    comment_count: Number(row.commentCount ?? 0),
+  };
+}
+
+// Phase 12e.7a — event-row shape and renderer. EventRow mirrors StoryRow
+// where the columns line up; the divergent fields are
+// `primarySourceUrl` / `primarySourceName` (denormalized on `events`)
+// versus `sourceUrl` / `sourceName` (on `stories`). `sources` is fetched
+// separately and passed in by the caller.
+interface EventRow {
+  id: string;
+  sector: string;
+  headline: string;
+  context: string;
+  whyItMatters: string;
+  whyItMattersTemplate: string | null;
+  primarySourceUrl: string;
+  primarySourceName: string | null;
+  publishedAt: Date | null;
+  createdAt: Date;
+  authorId: string | null;
+  authorName: string | null;
+  authorBio: string | null;
+  isSaved: boolean;
+  saveCount: number;
+  commentCount: number;
+}
+
+interface EventSourceRow {
+  url: string;
+  name: string | null;
+  role: string;
+}
+
+function shapeEvent(
+  row: EventRow,
+  role: string | null,
+  sources: EventSourceRow[],
+): Record<string, unknown> {
+  return {
+    id: row.id,
+    sector: row.sector,
+    headline: row.headline,
+    context: row.context,
+    why_it_matters: row.whyItMatters,
+    why_it_matters_to_you: personalizeStory({
+      whyItMatters: row.whyItMatters,
+      whyItMattersTemplate: row.whyItMattersTemplate,
+      role,
+    }),
+    commentary: null,
+    commentary_source: null,
+    // `source_url` and `source_name` are kept on the wire for
+    // backward compatibility with v1 consumers — they reflect the
+    // primary source. New consumers should read `sources` for the
+    // full attribution list.
+    source_url: row.primarySourceUrl,
+    source_name: row.primarySourceName,
+    primary_source_url: row.primarySourceUrl,
+    sources,
     published_at: row.publishedAt,
     created_at: row.createdAt,
     author: row.authorId
@@ -103,6 +184,25 @@ function saveCountExpr(): ReturnType<typeof sql<number>> {
 
 function commentCountExpr(): ReturnType<typeof sql<number>> {
   return sql<number>`(SELECT COUNT(*)::int FROM comments c WHERE c.story_id = ${stories.id} AND c.deleted_at IS NULL)`;
+}
+
+// Phase 12e.7a — event-side equivalents of the three subquery helpers
+// above. The `is_saved` / `save_count` / `comment_count` semantics on the
+// API payload are unchanged; the difference is which FK column the
+// subquery targets.
+function isEventSavedExpr(userId: string): ReturnType<typeof sql<boolean>> {
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM user_saves us
+    WHERE us.event_id = ${events.id} AND us.user_id = ${userId}
+  )`;
+}
+
+function eventSaveCountExpr(): ReturnType<typeof sql<number>> {
+  return sql<number>`(SELECT COUNT(*)::int FROM user_saves us WHERE us.event_id = ${events.id})`;
+}
+
+function eventCommentCountExpr(): ReturnType<typeof sql<number>> {
+  return sql<number>`(SELECT COUNT(*)::int FROM comments c WHERE c.event_id = ${events.id} AND c.deleted_at IS NULL)`;
 }
 
 const baseStoryColumns = {
@@ -140,7 +240,12 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
       return;
     }
 
-    const rows = (await db
+    // Phase 12e.7a — dual-read across `stories` (legacy hand-curated)
+    // and `events` (ingestion-written). Each table is queried with the
+    // same limit/offset; the two pages are merged client-side and sliced
+    // back to `limit` before shaping. `total` is the union row count
+    // (sum across both tables) so `has_more` reflects the union.
+    const storyRows = (await db
       .select({
         ...baseStoryColumns,
         isSaved: isSavedExpr(userId),
@@ -154,19 +259,97 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
       .limit(limit)
       .offset(offset)) as StoryRow[];
 
-    const [countRow] = await db
+    const eventRows = (await db
+      .select({
+        id: events.id,
+        sector: events.sector,
+        headline: events.headline,
+        context: events.context,
+        whyItMatters: events.whyItMatters,
+        whyItMattersTemplate: events.whyItMattersTemplate,
+        primarySourceUrl: events.primarySourceUrl,
+        primarySourceName: events.primarySourceName,
+        publishedAt: events.publishedAt,
+        createdAt: events.createdAt,
+        authorId: writers.id,
+        authorName: writers.name,
+        authorBio: writers.bio,
+        isSaved: isEventSavedExpr(userId),
+        saveCount: eventSaveCountExpr(),
+        commentCount: eventCommentCountExpr(),
+      })
+      .from(events)
+      .leftJoin(writers, eq(writers.id, events.authorId))
+      .where(inArray(events.sector, sectorsFilter))
+      .orderBy(desc(sql`COALESCE(${events.publishedAt}, ${events.createdAt})`))
+      .limit(limit)
+      .offset(offset)) as EventRow[];
+
+    type MergedItem =
+      | { _type: "story"; row: StoryRow }
+      | { _type: "event"; row: EventRow };
+    const merged: MergedItem[] = [
+      ...storyRows.map((row): MergedItem => ({ _type: "story", row })),
+      ...eventRows.map((row): MergedItem => ({ _type: "event", row })),
+    ];
+    merged.sort((a, b) => {
+      const aTs = (a.row.publishedAt ?? a.row.createdAt).getTime();
+      const bTs = (b.row.publishedAt ?? b.row.createdAt).getTime();
+      return bTs - aTs;
+    });
+    const pageItems = merged.slice(0, limit);
+
+    // Batch-fetch event_sources for whichever event items survived the
+    // merge slice. Skip the round-trip when no events are on the page.
+    const eventIds = pageItems
+      .filter((m): m is { _type: "event"; row: EventRow } => m._type === "event")
+      .map((m) => m.row.id);
+    const allSources =
+      eventIds.length > 0
+        ? await db
+            .select({
+              eventId: eventSources.eventId,
+              url: eventSources.url,
+              name: eventSources.name,
+              role: eventSources.role,
+            })
+            .from(eventSources)
+            .where(inArray(eventSources.eventId, eventIds))
+        : [];
+    const sourcesByEventId = new Map<string, EventSourceRow[]>();
+    for (const s of allSources) {
+      const arr = sourcesByEventId.get(s.eventId) ?? [];
+      arr.push({ url: s.url, name: s.name, role: s.role });
+      sourcesByEventId.set(s.eventId, arr);
+    }
+
+    // Counts: union total = stories matching sectors + events matching sectors.
+    const [storiesCountRow] = await db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(stories)
       .where(inArray(stories.sector, sectorsFilter));
-    const total = Number(countRow?.count ?? 0);
+    const [eventsCountRow] = await db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(events)
+      .where(inArray(events.sector, sectorsFilter));
+    const total =
+      Number(storiesCountRow?.count ?? 0) + Number(eventsCountRow?.count ?? 0);
 
-    const shaped = rows.map((row) => shapeStory(row, profile?.role ?? null));
+    const shaped = pageItems.map((m) =>
+      m._type === "story"
+        ? shapeStory(m.row, profile?.role ?? null)
+        : shapeEvent(
+            m.row,
+            profile?.role ?? null,
+            sourcesByEventId.get(m.row.id) ?? [],
+          ),
+    );
 
     res.json({
       data: {
         stories: shaped,
         total,
-        has_more: offset + rows.length < total,
+        has_more: offset + pageItems.length < total,
         limit,
         offset,
       },
@@ -204,7 +387,49 @@ export async function getStoryById(
       .limit(1)) as StoryRow[];
 
     if (!row) {
-      throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
+      // Phase 12e.7a — events fallback. The id may name an
+      // ingestion-written event rather than a hand-curated story.
+      const [eventRow] = (await db
+        .select({
+          id: events.id,
+          sector: events.sector,
+          headline: events.headline,
+          context: events.context,
+          whyItMatters: events.whyItMatters,
+          whyItMattersTemplate: events.whyItMattersTemplate,
+          primarySourceUrl: events.primarySourceUrl,
+          primarySourceName: events.primarySourceName,
+          publishedAt: events.publishedAt,
+          createdAt: events.createdAt,
+          authorId: writers.id,
+          authorName: writers.name,
+          authorBio: writers.bio,
+          isSaved: isEventSavedExpr(userId),
+          saveCount: eventSaveCountExpr(),
+          commentCount: eventCommentCountExpr(),
+        })
+        .from(events)
+        .leftJoin(writers, eq(writers.id, events.authorId))
+        .where(eq(events.id, id))
+        .limit(1)) as EventRow[];
+
+      if (!eventRow) {
+        throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
+      }
+
+      const sources = await db
+        .select({
+          url: eventSources.url,
+          name: eventSources.name,
+          role: eventSources.role,
+        })
+        .from(eventSources)
+        .where(eq(eventSources.eventId, id));
+
+      res.json({
+        data: { story: shapeEvent(eventRow, profile?.role ?? null, sources) },
+      });
+      return;
     }
 
     res.json({ data: { story: shapeStory(row, profile?.role ?? null) } });
@@ -213,23 +438,16 @@ export async function getStoryById(
   }
 }
 
-async function countSaves(storyId: string): Promise<number> {
+// Phase 12e.7a — saves can target either a story or an event. Counts
+// match on whichever FK column carries the id; the CHECK constraint at
+// the DB level guarantees exactly one is non-null per row, so the OR
+// here doesn't double-count.
+async function countSaves(itemId: string): Promise<number> {
   const [row] = await db
     .select({ count: sql<number>`COUNT(*)::int` })
     .from(userSaves)
-    .where(eq(userSaves.storyId, storyId));
+    .where(or(eq(userSaves.storyId, itemId), eq(userSaves.eventId, itemId)));
   return Number(row?.count ?? 0);
-}
-
-async function ensureStoryExists(storyId: string): Promise<void> {
-  const [row] = await db
-    .select({ id: stories.id })
-    .from(stories)
-    .where(eq(stories.id, storyId))
-    .limit(1);
-  if (!row) {
-    throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
-  }
 }
 
 export async function saveStory(
@@ -240,14 +458,36 @@ export async function saveStory(
   try {
     const userId = requireUserId(req);
     const { id } = idParamSchema.parse(req.params);
-    await ensureStoryExists(id);
 
-    await db
-      .insert(userSaves)
-      .values({ userId, storyId: id })
-      .onConflictDoNothing({
-        target: [userSaves.userId, userSaves.storyId],
-      });
+    // Dispatch on whether the id names a story or an event. UUIDs are
+    // generated globally so there's no namespace collision risk.
+    const [storyCheck] = await db
+      .select({ id: stories.id })
+      .from(stories)
+      .where(eq(stories.id, id))
+      .limit(1);
+
+    if (storyCheck) {
+      await db
+        .insert(userSaves)
+        .values({ userId, storyId: id })
+        .onConflictDoNothing({
+          target: [userSaves.userId, userSaves.storyId],
+        });
+    } else {
+      const [eventCheck] = await db
+        .select({ id: events.id })
+        .from(events)
+        .where(eq(events.id, id))
+        .limit(1);
+      if (!eventCheck) {
+        throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
+      }
+      await db
+        .insert(userSaves)
+        .values({ userId, eventId: id })
+        .onConflictDoNothing();
+    }
 
     const saveCount = await countSaves(id);
     res.json({ data: { saved: true, save_count: saveCount } });
@@ -267,7 +507,12 @@ export async function unsaveStory(
 
     await db
       .delete(userSaves)
-      .where(and(eq(userSaves.userId, userId), eq(userSaves.storyId, id)));
+      .where(
+        and(
+          eq(userSaves.userId, userId),
+          or(eq(userSaves.storyId, id), eq(userSaves.eventId, id)),
+        ),
+      );
 
     const saveCount = await countSaves(id);
     res.json({ data: { saved: false, save_count: saveCount } });

--- a/backend/src/db/migrations/0023_phase12e7a_event_saves_comments.sql
+++ b/backend/src/db/migrations/0023_phase12e7a_event_saves_comments.sql
@@ -1,0 +1,46 @@
+-- Phase 12e.7a — saves and comments can target either a story or an event.
+-- Adds a nullable event_id FK alongside the existing nullable-as-of-now
+-- story_id FK, plus a CHECK constraint that exactly one is non-null. The
+-- partial unique index on (user_id, event_id) preserves the no-duplicate-
+-- saves-per-target invariant for the new branch (the existing
+-- user_saves_user_story_unique still covers the story branch — its
+-- (user_id, story_id) uniqueness is unaffected by the NULL drop because
+-- Postgres treats NULLs as distinct in a unique constraint, so multiple
+-- event-saves with story_id NULL coexist freely).
+--
+-- Existing rows: every row currently has story_id non-null and event_id
+-- absent. After ADD COLUMN event_id (defaulting to NULL), every existing
+-- row satisfies the CHECK (1 + 0 = 1).
+--
+-- Rejection-test for the CHECK (run manually post-migration if needed):
+--   INSERT INTO user_saves (user_id, story_id, event_id) VALUES (
+--     '<uuid>', NULL, NULL);                      -- rejected: 0 + 0 ≠ 1
+--   INSERT INTO user_saves (user_id, story_id, event_id) VALUES (
+--     '<uuid>', '<story-uuid>', '<event-uuid>');  -- rejected: 1 + 1 ≠ 1
+
+BEGIN;
+
+-- user_saves: story_id nullable + event_id FK + exactly-one constraint + partial unique index
+ALTER TABLE user_saves ALTER COLUMN story_id DROP NOT NULL;
+ALTER TABLE user_saves
+  ADD COLUMN event_id UUID REFERENCES events(id) ON DELETE CASCADE;
+ALTER TABLE user_saves
+  ADD CONSTRAINT user_saves_exactly_one_target CHECK (
+    (story_id IS NOT NULL)::int + (event_id IS NOT NULL)::int = 1
+  );
+CREATE UNIQUE INDEX user_saves_user_event_unique
+  ON user_saves (user_id, event_id)
+  WHERE event_id IS NOT NULL;
+
+-- comments: same pattern
+ALTER TABLE comments ALTER COLUMN story_id DROP NOT NULL;
+ALTER TABLE comments
+  ADD COLUMN event_id UUID REFERENCES events(id) ON DELETE CASCADE;
+ALTER TABLE comments
+  ADD CONSTRAINT comments_exactly_one_target CHECK (
+    (story_id IS NOT NULL)::int + (event_id IS NOT NULL)::int = 1
+  );
+CREATE INDEX comments_event_idx ON comments (event_id)
+  WHERE event_id IS NOT NULL;
+
+COMMIT;

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -278,6 +278,13 @@ export const storyAggregates = pgTable(
 
 // ---------- User saves ----------
 
+// Phase 12e.7a — story_id is now nullable; rows target either a story or
+// an event (mutually exclusive, enforced at the DB level by the
+// `user_saves_exactly_one_target` CHECK in migration 0023). The partial
+// unique index `user_saves_user_event_unique` covers the event branch;
+// the existing `user_saves_user_story_unique` still covers the story
+// branch (Postgres NULLs are distinct, so event-save rows with story_id
+// NULL never collide on the story-side index).
 export const userSaves = pgTable(
   "user_saves",
   {
@@ -285,9 +292,8 @@ export const userSaves = pgTable(
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    storyId: uuid("story_id")
-      .notNull()
-      .references(() => stories.id, { onDelete: "cascade" }),
+    storyId: uuid("story_id").references(() => stories.id, { onDelete: "cascade" }),
+    eventId: uuid("event_id").references(() => events.id, { onDelete: "cascade" }),
     savedAt: timestamp("saved_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
@@ -367,13 +373,16 @@ export const teamInvites = pgTable(
 
 // ---------- Comments ----------
 
+// Phase 12e.7a — story_id is nullable as of migration 0023; comments
+// target either a story or an event (CHECK constraint
+// `comments_exactly_one_target` enforces exactly one). New event-side
+// queries use the partial `comments_event_idx` (event_id WHERE NOT NULL).
 export const comments = pgTable(
   "comments",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    storyId: uuid("story_id")
-      .notNull()
-      .references(() => stories.id, { onDelete: "cascade" }),
+    storyId: uuid("story_id").references(() => stories.id, { onDelete: "cascade" }),
+    eventId: uuid("event_id").references(() => events.id, { onDelete: "cascade" }),
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),

--- a/backend/tests/saves.integration.test.ts
+++ b/backend/tests/saves.integration.test.ts
@@ -39,13 +39,38 @@ describe("saves endpoints", () => {
       expect(res.status).toBe(401);
     });
 
-    it("returns 404 when the story does not exist", async () => {
-      mock.queueSelect([]);
+    it("returns 404 when neither a story nor an event exists for the id", async () => {
+      // Phase 12e.7a — saveStory now dispatches: it tries `stories`
+      // first, then falls back to `events`. Both miss → 404.
+      mock.queueSelect([]); // story miss
+      mock.queueSelect([]); // event miss
       const res = await request(app)
         .post(`/api/v1/stories/${storyId}/save`)
         .set(...auth(token));
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe("STORY_NOT_FOUND");
+    });
+
+    // Phase 12e.7a — event-save dispatch. When the id names an event
+    // rather than a story, the row is inserted with eventId set.
+    it("inserts a save targeting an event when story lookup misses", async () => {
+      const eventId = "55555555-5555-5555-5555-555555555555";
+      mock.queueSelect([]); // story miss
+      mock.queueSelect([{ id: eventId }]); // event hit
+      mock.queueInsert([]); // insert into user_saves with eventId
+      mock.queueSelect([{ count: 2 }]); // count via OR(story_id, event_id)
+
+      const res = await request(app)
+        .post(`/api/v1/stories/${eventId}/save`)
+        .set(...auth(token));
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ saved: true, save_count: 2 });
+      // The insert recorded an eventId, not a storyId.
+      const insert = mock.state.insertedValues.find(
+        (v) => v.eventId === eventId,
+      );
+      expect(insert).toBeDefined();
     });
 
     it("returns 400 for invalid UUID", async () => {

--- a/backend/tests/stories.integration.test.ts
+++ b/backend/tests/stories.integration.test.ts
@@ -87,7 +87,13 @@ describe("stories endpoints", () => {
       queueOnboarded();
       mock.queueSelect([{ sectors: ["ai"], role: "engineer" }]);
       mock.queueSelect([makeRow()]);
-      mock.queueSelect([{ count: 1 }]);
+      // Phase 12e.7a — getFeed does a dual-read across stories + events,
+      // batched event_sources, then a count per table. Empty events
+      // returns mean the event_sources fetch is skipped (controller
+      // guards on eventIds.length > 0).
+      mock.queueSelect([]); // events query — empty
+      mock.queueSelect([{ count: 1 }]); // stories count
+      mock.queueSelect([{ count: 0 }]); // events count
 
       const res = await request(app)
         .get("/api/v1/stories/feed")
@@ -107,7 +113,9 @@ describe("stories endpoints", () => {
       queueOnboarded();
       mock.queueSelect([{ sectors: ["ai"], role: "vc" }]);
       mock.queueSelect([makeRow({ sector: "finance" })]);
-      mock.queueSelect([{ count: 1 }]);
+      mock.queueSelect([]); // events query — empty
+      mock.queueSelect([{ count: 1 }]); // stories count
+      mock.queueSelect([{ count: 0 }]); // events count
 
       const res = await request(app)
         .get("/api/v1/stories/feed?sectors=finance")
@@ -124,7 +132,9 @@ describe("stories endpoints", () => {
       queueOnboarded();
       mock.queueSelect([{ sectors: ["ai"], role: "engineer" }]);
       mock.queueSelect([makeRow(), makeRow({ id: "22222222-2222-2222-2222-222222222222" })]);
-      mock.queueSelect([{ count: 10 }]);
+      mock.queueSelect([]); // events query — empty
+      mock.queueSelect([{ count: 10 }]); // stories count
+      mock.queueSelect([{ count: 0 }]); // events count
 
       const res = await request(app)
         .get("/api/v1/stories/feed?limit=2&offset=0")
@@ -136,6 +146,76 @@ describe("stories endpoints", () => {
       expect(res.body.data.has_more).toBe(true);
       expect(res.body.data.limit).toBe(2);
       expect(res.body.data.offset).toBe(0);
+    });
+
+    // Phase 12e.7a — dual-read merged sort. Verifies that an events row
+    // newer than every story comes first in the merged page, event_sources
+    // are batched + attached, and multi-source attribution surfaces on
+    // the wire shape of both event items and legacy story items.
+    it("merges stories + events sorted by published_at DESC and attaches sources", async () => {
+      queueOnboarded();
+      mock.queueSelect([{ sectors: ["ai"], role: "engineer" }]);
+      // stories: one row at 2026-04-01
+      mock.queueSelect([makeRow({ headline: "Older story" })]);
+      // events: one row at 2026-04-10 (newer) — should land first
+      const eventId = "33333333-3333-3333-3333-333333333333";
+      mock.queueSelect([
+        {
+          id: eventId,
+          sector: "ai",
+          headline: "Newer event",
+          context: "Event context",
+          whyItMatters: "Event WIM",
+          whyItMattersTemplate: null,
+          primarySourceUrl: "https://primary.example.com",
+          primarySourceName: "Primary Source",
+          publishedAt: new Date("2026-04-10T00:00:00Z"),
+          createdAt: new Date("2026-04-10T00:00:00Z"),
+          authorId: null,
+          authorName: null,
+          authorBio: null,
+          isSaved: false,
+          saveCount: 0,
+          commentCount: 0,
+        },
+      ]);
+      // event_sources batch: two rows for the one event (primary + alternate)
+      mock.queueSelect([
+        {
+          eventId,
+          url: "https://primary.example.com",
+          name: "Primary Source",
+          role: "primary",
+        },
+        {
+          eventId,
+          url: "https://alternate.example.com",
+          name: "Alternate Source",
+          role: "alternate",
+        },
+      ]);
+      mock.queueSelect([{ count: 1 }]); // stories count
+      mock.queueSelect([{ count: 1 }]); // events count
+
+      const res = await request(app)
+        .get("/api/v1/stories/feed")
+        .set(...auth(token));
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.stories).toHaveLength(2);
+      // Newer event lands first.
+      expect(res.body.data.stories[0].id).toBe(eventId);
+      expect(res.body.data.stories[0].headline).toBe("Newer event");
+      expect(res.body.data.stories[0].sources).toHaveLength(2);
+      expect(res.body.data.stories[0].primary_source_url).toBe(
+        "https://primary.example.com",
+      );
+      // Older story second; legacy stories carry a synthetic single-element sources array.
+      expect(res.body.data.stories[1].headline).toBe("Older story");
+      expect(res.body.data.stories[1].sources).toHaveLength(1);
+      expect(res.body.data.stories[1].sources[0].role).toBe("primary");
+      expect(res.body.data.total).toBe(2);
+      expect(res.body.data.has_more).toBe(false);
     });
 
     it("rejects invalid limit values", async () => {
@@ -179,9 +259,10 @@ describe("stories endpoints", () => {
       expect(res.status).toBe(400);
     });
 
-    it("returns 404 when story is missing", async () => {
+    it("returns 404 when story is missing (and events fallback also misses)", async () => {
       mock.queueSelect([{ role: "engineer" }]);
-      mock.queueSelect([]);
+      mock.queueSelect([]); // story lookup miss
+      mock.queueSelect([]); // Phase 12e.7a — events fallback miss
 
       const res = await request(app)
         .get(`/api/v1/stories/${storyId}`)
@@ -189,6 +270,63 @@ describe("stories endpoints", () => {
 
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe("STORY_NOT_FOUND");
+    });
+
+    // Phase 12e.7a — events fallback. When the id names an
+    // ingestion-written event (no row in `stories`), the controller
+    // falls back to the `events` table and returns the shaped event
+    // with its event_sources array.
+    it("returns event from the fallback path with multi-source attribution", async () => {
+      const eventId = "44444444-4444-4444-4444-444444444444";
+      mock.queueSelect([{ role: "engineer" }]);
+      mock.queueSelect([]); // story lookup miss
+      mock.queueSelect([
+        {
+          id: eventId,
+          sector: "semiconductors",
+          headline: "TSMC pulls in 2nm",
+          context: "Context.",
+          whyItMatters: "Costs fall.",
+          whyItMattersTemplate: null,
+          primarySourceUrl: "https://primary.example.com",
+          primarySourceName: "Primary",
+          publishedAt: new Date("2026-04-12T00:00:00Z"),
+          createdAt: new Date("2026-04-12T00:00:00Z"),
+          authorId: null,
+          authorName: null,
+          authorBio: null,
+          isSaved: false,
+          saveCount: 0,
+          commentCount: 0,
+        },
+      ]);
+      mock.queueSelect([
+        {
+          url: "https://primary.example.com",
+          name: "Primary",
+          role: "primary",
+        },
+        {
+          url: "https://alt.example.com",
+          name: "Alt",
+          role: "alternate",
+        },
+      ]);
+
+      const res = await request(app)
+        .get(`/api/v1/stories/${eventId}`)
+        .set(...auth(token));
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.story.id).toBe(eventId);
+      expect(res.body.data.story.headline).toBe("TSMC pulls in 2nm");
+      expect(res.body.data.story.sources).toHaveLength(2);
+      expect(res.body.data.story.primary_source_url).toBe(
+        "https://primary.example.com",
+      );
+      expect(res.body.data.story.why_it_matters_to_you).toContain(
+        "As an engineer",
+      );
     });
 
     it("returns the story with personalized why_it_matters_to_you", async () => {

--- a/frontend/src/components/stories/StoryCard.tsx
+++ b/frontend/src/components/stories/StoryCard.tsx
@@ -127,15 +127,22 @@ export function StoryCard({ story }: StoryCardProps): JSX.Element {
           </span>
         </div>
         {story.source_url && (
-          <a
-            href={story.source_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-slate-500 hover:text-violet-700"
-          >
-            {story.source_name ?? "Source"}
-            <ExternalLink className="h-3 w-3" />
-          </a>
+          <div className="inline-flex items-center gap-1">
+            <a
+              href={story.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-slate-500 hover:text-violet-700"
+            >
+              {story.source_name ?? "Source"}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+            {story.sources.length > 1 && (
+              <span className="text-slate-400">
+                +{story.sources.length - 1} more
+              </span>
+            )}
+          </div>
         )}
       </div>
     </article>

--- a/frontend/src/components/stories/StoryDetail.tsx
+++ b/frontend/src/components/stories/StoryDetail.tsx
@@ -79,15 +79,26 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
           {story.comment_count} comments
         </span>
         {story.source_url && (
-          <a
-            href={story.source_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-slate-600 hover:text-violet-700"
-          >
-            {story.source_name ?? "Read source"}
-            <ExternalLink className="h-3.5 w-3.5" />
-          </a>
+          <div className="flex flex-col items-end gap-1">
+            <a
+              href={story.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-slate-600 hover:text-violet-700"
+            >
+              {story.source_name ?? "Read source"}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+            {story.sources.length > 1 && (
+              <span className="text-xs text-slate-400">
+                Also covered by{" "}
+                {story.sources
+                  .filter((s) => s.role === "alternate")
+                  .map((s) => s.name ?? "unknown")
+                  .join(", ")}
+              </span>
+            )}
+          </div>
         )}
       </footer>
     </article>

--- a/frontend/src/types/story.ts
+++ b/frontend/src/types/story.ts
@@ -54,6 +54,11 @@ export interface Story {
   commentary_source: CommentarySource | null;
   source_url: string;
   source_name: string | null;
+  // Phase 12e.7a: multi-source attribution for ingestion-written events.
+  // Legacy hand-curated stories carry a synthetic single-element array
+  // so the wire shape is uniform across legacy and ingestion items.
+  primary_source_url: string | null;
+  sources: Array<{ url: string; name: string | null; role: "primary" | "alternate" }>;
   published_at: string | null;
   created_at: string;
   author: StoryAuthor | null;


### PR DESCRIPTION
Closes out 12e.7a.

- Migration 0023: story_id nullable on user_saves + comments; event_id FK added to both; CHECK constraint (exactly one non-null); partial unique index on user_saves(user_id, event_id)
- storyController: dual-read getFeed (stories ∪ events, merged sort); getStoryById events fallback; saveStory/unsaveStory dispatch on story vs event; countSaves union OR
- story.ts: primary_source_url + sources array added to Story interface; shapeStory/shapeEvent both populate uniform wire shape
- StoryCard + StoryDetail: multi-source attribution in footer (+N more / Also covered by)
- Tests: +3 (dual-read sort, events fallback, event-save dispatch)