### PR TITLE
feat(api,infra): admin ingestion status route, last-success tracking, seed guard (12e.8)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import { storiesRouter } from "./routes/stories";
 import { teamsRouter } from "./routes/teams";
 import { usersRouter } from "./routes/users";
 import { v2Router } from "./routes/v2";
+import adminRoutes from "./routes/adminRoutes";
 
 function parseAllowedOrigins(): string[] {
   const raw =
@@ -90,6 +91,11 @@ export function createApp(): Express {
   // Middleware chain (apiKeyAuth → apiKeyRateLimit) is applied inside
   // routes/v2/index.ts so it only affects v2 endpoints, not v1.
   app.use("/api/v2", v2Router);
+
+  // Phase 12e.8 — admin routes off the public /api/v* surface so they
+  // stay out of public-API documentation. Auth + ADMIN_USER_IDS
+  // allowlist applied inside routes/adminRoutes.ts.
+  app.use("/admin", adminRoutes);
 
   installSentryErrorHandler(app);
 

--- a/backend/src/controllers/adminController.ts
+++ b/backend/src/controllers/adminController.ts
@@ -1,0 +1,195 @@
+import type { NextFunction, Request, Response } from "express";
+import type { Queue } from "bullmq";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { db } from "../db";
+import {
+  events,
+  eventSources,
+  ingestionSources,
+  ingestionCandidates,
+} from "../db/schema";
+import { getEnrichmentQueue } from "../jobs/ingestion/enrichmentQueue";
+import { getSourcePollQueue } from "../jobs/ingestion/sourcePollQueue";
+
+// Phase 12e.8 — read-only admin status endpoint.
+// Returns a snapshot of the ingestion pipeline health:
+//   - per-source: last_success_at, consecutive_failure_count,
+//     rejection_rate_24h, 24h ingest counts
+//   - queue depths for enrichment + source-poll queues
+//   - last 50 failed candidates
+//   - 24h cluster statistics (events created vs sources attached)
+//
+// Read-only by design — the caller's role is observability, not
+// remediation. Source-level kill-switch decisions stay manual until a
+// future phase formalizes them.
+
+const RECENT_FAILURES_LIMIT = 50;
+const REJECTION_RATE_MIN_SAMPLE = 50;
+
+interface QueueDepths {
+  waiting: number;
+  active: number;
+  failed: number;
+}
+
+// When the queue getter returns null (REDIS_URL unset), the entire
+// ingestion pipeline is offline; surface zeros rather than 500ing on
+// the admin route — the per-source columns + recent_failures still
+// reflect last-known DB state and remain useful even mid-outage.
+async function readQueueDepths<T>(
+  queue: Queue<T> | null,
+): Promise<QueueDepths> {
+  if (!queue) return { waiting: 0, active: 0, failed: 0 };
+  const [waiting, active, failed] = await Promise.all([
+    queue.getWaitingCount(),
+    queue.getActiveCount(),
+    queue.getFailedCount(),
+  ]);
+  return { waiting, active, failed };
+}
+
+export async function getIngestionStatus(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    // --- Per-source metadata ---
+    const sources = await db
+      .select({
+        id: ingestionSources.id,
+        slug: ingestionSources.slug,
+        displayName: ingestionSources.displayName,
+        adapterType: ingestionSources.adapterType,
+        enabled: ingestionSources.enabled,
+        lastPolledAt: ingestionSources.lastPolledAt,
+        lastSuccessAt: ingestionSources.lastSuccessAt,
+        consecutiveFailureCount: ingestionSources.consecutiveFailureCount,
+      })
+      .from(ingestionSources)
+      .orderBy(ingestionSources.slug);
+
+    // --- 24h candidate counts per source (total + rejected + published) ---
+    // Rejected = anything that didn't reach `published`, including
+    // heuristic_filtered, llm_rejected, failed. The rate is null when
+    // sample < REJECTION_RATE_MIN_SAMPLE — small denominators are noisy
+    // and the kill-switch threshold (per roadmap §5.4) is also gated on
+    // a 50+ sample.
+    const candidateCounts = await db
+      .select({
+        ingestionSourceId: ingestionCandidates.ingestionSourceId,
+        total: sql<number>`COUNT(*)::int`,
+        rejected: sql<number>`COUNT(*) FILTER (WHERE status IN ('heuristic_filtered','llm_rejected','failed'))::int`,
+        published: sql<number>`COUNT(*) FILTER (WHERE status = 'published')::int`,
+      })
+      .from(ingestionCandidates)
+      .where(gte(ingestionCandidates.discoveredAt, since24h))
+      .groupBy(ingestionCandidates.ingestionSourceId);
+
+    const countsBySource = new Map(
+      candidateCounts.map((r) => [r.ingestionSourceId, r]),
+    );
+
+    const sourcesPayload = sources.map((s) => {
+      const counts = countsBySource.get(s.id);
+      const total = Number(counts?.total ?? 0);
+      const rejected = Number(counts?.rejected ?? 0);
+      const published = Number(counts?.published ?? 0);
+      const rejectionRate24h =
+        total >= REJECTION_RATE_MIN_SAMPLE
+          ? Math.round((rejected / total) * 100) / 100
+          : null;
+      return {
+        id: s.id,
+        slug: s.slug,
+        display_name: s.displayName,
+        adapter_type: s.adapterType,
+        enabled: s.enabled,
+        last_polled_at: s.lastPolledAt,
+        last_success_at: s.lastSuccessAt,
+        consecutive_failure_count: s.consecutiveFailureCount,
+        candidates_24h: total,
+        published_24h: published,
+        rejected_24h: rejected,
+        rejection_rate_24h: rejectionRate24h,
+      };
+    });
+
+    // --- Queue depths ---
+    const enrichmentQueue = getEnrichmentQueue();
+    const sourcePollQueue = getSourcePollQueue();
+    const [enrichment, sourcePoll] = await Promise.all([
+      readQueueDepths(enrichmentQueue),
+      readQueueDepths(sourcePollQueue),
+    ]);
+
+    // --- Recent failures (last 50) ---
+    // 'failed' is the explicit dead-letter status from the chain
+    // orchestrator. heuristic_filtered / llm_rejected are normal
+    // attrition and intentionally omitted from this view — they'd
+    // drown the signal.
+    const recentFailures = await db
+      .select({
+        id: ingestionCandidates.id,
+        ingestionSourceId: ingestionCandidates.ingestionSourceId,
+        url: ingestionCandidates.url,
+        status: ingestionCandidates.status,
+        statusReason: ingestionCandidates.statusReason,
+        discoveredAt: ingestionCandidates.discoveredAt,
+        processedAt: ingestionCandidates.processedAt,
+      })
+      .from(ingestionCandidates)
+      .where(eq(ingestionCandidates.status, "failed"))
+      .orderBy(desc(ingestionCandidates.processedAt))
+      .limit(RECENT_FAILURES_LIMIT);
+
+    // --- 24h cluster statistics ---
+    // events_created: new event rows in the window (each one represents
+    // a new-event write path).
+    // sources_attached: alternate event_sources rows joined to existing
+    // events in the window (each one represents a cluster-match attach).
+    const [eventsCreatedRow] = await db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(events)
+      .where(gte(events.createdAt, since24h));
+    const [sourcesAttachedRow] = await db
+      .select({ count: sql<number>`COUNT(*)::int` })
+      .from(eventSources)
+      .where(
+        and(
+          eq(eventSources.role, "alternate"),
+          gte(eventSources.createdAt, since24h),
+        ),
+      );
+    const eventsCreated = Number(eventsCreatedRow?.count ?? 0);
+    const sourcesAttached = Number(sourcesAttachedRow?.count ?? 0);
+
+    res.json({
+      data: {
+        as_of: new Date(),
+        sources: sourcesPayload,
+        queues: {
+          enrichment,
+          source_poll: sourcePoll,
+        },
+        recent_failures: recentFailures.map((f) => ({
+          id: f.id,
+          source_id: f.ingestionSourceId,
+          url: f.url,
+          status: f.status,
+          reason: f.statusReason,
+          discovered_at: f.discoveredAt,
+          processed_at: f.processedAt,
+        })),
+        cluster_stats_24h: {
+          events_created: eventsCreated,
+          sources_attached: sourcesAttached,
+        },
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/db/migrations/0025_phase12e8_last_success_at.sql
+++ b/backend/src/db/migrations/0025_phase12e8_last_success_at.sql
@@ -1,0 +1,5 @@
+-- Phase 12e.8 — track last successful poll per source separately from
+-- lastPolledAt (which records last attempt, success or failure).
+-- Nullable: NULL means the source has never successfully polled.
+ALTER TABLE ingestion_sources
+  ADD COLUMN last_success_at TIMESTAMPTZ;

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -565,6 +565,11 @@ export const ingestionSources = pgTable(
     }),
     config: jsonb("config").$type<Record<string, unknown>>().notNull().default({}),
     lastPolledAt: timestamp("last_polled_at", { withTimezone: true }),
+    // Phase 12e.8 — last successful poll per source. Distinct from
+    // lastPolledAt, which records every attempt (success or failure).
+    // Null = source has never successfully polled. Written by
+    // sourcePollJob on the success branch only.
+    lastSuccessAt: timestamp("last_success_at", { withTimezone: true }),
     consecutiveFailureCount: integer("consecutive_failure_count").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/backend/src/jobs/ingestion/sourcePollJob.ts
+++ b/backend/src/jobs/ingestion/sourcePollJob.ts
@@ -84,12 +84,17 @@ async function persistCandidates(
 }
 
 async function markSuccess(sourceId: string): Promise<void> {
+  // Phase 12e.8 — lastSuccessAt is written here only (not in markFailure)
+  // so the admin route can distinguish "polled but failed" from "never
+  // succeeded" without joining ingestion_candidates.
+  const now = new Date();
   await db
     .update(ingestionSources)
     .set({
       consecutiveFailureCount: 0,
-      lastPolledAt: new Date(),
-      updatedAt: new Date(),
+      lastPolledAt: now,
+      lastSuccessAt: now,
+      updatedAt: now,
     })
     .where(eq(ingestionSources.id, sourceId));
 }

--- a/backend/src/middleware/requireAdmin.ts
+++ b/backend/src/middleware/requireAdmin.ts
@@ -1,0 +1,31 @@
+import type { NextFunction, Request, Response } from "express";
+import { AppError } from "./errorHandler";
+
+// Phase 12e.8 — gate admin routes behind an env-var allowlist.
+// ADMIN_USER_IDS is a comma-separated list of user UUIDs. If the env
+// var is absent or empty, all admin requests are rejected — there is
+// no open-admin fallback. Requires requireAuth to have run first so
+// req.user is populated.
+export function requireAdmin(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const raw = process.env.ADMIN_USER_IDS ?? "";
+  const allowlist = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  if (allowlist.length === 0) {
+    next(new AppError("FORBIDDEN", "Admin access not configured", 403));
+    return;
+  }
+
+  if (!req.user || !allowlist.includes(req.user.userId)) {
+    next(new AppError("FORBIDDEN", "Forbidden", 403));
+    return;
+  }
+
+  next();
+}

--- a/backend/src/routes/adminRoutes.ts
+++ b/backend/src/routes/adminRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/auth";
+import { requireAdmin } from "../middleware/requireAdmin";
+import { getIngestionStatus } from "../controllers/adminController";
+
+// Phase 12e.8 — admin routes mounted at `/admin/*`. Off the public
+// `/api/v*` surface deliberately so they don't appear in the
+// public-API documentation. All endpoints require both an
+// authenticated user (requireAuth) and membership in the
+// ADMIN_USER_IDS allowlist (requireAdmin).
+const router = Router();
+
+router.use(requireAuth, requireAdmin);
+
+router.get("/ingestion/status", getIngestionStatus);
+
+export default router;

--- a/backend/src/scripts/seedStories.ts
+++ b/backend/src/scripts/seedStories.ts
@@ -28,6 +28,23 @@
  */
 
 import "dotenv/config";
+
+// Phase 12e.8 — production guard. Refuse to run when NODE_ENV is
+// "production". The hand-curated seed file is dev-only content; a
+// production seed event would silently land prototype rows next to
+// ingestion-written events. Unbypassable by `--yes` or any CLI flag —
+// removing this guard requires editing the source file, which is the
+// intentional friction. Runs before the DB import so the pg pool
+// isn't even constructed against a prod connection string.
+if (process.env.NODE_ENV === "production") {
+  // eslint-disable-next-line no-console
+  console.error(
+    "seedStories: refusing to run in production. " +
+      "Remove this guard in the source file if a production seed is intentionally required.",
+  );
+  process.exit(1);
+}
+
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";

--- a/backend/tests/admin.integration.test.ts
+++ b/backend/tests/admin.integration.test.ts
@@ -1,0 +1,191 @@
+import request from "supertest";
+import { createMockDb } from "./helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+// Force the queue getters to return null — the test environment has no
+// Redis configured. The admin controller should surface zeros for all
+// queue depths in that case rather than 500ing.
+jest.mock("../src/jobs/ingestion/enrichmentQueue", () => ({
+  getEnrichmentQueue: () => null,
+}));
+jest.mock("../src/jobs/ingestion/sourcePollQueue", () => ({
+  getSourcePollQueue: () => null,
+}));
+
+import { createApp } from "../src/app";
+import { generateToken } from "../src/services/authService";
+
+const app = createApp();
+
+function auth(token: string): [string, string] {
+  return ["Authorization", `Bearer ${token}`];
+}
+
+const adminUserId = "11111111-1111-1111-1111-111111111111";
+const otherUserId = "22222222-2222-2222-2222-222222222222";
+const email = "admin@example.com";
+
+const ORIGINAL_ADMIN = process.env.ADMIN_USER_IDS;
+
+afterEach(() => {
+  if (ORIGINAL_ADMIN === undefined) delete process.env.ADMIN_USER_IDS;
+  else process.env.ADMIN_USER_IDS = ORIGINAL_ADMIN;
+});
+
+describe("GET /admin/ingestion/status", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("returns 401 without an auth token", async () => {
+    process.env.ADMIN_USER_IDS = adminUserId;
+    const res = await request(app).get("/admin/ingestion/status");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller is not in ADMIN_USER_IDS", async () => {
+    process.env.ADMIN_USER_IDS = adminUserId;
+    const token = generateToken(otherUserId, "other@x.y");
+    const res = await request(app)
+      .get("/admin/ingestion/status")
+      .set(...auth(token));
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 403 when ADMIN_USER_IDS is unset", async () => {
+    delete process.env.ADMIN_USER_IDS;
+    const token = generateToken(adminUserId, email);
+    const res = await request(app)
+      .get("/admin/ingestion/status")
+      .set(...auth(token));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the full status payload for an admin caller", async () => {
+    process.env.ADMIN_USER_IDS = adminUserId;
+    const token = generateToken(adminUserId, email);
+
+    // 1. ingestion_sources select (orderBy slug)
+    mock.queueSelect([
+      {
+        id: "src-1",
+        slug: "cnbc-markets",
+        displayName: "CNBC Markets",
+        adapterType: "rss",
+        enabled: true,
+        lastPolledAt: new Date("2026-05-03T00:00:00Z"),
+        lastSuccessAt: new Date("2026-05-03T00:00:00Z"),
+        consecutiveFailureCount: 0,
+      },
+    ]);
+    // 2. candidate counts (groupBy ingestion_source_id) — 60 candidates
+    //    in window with 50 rejected → rate = 50/60 = 0.83.
+    mock.queueSelect([
+      {
+        ingestionSourceId: "src-1",
+        total: 60,
+        rejected: 50,
+        published: 8,
+      },
+    ]);
+    // 3. recent_failures select
+    mock.queueSelect([
+      {
+        id: "cand-1",
+        ingestionSourceId: "src-1",
+        url: "https://example.com/x",
+        status: "failed",
+        statusReason: "facts_parse_error",
+        discoveredAt: new Date("2026-05-02T00:00:00Z"),
+        processedAt: new Date("2026-05-02T01:00:00Z"),
+      },
+    ]);
+    // 4. events created count (Drizzle select)
+    mock.queueSelect([{ count: 12 }]);
+    // 5. event_sources attached count (Drizzle select)
+    mock.queueSelect([{ count: 3 }]);
+
+    const res = await request(app)
+      .get("/admin/ingestion/status")
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.sources).toHaveLength(1);
+    const s = res.body.data.sources[0];
+    expect(s.slug).toBe("cnbc-markets");
+    expect(s.consecutive_failure_count).toBe(0);
+    expect(s.candidates_24h).toBe(60);
+    expect(s.published_24h).toBe(8);
+    expect(s.rejected_24h).toBe(50);
+    // 50/60 → 0.83 (rounded to 2dp)
+    expect(s.rejection_rate_24h).toBe(0.83);
+    expect(s.last_success_at).toBeTruthy();
+    // Queue depths reflect the null-queue case (Redis unconfigured).
+    expect(res.body.data.queues.enrichment).toEqual({
+      waiting: 0,
+      active: 0,
+      failed: 0,
+    });
+    expect(res.body.data.queues.source_poll).toEqual({
+      waiting: 0,
+      active: 0,
+      failed: 0,
+    });
+    expect(res.body.data.recent_failures).toHaveLength(1);
+    expect(res.body.data.recent_failures[0].reason).toBe("facts_parse_error");
+    expect(res.body.data.cluster_stats_24h.events_created).toBe(12);
+    expect(res.body.data.cluster_stats_24h.sources_attached).toBe(3);
+  });
+
+  // Phase 12e.8 — rejection_rate_24h is null when sample < 50. Small
+  // samples are noisy and the kill-switch threshold (per roadmap §5.4)
+  // also gates on a 50+ sample, so the admin view mirrors that floor.
+  it("reports rejection_rate_24h=null when candidate sample < 50", async () => {
+    process.env.ADMIN_USER_IDS = adminUserId;
+    const token = generateToken(adminUserId, email);
+
+    mock.queueSelect([
+      {
+        id: "src-2",
+        slug: "import-ai",
+        displayName: "Import AI",
+        adapterType: "rss",
+        enabled: true,
+        lastPolledAt: new Date("2026-05-03T00:00:00Z"),
+        lastSuccessAt: null,
+        consecutiveFailureCount: 1,
+      },
+    ]);
+    mock.queueSelect([
+      {
+        ingestionSourceId: "src-2",
+        total: 12,
+        rejected: 10,
+        published: 2,
+      },
+    ]);
+    mock.queueSelect([]); // recent_failures
+    mock.queueSelect([{ count: 0 }]); // events created
+    mock.queueSelect([{ count: 0 }]); // sources attached
+
+    const res = await request(app)
+      .get("/admin/ingestion/status")
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.sources[0].rejection_rate_24h).toBeNull();
+    expect(res.body.data.sources[0].candidates_24h).toBe(12);
+    expect(res.body.data.sources[0].last_success_at).toBeNull();
+  });
+});

--- a/backend/tests/ingestion/sourcePollJob.test.ts
+++ b/backend/tests/ingestion/sourcePollJob.test.ts
@@ -105,6 +105,9 @@ describe("processSourcePollJob", () => {
       expect(mock.state.updatedRows.length).toBe(1);
       expect(mock.state.updatedRows[0]!.consecutiveFailureCount).toBe(0);
       expect(mock.state.updatedRows[0]!.lastPolledAt).toBeInstanceOf(Date);
+      // Phase 12e.8 — markSuccess writes lastSuccessAt alongside
+      // lastPolledAt; markFailure does not.
+      expect(mock.state.updatedRows[0]!.lastSuccessAt).toBeInstanceOf(Date);
     });
 
     it("counts conflict-skipped rows as not-persisted", async () => {
@@ -160,6 +163,9 @@ describe("processSourcePollJob", () => {
       // easily inspect its value here, but we can check the field is set.
       expect(update.consecutiveFailureCount).toBeDefined();
       expect(update.lastPolledAt).toBeInstanceOf(Date);
+      // Phase 12e.8 — markFailure does NOT touch lastSuccessAt; the
+      // column tracks the last successful poll exclusively.
+      expect(update.lastSuccessAt).toBeUndefined();
     });
 
     it("falls back to 'network' when error is not an Error instance", async () => {

--- a/backend/tests/middleware/requireAdmin.test.ts
+++ b/backend/tests/middleware/requireAdmin.test.ts
@@ -1,0 +1,73 @@
+import type { NextFunction, Request, Response } from "express";
+import { requireAdmin } from "../../src/middleware/requireAdmin";
+import { AppError } from "../../src/middleware/errorHandler";
+
+function makeRes(): Response {
+  // Body is never written by requireAdmin — it always either calls next()
+  // or hands an AppError to next(). A minimal cast is enough for the tests.
+  return {} as unknown as Response;
+}
+
+function makeReq(userId?: string): Request {
+  return { user: userId ? { userId, email: "x@y.z" } : undefined } as unknown as Request;
+}
+
+describe("requireAdmin middleware", () => {
+  const ORIGINAL = process.env.ADMIN_USER_IDS;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.ADMIN_USER_IDS;
+    } else {
+      process.env.ADMIN_USER_IDS = ORIGINAL;
+    }
+  });
+
+  it("rejects with FORBIDDEN when ADMIN_USER_IDS is unset", () => {
+    delete process.env.ADMIN_USER_IDS;
+    const next = jest.fn() as unknown as NextFunction;
+    requireAdmin(makeReq("user-1"), makeRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(AppError));
+    const err = (next as jest.Mock).mock.calls[0][0] as AppError;
+    expect(err.code).toBe("FORBIDDEN");
+    expect(err.status).toBe(403);
+  });
+
+  it("rejects when ADMIN_USER_IDS is empty string", () => {
+    process.env.ADMIN_USER_IDS = "   ";
+    const next = jest.fn() as unknown as NextFunction;
+    requireAdmin(makeReq("user-1"), makeRes(), next);
+    expect((next as jest.Mock).mock.calls[0][0]).toBeInstanceOf(AppError);
+  });
+
+  it("rejects when the requesting user is not in the allowlist", () => {
+    process.env.ADMIN_USER_IDS = "admin-a, admin-b";
+    const next = jest.fn() as unknown as NextFunction;
+    requireAdmin(makeReq("user-x"), makeRes(), next);
+    const err = (next as jest.Mock).mock.calls[0][0] as AppError;
+    expect(err.code).toBe("FORBIDDEN");
+  });
+
+  it("rejects when req.user is absent (e.g. requireAuth not run)", () => {
+    process.env.ADMIN_USER_IDS = "admin-a";
+    const next = jest.fn() as unknown as NextFunction;
+    requireAdmin(makeReq(undefined), makeRes(), next);
+    expect((next as jest.Mock).mock.calls[0][0]).toBeInstanceOf(AppError);
+  });
+
+  it("calls next() with no error when the user is in the allowlist", () => {
+    process.env.ADMIN_USER_IDS = "admin-a, admin-b";
+    const next = jest.fn() as unknown as NextFunction;
+    requireAdmin(makeReq("admin-b"), makeRes(), next);
+    expect(next).toHaveBeenCalledWith();
+    // Crucially: not called with an error argument.
+    expect((next as jest.Mock).mock.calls[0]).toHaveLength(0);
+  });
+
+  it("trims whitespace and ignores empty entries in the allowlist", () => {
+    process.env.ADMIN_USER_IDS = " ,admin-a , , admin-b , ";
+    const next = jest.fn() as unknown as NextFunction;
+    requireAdmin(makeReq("admin-a"), makeRes(), next);
+    expect((next as jest.Mock).mock.calls[0]).toHaveLength(0);
+  });
+});

--- a/backend/tests/seedStories.test.ts
+++ b/backend/tests/seedStories.test.ts
@@ -235,3 +235,48 @@ describe("insertStoryBatch", () => {
     );
   });
 });
