### PR TITLE
feat(api,frontend): commentary + comments events fallback, discrete source list (12e.7b)

### DIFF
--- a/backend/src/controllers/commentController.ts
+++ b/backend/src/controllers/commentController.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
-import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
-import { comments, stories, users } from "../db/schema";
+import { comments, events, stories, users } from "../db/schema";
 import { AppError } from "../middleware/errorHandler";
 
 const MAX_CONTENT = 2000;
@@ -35,7 +35,11 @@ function requireUserId(req: Request): string {
 
 interface CommentRow {
   id: string;
-  storyId: string;
+  // Phase 12e.7b — exactly one of storyId / eventId is non-null per
+  // row (DB-level CHECK in migration 0023). Type reflects reality so
+  // downstream code branches explicitly rather than coercing.
+  storyId: string | null;
+  eventId: string | null;
   userId: string;
   parentCommentId: string | null;
   content: string;
@@ -54,7 +58,11 @@ function shapeComment(
   const isDeleted = Boolean(row.deletedAt);
   return {
     id: row.id,
+    // Phase 12e.7b — both fields surface on the wire, one always null.
+    // Clients can tell story-targeted from event-targeted comments by
+    // checking which is set without a separate type discriminator.
     story_id: row.storyId,
+    event_id: row.eventId,
     parent_comment_id: row.parentCommentId,
     content: isDeleted ? "[deleted]" : row.content,
     is_deleted: isDeleted,
@@ -73,6 +81,7 @@ function shapeComment(
 const baseCommentColumns = {
   id: comments.id,
   storyId: comments.storyId,
+  eventId: comments.eventId,
   userId: comments.userId,
   parentCommentId: comments.parentCommentId,
   content: comments.content,
@@ -84,15 +93,25 @@ const baseCommentColumns = {
   authorProfilePictureUrl: users.profilePictureUrl,
 };
 
-async function ensureStoryExists(storyId: string): Promise<void> {
-  const [row] = await db
+// Phase 12e.7b — resolve a target id to either a story or an event row,
+// returning the discriminator so callers can dispatch the comment write
+// to the matching FK column. 404 if neither table has the id.
+async function ensureTargetExists(targetId: string): Promise<"story" | "event"> {
+  const [storyRow] = await db
     .select({ id: stories.id })
     .from(stories)
-    .where(eq(stories.id, storyId))
+    .where(eq(stories.id, targetId))
     .limit(1);
-  if (!row) {
-    throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
-  }
+  if (storyRow) return "story";
+
+  const [eventRow] = await db
+    .select({ id: events.id })
+    .from(events)
+    .where(eq(events.id, targetId))
+    .limit(1);
+  if (eventRow) return "event";
+
+  throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
 }
 
 async function replyCountExpr(parentId: string): Promise<number> {
@@ -116,18 +135,25 @@ export async function createComment(
     const { content, parent_comment_id: parentCommentId } =
       createCommentSchema.parse(req.body);
 
-    await ensureStoryExists(storyId);
+    const targetType = await ensureTargetExists(storyId);
 
     if (parentCommentId) {
       const [parent] = await db
-        .select({ id: comments.id, storyId: comments.storyId })
+        .select({
+          id: comments.id,
+          storyId: comments.storyId,
+          eventId: comments.eventId,
+        })
         .from(comments)
         .where(eq(comments.id, parentCommentId))
         .limit(1);
       if (!parent) {
         throw new AppError("PARENT_NOT_FOUND", "Parent comment not found", 404);
       }
-      if (parent.storyId !== storyId) {
+      // Whichever FK the parent carries must match the requested target.
+      // The CHECK constraint guarantees exactly one is non-null per row.
+      const parentTarget = parent.storyId ?? parent.eventId;
+      if (parentTarget !== storyId) {
         throw new AppError(
           "PARENT_MISMATCH",
           "Parent comment belongs to a different story",
@@ -139,7 +165,8 @@ export async function createComment(
     const [inserted] = await db
       .insert(comments)
       .values({
-        storyId,
+        storyId: targetType === "story" ? storyId : null,
+        eventId: targetType === "event" ? storyId : null,
         userId,
         content,
         parentCommentId: parentCommentId ?? null,
@@ -169,15 +196,21 @@ export async function listStoryComments(
     const { story_id: storyId } = storyIdParamSchema.parse(req.params);
     const { limit, offset } = listQuerySchema.parse(req.query);
 
-    await ensureStoryExists(storyId);
+    await ensureTargetExists(storyId);
+
+    // Phase 12e.7b — match either FK column. The CHECK constraint
+    // guarantees exactly one is non-null per row, so the OR doesn't
+    // double-count.
+    const targetFilter = or(
+      eq(comments.storyId, storyId),
+      eq(comments.eventId, storyId),
+    )!;
 
     const rows = (await db
       .select(baseCommentColumns)
       .from(comments)
       .innerJoin(users, eq(users.id, comments.userId))
-      .where(
-        and(eq(comments.storyId, storyId), isNull(comments.parentCommentId)),
-      )
+      .where(and(targetFilter, isNull(comments.parentCommentId)))
       .orderBy(desc(comments.createdAt))
       .limit(limit)
       .offset(offset)) as CommentRow[];
@@ -185,9 +218,7 @@ export async function listStoryComments(
     const [countRow] = await db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(comments)
-      .where(
-        and(eq(comments.storyId, storyId), isNull(comments.parentCommentId)),
-      );
+      .where(and(targetFilter, isNull(comments.parentCommentId)));
     const total = Number(countRow?.count ?? 0);
 
     const shaped = await Promise.all(

--- a/backend/src/db/migrations/0024_phase12e7b_commentary_cache_drop_fk.sql
+++ b/backend/src/db/migrations/0024_phase12e7b_commentary_cache_drop_fk.sql
@@ -1,0 +1,7 @@
+-- Phase 12e.7b — commentary_cache.story_id FK dropped so the column can
+-- carry either a story id or an event id (single UUID namespace).
+-- The column stays NOT NULL and uuid — only the FK constraint is removed.
+-- Cascade-delete from stories no longer fires; orphaned cache rows for
+-- deleted events are handled by the 12c.1 GC stub.
+ALTER TABLE commentary_cache
+  DROP CONSTRAINT commentary_cache_story_id_fkey;

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -499,6 +499,13 @@ export const apiKeys = pgTable(
 // tiered template and are deliberately NOT cached; only successful
 // model output lands here. GC of orphaned rows is a stub in 12c and
 // gets scheduled in 12c.1.
+//
+// Phase 12e.7b. The story_id FK was dropped (migration 0024) so the
+// column can carry either a stories.id or an events.id (single UUID
+// namespace). The column stays NOT NULL and uuid; only the FK
+// constraint was removed. Cascade-delete from stories no longer fires
+// for cache rows; orphaned rows from deleted events are handled by the
+// 12c.1 GC stub when it ships.
 
 export const commentaryCache = pgTable(
   "commentary_cache",
@@ -507,9 +514,7 @@ export const commentaryCache = pgTable(
     userId: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    storyId: uuid("story_id")
-      .notNull()
-      .references(() => stories.id, { onDelete: "cascade" }),
+    storyId: uuid("story_id").notNull(),
     depth: text("depth").$type<DepthLevel>().notNull(),
     profileVersion: integer("profile_version").notNull(),
     commentary: jsonb("commentary")

--- a/backend/src/services/commentaryService.ts
+++ b/backend/src/services/commentaryService.ts
@@ -31,6 +31,7 @@ import { and, eq } from "drizzle-orm";
 import type { db as DbType } from "../db";
 import {
   commentaryCache,
+  events,
   stories,
   userProfiles,
   userTopicInterests,
@@ -187,6 +188,10 @@ export async function getOrGenerateCommentary(
   }
 
   // ---- 2. Gather story + profile context for the prompt ----
+  // 12e.7b — look up the content row by id in stories first, then events.
+  // Both tables expose the same four fields the prompt builder needs;
+  // the cache layer uses a single story_id column to hold either id
+  // (FK dropped in migration 0024 so the column can carry either).
   const [story] = await deps.db
     .select({
       id: stories.id,
@@ -198,7 +203,33 @@ export async function getOrGenerateCommentary(
     .from(stories)
     .where(eq(stories.id, input.storyId))
     .limit(1);
-  if (!story) {
+
+  let contentRow:
+    | {
+        id: string;
+        sector: string;
+        headline: string;
+        context: string;
+        whyItMatters: string;
+      }
+    | undefined = story;
+
+  if (!contentRow) {
+    const [eventRow] = await deps.db
+      .select({
+        id: events.id,
+        sector: events.sector,
+        headline: events.headline,
+        context: events.context,
+        whyItMatters: events.whyItMatters,
+      })
+      .from(events)
+      .where(eq(events.id, input.storyId))
+      .limit(1);
+    contentRow = eventRow;
+  }
+
+  if (!contentRow) {
     throw new Error(`story not found: ${input.storyId}`);
   }
 
@@ -220,7 +251,7 @@ export async function getOrGenerateCommentary(
     .where(eq(userTopicInterests.userId, input.userId));
 
   const matched = computeMatchedInterests({
-    storySector: story.sector,
+    storySector: contentRow.sector,
     userSectors: profile?.sectors ?? null,
     userTopicsForSector: topicRows,
   });
@@ -238,7 +269,7 @@ export async function getOrGenerateCommentary(
     depth: input.depth,
     profile: profileShape,
     matchedTopics: matched.matchedTopics,
-    story,
+    story: contentRow,
   });
 
   // ---- 4 & 5. Call + parse, with one parse-failure retry ----
@@ -254,7 +285,7 @@ export async function getOrGenerateCommentary(
   if (!haiku.ok) {
     return buildAndLogFallback(
       input,
-      story,
+      contentRow,
       profileShape,
       matched,
       haikuReasonToTier3(haiku.reason),
@@ -279,7 +310,7 @@ export async function getOrGenerateCommentary(
     if (!haiku.ok) {
       return buildAndLogFallback(
         input,
-        story,
+        contentRow,
         profileShape,
         matched,
         haikuReasonToTier3(haiku.reason),
@@ -298,7 +329,7 @@ export async function getOrGenerateCommentary(
   if (!parsed.ok) {
     return buildAndLogFallback(
       input,
-      story,
+      contentRow,
       profileShape,
       matched,
       parseFailureToTier3(parsed.reason),
@@ -318,7 +349,7 @@ export async function getOrGenerateCommentary(
   if (!banCheck.clean) {
     return buildAndLogFallback(
       input,
-      story,
+      contentRow,
       profileShape,
       matched,
       "haiku_banned_phrase",
@@ -332,7 +363,7 @@ export async function getOrGenerateCommentary(
   if (!openerCheck.clean) {
     return buildAndLogFallback(
       input,
-      story,
+      contentRow,
       profileShape,
       matched,
       "haiku_banned_opener",
@@ -395,7 +426,7 @@ export async function getOrGenerateCommentary(
   // Truly unexpected — neither insert nor re-read produced a row.
   return buildAndLogFallback(
     input,
-    story,
+    contentRow,
     profileShape,
     matched,
     "cache_race_unexpected",

--- a/backend/tests/commentaryService.test.ts
+++ b/backend/tests/commentaryService.test.ts
@@ -382,9 +382,12 @@ describe("commentaryService — getOrGenerateCommentary", () => {
     });
   });
 
-  it("throws STORY_NOT_FOUND-shaped error when the story is missing", async () => {
+  it("throws STORY_NOT_FOUND-shaped error when neither stories nor events has the id", async () => {
     mock.queueSelect([]); // cache miss
     mock.queueSelect([]); // story missing
+    // Phase 12e.7b — service falls through to events on story miss.
+    // Both empty → throws.
+    mock.queueSelect([]); // event missing
 
     const create = jest.fn();
     await expect(
@@ -394,5 +397,56 @@ describe("commentaryService — getOrGenerateCommentary", () => {
       }),
     ).rejects.toThrow(/story not found/);
     expect(create).not.toHaveBeenCalled();
+  });
+
+  // Phase 12e.7b — events fallback in the content-row lookup. When the
+  // id misses in stories, the service queries events and proceeds with
+  // commentary generation as if it were a story (same {sector, headline,
+  // context, whyItMatters} shape).
+  it("falls through to events on story miss and generates commentary", async () => {
+    mock.queueSelect([]); // cache miss
+    mock.queueSelect([]); // story missing — fall through
+    mock.queueSelect([
+      {
+        id: baseInput.storyId,
+        sector: "semiconductors",
+        headline: "TSMC pulls in 2nm",
+        context: "context from event row",
+        whyItMatters: "Costs fall.",
+      },
+    ]);
+    mock.queueSelect([
+      {
+        role: "engineer",
+        domain: "semiconductors_design",
+        seniority: "senior",
+        sectors: ["semiconductors"],
+        goals: ["stay_current"],
+      },
+    ]);
+    mock.queueSelect([{ sector: "semiconductors", topic: "process_nodes" }]);
+    mock.queueInsert([
+      {
+        id: "cache-new",
+        userId: baseInput.userId,
+        storyId: baseInput.storyId,
+        depth: baseInput.depth,
+        profileVersion: baseInput.profileVersion,
+        commentary: goodCommentary,
+      },
+    ]);
+
+    const create = jest.fn().mockResolvedValue({
+      content: [{ type: "text", text: haikuJsonText(goodCommentary) }],
+    });
+
+    const result = await getOrGenerateCommentary(baseInput, {
+      db: mock.db,
+      haiku: { client: { create } },
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe("haiku");
+    expect(result.commentary).toEqual(goodCommentary);
   });
 });

--- a/backend/tests/comments.integration.test.ts
+++ b/backend/tests/comments.integration.test.ts
@@ -32,6 +32,7 @@ function commentRow(overrides: Record<string, unknown> = {}): Record<string, unk
   return {
     id: commentId,
     storyId,
+    eventId: null,
     userId,
     parentCommentId: null,
     content: "Great story.",
@@ -78,14 +79,46 @@ describe("comments endpoints", () => {
       expect(res.status).toBe(400);
     });
 
-    it("returns 404 when the story does not exist", async () => {
-      mock.queueSelect([]);
+    it("returns 404 when neither a story nor an event exists for the id", async () => {
+      // Phase 12e.7b — ensureTargetExists tries stories first, then
+      // events. Both empty → 404.
+      mock.queueSelect([]); // story miss
+      mock.queueSelect([]); // event miss
       const res = await request(app)
         .post(`/api/v1/stories/${storyId}/comments`)
         .set(...auth(token))
         .send({ content: "Nice." });
       expect(res.status).toBe(404);
       expect(res.body.error.code).toBe("STORY_NOT_FOUND");
+    });
+
+    // Phase 12e.7b — event-path dispatch. When the id misses in stories
+    // but hits in events, the comment INSERT lands with eventId set
+    // (and storyId null), satisfying the comments_exactly_one_target
+    // CHECK constraint.
+    it("creates an event-targeted comment when the id resolves to an event", async () => {
+      const eventId = "44444444-4444-4444-4444-444444444444";
+      mock.queueSelect([]); // story miss → fall through
+      mock.queueSelect([{ id: eventId }]); // event hit
+      mock.queueInsert([{ id: commentId }]);
+      mock.queueSelect([
+        commentRow({ storyId: null, eventId, id: commentId }),
+      ]);
+
+      const res = await request(app)
+        .post(`/api/v1/stories/${eventId}/comments`)
+        .set(...auth(token))
+        .send({ content: "Event-targeted comment." });
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.comment.story_id).toBeNull();
+      expect(res.body.data.comment.event_id).toBe(eventId);
+      // The inserted row carries eventId, not storyId.
+      const insert = mock.state.insertedValues.find(
+        (v) => v.eventId === eventId,
+      );
+      expect(insert).toBeDefined();
+      expect(insert?.storyId).toBeNull();
     });
 
     it("creates a top-level comment and returns it with author info", async () => {
@@ -172,6 +205,32 @@ describe("comments endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body.data.comments[0].is_deleted).toBe(true);
       expect(res.body.data.comments[0].content).toBe("[deleted]");
+    });
+
+    // Phase 12e.7b — listStoryComments uses an OR(storyId, eventId)
+    // filter so a request against an event id returns event-targeted
+    // comments. Wire shape exposes both fields (one always null) for
+    // each row.
+    it("returns event-targeted comments when the id resolves to an event", async () => {
+      const eventId = "55555555-5555-5555-5555-555555555555";
+      mock.queueSelect([]); // story miss in ensureTargetExists
+      mock.queueSelect([{ id: eventId }]); // event hit
+      mock.queueSelect([
+        commentRow({ storyId: null, eventId, content: "Take on the event." }),
+      ]);
+      mock.queueSelect([{ count: 1 }]);
+      mock.queueSelect([{ count: 0 }]); // reply_count
+
+      const res = await request(app)
+        .get(`/api/v1/stories/${eventId}/comments`)
+        .set(...auth(token));
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.comments).toHaveLength(1);
+      expect(res.body.data.comments[0].story_id).toBeNull();
+      expect(res.body.data.comments[0].event_id).toBe(eventId);
+      expect(res.body.data.comments[0].content).toBe("Take on the event.");
+      expect(res.body.data.total).toBe(1);
     });
   });
 

--- a/frontend/src/components/stories/StoryDetail.tsx
+++ b/frontend/src/components/stories/StoryDetail.tsx
@@ -62,6 +62,39 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
         />
       )}
 
+      {/*
+        Phase 12e.7b — discrete coverage list for multi-source events.
+        Single-source stories keep the existing footer attribution; only
+        multi-source items render this section. Primary source carries a
+        small badge so the relationship to the footer link is explicit.
+      */}
+      {story.sources.length > 1 && (
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-700">
+            Coverage
+          </h2>
+          <ul className="space-y-1">
+            {story.sources.map((s) => (
+              <li key={s.url} className="flex items-center gap-2 text-sm">
+                {s.role === "primary" && (
+                  <span className="rounded bg-violet-100 px-1.5 py-0.5 text-xs font-medium text-violet-700">
+                    Primary
+                  </span>
+                )}
+                <a
+                  href={s.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-slate-600 hover:text-violet-700 hover:underline"
+                >
+                  {s.name ?? s.url}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       <section className="space-y-4">
         <div>
           <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-700">


### PR DESCRIPTION
Closes out 12e.7b.

- Migration 0024: drop commentary_cache.story_id FK so column carries either story or event id (single UUID namespace)
- commentaryService: story lookup falls back to events on miss; contentRow replaces story downstream
- commentController: ensureTargetExists (story OR event); createComment dispatches storyId/eventId FK; listStoryComments OR-filter; CommentRow + shapeComment updated for nullable storyId + new eventId
- StoryDetail: discrete Coverage section for multi-source events (sources.length > 1)
- Tests: +3 (commentary events fallback, createComment event dispatch, listStoryComments OR-filter)