+
+// Phase 12e.8 — production guard. The guard runs at module-load time
+// and calls process.exit(1), so it can't be tested in-process (it would
+// kill the jest worker). spawnSync isolates it. Slow (~3s) but the only
+// way to assert the runtime exit semantics.
+describe("seedStories — production guard (12e.8)", () => {
+  // Disabled by default in fast-feedback runs; enable via SEED_GUARD_TEST=1.
+  // The spawn cost (npx ts-node startup, ~2-3s) isn't worth paying on
+  // every jest run when the guard logic is a 4-line top-of-file check.
+  const ENABLED = process.env.SEED_GUARD_TEST === "1";
+  const maybeIt = ENABLED ? it : it.skip;
+
+  maybeIt(
+    "exits with code 1 when NODE_ENV=production, even with --yes",
+    () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const path = require("node:path") as typeof import("node:path");
+
+      const script = path.resolve(__dirname, "../src/scripts/seedStories.ts");
+      const result = spawnSync(
+        "npx",
+        ["ts-node", script, "--yes"],
+        {
+          env: {
+            ...process.env,
+            NODE_ENV: "production",
+            // Provide a connection string so the guard isn't tripped on a
+            // missing-DB error before NODE_ENV is even checked. The guard
+            // runs before the DB import — but defensive.
+            DATABASE_URL: "postgresql://noop:noop@localhost:1/noop",
+          },
+          encoding: "utf8",
+          timeout: 30_000,
+          shell: process.platform === "win32",
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr ?? "").toContain("refusing to run in production");
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
Closes out 12e.8.

- Migration 0025: last_success_at column on ingestion_sources
- sourcePollJob: writes lastSuccessAt on success branch only
- requireAdmin middleware: ADMIN_USER_IDS env-var allowlist, no open-admin fallback
- GET /admin/ingestion/status: per-source stats, queue depths (null-safe), last 50 failures, 24h cluster stats
- /admin mounted off /api/v* surface intentionally
- seedStories: NODE_ENV=production guard before DB import, unbypassable by --yes
- Tests: +12 across 2 new suites (requireAdmin, admin integration) + sourcePollJob assertions + seed guard