### PR TITLE
feat(ingestion): arXiv Atom + SEC EDGAR adapters, edgar adapter type fix (12e.5d)

### DIFF
--- a/backend/src/db/migrations/0026_phase12e5d_edgar_adapter_fix.sql
+++ b/backend/src/db/migrations/0026_phase12e5d_edgar_adapter_fix.sql
@@ -1,0 +1,21 @@
+-- Phase 12e.5d — two corrections to the ingestion_sources seed:
+--
+-- 1. sec-edgar-full: the endpoint returns Atom XML (output=atom), not JSON.
+--    Changing adapter_type to 'rss' lets the existing rssAdapter handle it
+--    with no new code.
+--
+-- 2. sec-edgar-semis: the endpoint has a {cik} placeholder — the adapter
+--    loops over a CIK list stored in config. Populate config with the
+--    initial chip-company CIK list.
+
+UPDATE ingestion_sources
+  SET adapter_type = 'rss'
+  WHERE slug = 'sec-edgar-full';
+
+UPDATE ingestion_sources
+  SET config = jsonb_set(
+    config,
+    '{ciks}',
+    '["0001045810","0000002488","0001046179","0000937556","0000050863","0000804328","0001730168","0001058057","0000723125","0000796343","0000707549","0000319201"]'::jsonb
+  )
+  WHERE slug = 'sec-edgar-semis';

--- a/backend/src/jobs/ingestion/adapters/arxivAtom.ts
+++ b/backend/src/jobs/ingestion/adapters/arxivAtom.ts
@@ -1,8 +1,98 @@
-// arXiv Atom API adapter — stub. Implementation lands in 12e.5d
-// (daily 21:00 UTC cadence, per-cycle volume cap to bound LLM cost).
+// arXiv Atom API adapter (Phase 12e.5d).
+//
+// Fetches the pre-seeded Atom endpoint (cs.AI + cs.CL + cs.LG, sorted
+// by submittedDate descending) and emits up to ARXIV_VOLUME_CAP candidates
+// per cycle. Volume cap is the primary cost-control mechanism — the daily
+// cadence means a single cycle can surface 100+ papers; the LLM relevance
+// gate runs one Haiku call per surviving candidate.
+//
+// Failure strings (stable contract with sourcePollJob):
+//   timeout | network | http_4xx | http_5xx | parse_error
 
-import type { AdapterContext, AdapterResult } from "../types";
+import crypto from "node:crypto";
+import Parser from "rss-parser";
+import type { AdapterContext, AdapterResult, Candidate } from "../types";
 
-export async function arxivAtomAdapter(_ctx: AdapterContext): Promise<AdapterResult> {
-  throw new Error("arxiv_atom adapter not yet implemented (Phase 12e.5d)");
+const FETCH_TIMEOUT_MS = 30_000;
+const ARXIV_VOLUME_CAP = 20;
+const USER_AGENT = "SIGNAL/12e.5d (+contact@signal.so)";
+
+function sha256Truncated(input: string): string {
+  return crypto.createHash("sha256").update(input, "utf8").digest("hex").slice(0, 32);
+}
+
+// arXiv entry ids look like "http://arxiv.org/abs/2301.00001v2".
+// Strip to the bare paper id ("2301.00001") — version suffix excluded so
+// v1 and v2 of the same paper dedup against the same external_id.
+function extractArxivId(rawId: string): string {
+  const match = /abs\/([^v]+)/.exec(rawId);
+  return match?.[1]?.trim() ?? sha256Truncated(rawId);
+}
+
+function classifyFetchError(err: unknown): "timeout" | "network" {
+  return (err as { name?: string }).name === "AbortError" ? "timeout" : "network";
+}
+
+export async function arxivAtomAdapter(ctx: AdapterContext): Promise<AdapterResult> {
+  if (!ctx.endpoint) throw new Error("network");
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  let body: string;
+  try {
+    let res: Response;
+    try {
+      res = await fetch(ctx.endpoint, {
+        headers: { "User-Agent": USER_AGENT, Accept: "application/atom+xml, */*" },
+        signal: ctrl.signal,
+      });
+    } catch (err) {
+      throw new Error(classifyFetchError(err));
+    }
+    if (res.status >= 400 && res.status < 500) throw new Error("http_4xx");
+    if (res.status >= 500) throw new Error("http_5xx");
+    body = await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const parser = new Parser();
+  let feed: Awaited<ReturnType<typeof parser.parseString>>;
+  try {
+    feed = await parser.parseString(body);
+  } catch {
+    throw new Error("parse_error");
+  }
+
+  const candidates: Candidate[] = [];
+  for (const item of feed.items.slice(0, ARXIV_VOLUME_CAP)) {
+    const rawId = (item as { id?: string }).id ?? item.guid ?? "";
+    const externalId =
+      rawId.length > 0 ? extractArxivId(rawId) : sha256Truncated(item.link ?? "");
+    const url = item.link ?? `https://arxiv.org/abs/${externalId}`;
+    const title = item.title?.trim() ?? null;
+    // rss-parser populates Atom <summary> into the `summary` field; some
+    // Atom variants also surface `<content>` and rss-parser may set
+    // `contentSnippet` when an HTML body is present. Try in that order.
+    const summary =
+      item.contentSnippet?.trim() ||
+      item.content?.trim() ||
+      item.summary?.trim() ||
+      null;
+    // arXiv Atom uses isoDate (normalized updated field).
+    const publishedAt = item.isoDate ? new Date(item.isoDate) : null;
+    const contentHash = sha256Truncated(`${url}\n${title ?? ""}\n${summary ?? ""}`);
+
+    candidates.push({
+      externalId,
+      url,
+      title,
+      summary,
+      publishedAt,
+      contentHash,
+      rawPayload: item as unknown as Record<string, unknown>,
+    });
+  }
+
+  return { candidates };
 }

--- a/backend/src/jobs/ingestion/adapters/index.ts
+++ b/backend/src/jobs/ingestion/adapters/index.ts
@@ -15,17 +15,15 @@ import { redditAdapter } from "./reddit";
 
 const REGISTRY: Record<IngestionAdapterType, AdapterFn | null> = {
   rss: rssAdapter,
-  arxiv_atom: null,
-  sec_edgar_json: null,
+  arxiv_atom: arxivAtomAdapter,
+  sec_edgar_json: secEdgarJsonAdapter,
   hackernews_api: null,
   reddit_api: null,
 };
 
 // Suppress "imported but not yet wired" noise — the per-adapter modules
-// are kept linked here so 12e.5d/.5e only need to flip the registry
-// entry rather than hunt down both an import and a map slot.
-void arxivAtomAdapter;
-void secEdgarJsonAdapter;
+// are kept linked here so 12e.5e only needs to flip the registry entry
+// rather than hunt down both an import and a map slot.
 void hackerNewsAdapter;
 void redditAdapter;
 

--- a/backend/src/jobs/ingestion/adapters/secEdgarJson.ts
+++ b/backend/src/jobs/ingestion/adapters/secEdgarJson.ts
@@ -1,10 +1,167 @@
-// SEC EDGAR JSON adapter — stub. Implementation lands in 12e.5d
-// (business-hours-aware cadence: every 15 min 9-5 ET, hourly off-hours;
-// CIK-filtered for the semis-tagged subset and unfiltered for the full
-// feed).
+// SEC EDGAR JSON adapter (Phase 12e.5d).
+//
+// Fetches https://data.sec.gov/submissions/CIK{cik}.json for each CIK
+// in config.ciks and emits recent filings of interest (10-K, 10-Q, 8-K,
+// S-1, 20-F) as candidates. Body text is unavailable at this stage —
+// the heuristic body-fetch step (12e.3) retrieves the actual document.
+//
+// SEC EDGAR fair-access policy requires:
+//   - A descriptive User-Agent identifying the app and a contact email.
+//   - No more than 10 requests/second (we stay well under with 150ms delay).
+//
+// Failure strings: timeout | network | http_4xx | http_5xx | parse_error
 
-import type { AdapterContext, AdapterResult } from "../types";
+import crypto from "node:crypto";
+import type { AdapterContext, AdapterResult, Candidate } from "../types";
 
-export async function secEdgarJsonAdapter(_ctx: AdapterContext): Promise<AdapterResult> {
-  throw new Error("sec_edgar_json adapter not yet implemented (Phase 12e.5d)");
+const FETCH_TIMEOUT_MS = 30_000;
+const USER_AGENT = "SIGNAL/12e.5d signal-ingestion (+contact@signal.so)";
+const INTER_CIK_DELAY_MS = 150;
+const RELEVANT_FORMS = new Set(["10-K", "10-Q", "8-K", "S-1", "20-F"]);
+const DEFAULT_LOOKBACK_DAYS = 7;
+
+function sha256Truncated(input: string): string {
+  return crypto.createHash("sha256").update(input, "utf8").digest("hex").slice(0, 32);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function classifyFetchError(err: unknown): "timeout" | "network" {
+  return (err as { name?: string }).name === "AbortError" ? "timeout" : "network";
+}
+
+// Pad CIK to 10 digits (EDGAR standard).
+function padCik(cik: string): string {
+  return cik.replace(/^0+/, "").padStart(10, "0");
+}
+
+function accessionToPath(accession: string): string {
+  return accession.replace(/-/g, "");
+}
+
+interface EdgarFilings {
+  recent: {
+    accessionNumber: string[];
+    filingDate: string[];
+    form: string[];
+    primaryDocument: string[];
+  };
+}
+
+interface EdgarSubmissions {
+  name?: string;
+  cik?: string;
+  filings?: EdgarFilings;
+}
+
+async function fetchCikCandidates(
+  cik: string,
+  since: Date,
+  first: boolean,
+): Promise<Candidate[]> {
+  if (!first) await sleep(INTER_CIK_DELAY_MS);
+
+  const paddedCik = padCik(cik);
+  const url = `https://data.sec.gov/submissions/CIK${paddedCik}.json`;
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  let data: EdgarSubmissions;
+  try {
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+        signal: ctrl.signal,
+      });
+    } catch (err) {
+      throw new Error(classifyFetchError(err));
+    }
+    if (res.status >= 400 && res.status < 500) throw new Error("http_4xx");
+    if (res.status >= 500) throw new Error("http_5xx");
+    data = (await res.json()) as EdgarSubmissions;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const companyName = data.name ?? `CIK ${cik}`;
+  const recent = data.filings?.recent;
+  if (!recent) return [];
+
+  const candidates: Candidate[] = [];
+  const count = recent.accessionNumber.length;
+
+  for (let i = 0; i < count; i++) {
+    const form = recent.form[i] ?? "";
+    if (!RELEVANT_FORMS.has(form)) continue;
+
+    const filingDateStr = recent.filingDate[i] ?? "";
+    const filingDate = filingDateStr ? new Date(`${filingDateStr}T00:00:00Z`) : null;
+    if (!filingDate || filingDate < since) continue;
+
+    const accession = recent.accessionNumber[i] ?? "";
+    const primaryDoc = recent.primaryDocument[i] ?? "";
+    const numericCik = cik.replace(/^0+/, "");
+    const filingUrl = primaryDoc
+      ? `https://www.sec.gov/Archives/edgar/data/${numericCik}/${accessionToPath(accession)}/${primaryDoc}`
+      : `https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=${paddedCik}&type=${form}`;
+
+    const title = `${companyName} — ${form} (${filingDateStr})`;
+    const externalId = accession;
+    const contentHash = sha256Truncated(`${filingUrl}\n${title}`);
+
+    candidates.push({
+      externalId,
+      url: filingUrl,
+      title,
+      summary: null,
+      publishedAt: filingDate,
+      contentHash,
+      rawPayload: {
+        cik,
+        companyName,
+        accessionNumber: accession,
+        form,
+        filingDate: filingDateStr,
+        primaryDocument: primaryDoc,
+      },
+    });
+  }
+
+  return candidates;
+}
+
+export async function secEdgarJsonAdapter(ctx: AdapterContext): Promise<AdapterResult> {
+  const rawCiks = ctx.config.ciks;
+  if (!Array.isArray(rawCiks) || rawCiks.length === 0) {
+    // No CIK list = nothing to fetch. Not an error — the source may
+    // be the sec-edgar-full row (now typed 'rss') or a misconfigured row.
+    return { candidates: [] };
+  }
+  const ciks = rawCiks.filter((c): c is string => typeof c === "string");
+
+  const since = ctx.lastPolledAt
+    ? new Date(ctx.lastPolledAt)
+    : new Date(Date.now() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+
+  const all: Candidate[] = [];
+  for (let i = 0; i < ciks.length; i++) {
+    const cik = ciks[i];
+    if (!cik) continue;
+    try {
+      const candidates = await fetchCikCandidates(cik, since, i === 0);
+      all.push(...candidates);
+    } catch (err) {
+      // One CIK failing shouldn't abort the rest. Log and continue.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[edgar-adapter] CIK ${cik} failed:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  return { candidates: all };
 }

--- a/backend/tests/ingestion/arxivAtomAdapter.test.ts
+++ b/backend/tests/ingestion/arxivAtomAdapter.test.ts
@@ -1,0 +1,172 @@
+import { arxivAtomAdapter } from "../../src/jobs/ingestion/adapters/arxivAtom";
+import type { AdapterContext } from "../../src/jobs/ingestion/types";
+
+function makeCtx(overrides: Partial<AdapterContext> = {}): AdapterContext {
+  return {
+    sourceId: "00000000-0000-0000-0000-000000000001",
+    slug: "arxiv-ai-cl-lg",
+    adapterType: "arxiv_atom",
+    endpoint: "https://export.arxiv.org/api/query?search_query=cat:cs.AI",
+    config: {},
+    lastPolledAt: null,
+    ...overrides,
+  };
+}
+
+function mockOk(body: string): void {
+  global.fetch = jest.fn().mockResolvedValue({
+    status: 200,
+    headers: { get: () => "application/atom+xml" },
+    text: async () => body,
+  } as unknown as Response);
+}
+
+function buildAtom(entries: { id: string; title: string; updated: string; summary?: string }[]): string {
+  const items = entries
+    .map(
+      (e) => `
+  <entry>
+    <id>${e.id}</id>
+    <updated>${e.updated}</updated>
+    <published>${e.updated}</published>
+    <title>${e.title}</title>
+    <summary>${e.summary ?? "Abstract text for " + e.title}</summary>
+    <link href="${e.id}" rel="alternate" type="text/html"/>
+  </entry>`,
+    )
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>arXiv Query</title>
+  <link href="https://arxiv.org/" rel="alternate"/>
+  <id>http://arxiv.org/api/query</id>
+  <updated>2026-04-15T00:00:00Z</updated>
+  ${items}
+</feed>`;
+}
+
+describe("arxivAtomAdapter", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  describe("happy path", () => {
+    it("emits one candidate per entry with version-stripped externalId", async () => {
+      const xml = buildAtom([
+        {
+          id: "http://arxiv.org/abs/2401.12345v2",
+          title: "Scaling Laws for Mixture-of-Experts",
+          updated: "2026-04-15T10:00:00Z",
+        },
+        {
+          id: "http://arxiv.org/abs/2402.99999v1",
+          title: "Attention Is Still All You Need",
+          updated: "2026-04-14T12:00:00Z",
+        },
+      ]);
+      mockOk(xml);
+      const result = await arxivAtomAdapter(makeCtx());
+      expect(result.candidates.length).toBe(2);
+      expect(result.candidates[0]!.externalId).toBe("2401.12345");
+      expect(result.candidates[1]!.externalId).toBe("2402.99999");
+    });
+
+    it("uses isoDate (Atom updated field) for publishedAt", async () => {
+      const xml = buildAtom([
+        {
+          id: "http://arxiv.org/abs/2403.00001v1",
+          title: "T",
+          updated: "2026-04-10T08:30:00Z",
+        },
+      ]);
+      mockOk(xml);
+      const result = await arxivAtomAdapter(makeCtx());
+      const pub = result.candidates[0]!.publishedAt;
+      expect(pub).toBeInstanceOf(Date);
+      expect(pub!.toISOString()).toBe("2026-04-10T08:30:00.000Z");
+    });
+
+    it("caps volume at 20 even when feed contains 30 entries", async () => {
+      const entries = Array.from({ length: 30 }, (_, i) => ({
+        id: `http://arxiv.org/abs/2404.${String(i).padStart(5, "0")}v1`,
+        title: `Paper ${i}`,
+        updated: "2026-04-15T00:00:00Z",
+      }));
+      const xml = buildAtom(entries);
+      mockOk(xml);
+      const result = await arxivAtomAdapter(makeCtx());
+      expect(result.candidates.length).toBe(20);
+      expect(result.candidates[0]!.externalId).toBe("2404.00000");
+      expect(result.candidates[19]!.externalId).toBe("2404.00019");
+    });
+
+    it("emits 32-char hex contentHash", async () => {
+      const xml = buildAtom([
+        {
+          id: "http://arxiv.org/abs/2401.00001v1",
+          title: "T",
+          updated: "2026-04-15T00:00:00Z",
+        },
+      ]);
+      mockOk(xml);
+      const result = await arxivAtomAdapter(makeCtx());
+      expect(result.candidates[0]!.contentHash).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("populates summary from contentSnippet (Atom summary field)", async () => {
+      const xml = buildAtom([
+        {
+          id: "http://arxiv.org/abs/2401.55555v1",
+          title: "T",
+          updated: "2026-04-15T00:00:00Z",
+          summary: "A novel approach to scaling.",
+        },
+      ]);
+      mockOk(xml);
+      const result = await arxivAtomAdapter(makeCtx());
+      expect(result.candidates[0]!.summary).toContain("novel approach to scaling");
+    });
+  });
+
+  describe("failure classification", () => {
+    it("throws timeout on AbortError", async () => {
+      const abortErr = new Error("aborted");
+      abortErr.name = "AbortError";
+      global.fetch = jest.fn().mockRejectedValue(abortErr);
+      await expect(arxivAtomAdapter(makeCtx())).rejects.toThrow("timeout");
+    });
+
+    it("throws network on generic fetch failure", async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error("ENOTFOUND"));
+      await expect(arxivAtomAdapter(makeCtx())).rejects.toThrow("network");
+    });
+
+    it("throws http_4xx on 429 rate limit", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 429,
+        headers: { get: () => "text/plain" },
+        text: async () => "rate limited",
+      } as unknown as Response);
+      await expect(arxivAtomAdapter(makeCtx())).rejects.toThrow("http_4xx");
+    });
+
+    it("throws http_5xx on 503", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 503,
+        headers: { get: () => "text/plain" },
+        text: async () => "",
+      } as unknown as Response);
+      await expect(arxivAtomAdapter(makeCtx())).rejects.toThrow("http_5xx");
+    });
+
+    it("throws parse_error on malformed XML", async () => {
+      mockOk("<not-an-atom-feed>{}{}{}");
+      await expect(arxivAtomAdapter(makeCtx())).rejects.toThrow("parse_error");
+    });
+
+    it("throws network when endpoint is null", async () => {
+      await expect(arxivAtomAdapter(makeCtx({ endpoint: null }))).rejects.toThrow("network");
+    });
+  });
+});

--- a/backend/tests/ingestion/secEdgarJsonAdapter.test.ts
+++ b/backend/tests/ingestion/secEdgarJsonAdapter.test.ts
@@ -1,0 +1,235 @@
+import { secEdgarJsonAdapter } from "../../src/jobs/ingestion/adapters/secEdgarJson";
+import type { AdapterContext } from "../../src/jobs/ingestion/types";
+
+function makeCtx(overrides: Partial<AdapterContext> = {}): AdapterContext {
+  return {
+    sourceId: "00000000-0000-0000-0000-000000000002",
+    slug: "sec-edgar-semis",
+    adapterType: "sec_edgar_json",
+    endpoint: "https://data.sec.gov/submissions/CIK{cik}.json",
+    config: {},
+    lastPolledAt: null,
+    ...overrides,
+  };
+}
+
+interface FilingRow {
+  accessionNumber: string;
+  filingDate: string;
+  form: string;
+  primaryDocument: string;
+}
+
+function buildSubmissionsJson(name: string, rows: FilingRow[]): unknown {
+  return {
+    name,
+    cik: "1045810",
+    filings: {
+      recent: {
+        accessionNumber: rows.map((r) => r.accessionNumber),
+        filingDate: rows.map((r) => r.filingDate),
+        form: rows.map((r) => r.form),
+        primaryDocument: rows.map((r) => r.primaryDocument),
+      },
+    },
+  };
+}
+
+function mockJson(payload: unknown): jest.Mock {
+  const fn = jest.fn().mockResolvedValue({
+    status: 200,
+    headers: { get: () => "application/json" },
+    json: async () => payload,
+  } as unknown as Response);
+  global.fetch = fn;
+  return fn;
+}
+
+describe("secEdgarJsonAdapter", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  describe("config validation", () => {
+    it("returns empty candidates when config.ciks is missing", async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock;
+      const result = await secEdgarJsonAdapter(makeCtx({ config: {} }));
+      expect(result.candidates).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("returns empty candidates when config.ciks is an empty array", async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock;
+      const result = await secEdgarJsonAdapter(makeCtx({ config: { ciks: [] } }));
+      expect(result.candidates).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("happy path", () => {
+    it("emits candidates only for relevant forms (10-K, 10-Q, 8-K, S-1, 20-F)", async () => {
+      const since = new Date("2026-04-01T00:00:00Z");
+      mockJson(
+        buildSubmissionsJson("NVIDIA CORP", [
+          { accessionNumber: "0001045810-26-000001", filingDate: "2026-04-15", form: "10-K", primaryDocument: "nv10k.htm" },
+          { accessionNumber: "0001045810-26-000002", filingDate: "2026-04-14", form: "10-Q", primaryDocument: "nv10q.htm" },
+          { accessionNumber: "0001045810-26-000003", filingDate: "2026-04-13", form: "8-K", primaryDocument: "nv8k.htm" },
+          { accessionNumber: "0001045810-26-000004", filingDate: "2026-04-12", form: "S-1", primaryDocument: "nvs1.htm" },
+          { accessionNumber: "0001045810-26-000005", filingDate: "2026-04-11", form: "20-F", primaryDocument: "nv20f.htm" },
+          { accessionNumber: "0001045810-26-000006", filingDate: "2026-04-10", form: "DEF 14A", primaryDocument: "proxy.htm" },
+          { accessionNumber: "0001045810-26-000007", filingDate: "2026-04-09", form: "SC 13G", primaryDocument: "sc13g.htm" },
+          { accessionNumber: "0001045810-26-000008", filingDate: "2026-04-08", form: "4", primaryDocument: "form4.xml" },
+        ]),
+      );
+      const result = await secEdgarJsonAdapter(
+        makeCtx({ config: { ciks: ["0001045810"] }, lastPolledAt: since }),
+      );
+      expect(result.candidates.length).toBe(5);
+      const forms = result.candidates.map((c) => c.rawPayload.form);
+      expect(forms).toEqual(["10-K", "10-Q", "8-K", "S-1", "20-F"]);
+    });
+
+    it("excludes filings older than `since` (lastPolledAt)", async () => {
+      const since = new Date("2026-04-10T00:00:00Z");
+      mockJson(
+        buildSubmissionsJson("NVIDIA CORP", [
+          { accessionNumber: "0001045810-26-000001", filingDate: "2026-04-15", form: "10-K", primaryDocument: "a.htm" },
+          { accessionNumber: "0001045810-26-000002", filingDate: "2026-04-09", form: "10-K", primaryDocument: "b.htm" },
+          { accessionNumber: "0001045810-26-000003", filingDate: "2026-01-01", form: "10-K", primaryDocument: "c.htm" },
+        ]),
+      );
+      const result = await secEdgarJsonAdapter(
+        makeCtx({ config: { ciks: ["0001045810"] }, lastPolledAt: since }),
+      );
+      expect(result.candidates.length).toBe(1);
+      expect(result.candidates[0]!.externalId).toBe("0001045810-26-000001");
+    });
+
+    it("constructs the EDGAR Archives URL correctly", async () => {
+      const since = new Date("2026-04-01T00:00:00Z");
+      mockJson(
+        buildSubmissionsJson("NVIDIA CORP", [
+          {
+            accessionNumber: "0001045810-26-000123",
+            filingDate: "2026-04-15",
+            form: "10-K",
+            primaryDocument: "nv10k2026.htm",
+          },
+        ]),
+      );
+      const result = await secEdgarJsonAdapter(
+        makeCtx({ config: { ciks: ["0001045810"] }, lastPolledAt: since }),
+      );
+      expect(result.candidates[0]!.url).toBe(
+        "https://www.sec.gov/Archives/edgar/data/1045810/000104581026000123/nv10k2026.htm",
+      );
+    });
+
+    it("titles candidates as `{companyName} — {form} ({filingDate})`", async () => {
+      const since = new Date("2026-04-01T00:00:00Z");
+      mockJson(
+        buildSubmissionsJson("NVIDIA CORP", [
+          { accessionNumber: "0001045810-26-000001", filingDate: "2026-04-15", form: "10-K", primaryDocument: "x.htm" },
+        ]),
+      );
+      const result = await secEdgarJsonAdapter(
+        makeCtx({ config: { ciks: ["0001045810"] }, lastPolledAt: since }),
+      );
+      expect(result.candidates[0]!.title).toBe("NVIDIA CORP — 10-K (2026-04-15)");
+      expect(result.candidates[0]!.summary).toBeNull();
+    });
+
+    it("uses default 7-day lookback when lastPolledAt is null", async () => {
+      // Stable "now" so the 7-day boundary is deterministic.
+      jest.useFakeTimers().setSystemTime(new Date("2026-04-20T00:00:00Z"));
+      try {
+        mockJson(
+          buildSubmissionsJson("NVIDIA CORP", [
+            { accessionNumber: "0001045810-26-000001", filingDate: "2026-04-19", form: "10-K", primaryDocument: "a.htm" },
+            { accessionNumber: "0001045810-26-000002", filingDate: "2026-04-10", form: "10-K", primaryDocument: "b.htm" },
+          ]),
+        );
+        const result = await secEdgarJsonAdapter(
+          makeCtx({ config: { ciks: ["0001045810"] }, lastPolledAt: null }),
+        );
+        expect(result.candidates.length).toBe(1);
+        expect(result.candidates[0]!.externalId).toBe("0001045810-26-000001");
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe("multi-CIK behavior", () => {
+    it("continues to next CIK when one CIK fetch fails", async () => {
+      const since = new Date("2026-04-01T00:00:00Z");
+      const fetchMock = jest
+        .fn()
+        // First CIK: HTTP 500.
+        .mockResolvedValueOnce({
+          status: 500,
+          headers: { get: () => "text/plain" },
+          text: async () => "server error",
+          json: async () => ({}),
+        } as unknown as Response)
+        // Second CIK: success.
+        .mockResolvedValueOnce({
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: async () =>
+            buildSubmissionsJson("AMD", [
+              { accessionNumber: "0000002488-26-000099", filingDate: "2026-04-15", form: "10-K", primaryDocument: "amd.htm" },
+            ]),
+        } as unknown as Response);
+      global.fetch = fetchMock;
+
+      // Suppress the [edgar-adapter] error log for the failing CIK.
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await secEdgarJsonAdapter(
+        makeCtx({ config: { ciks: ["0001045810", "0000002488"] }, lastPolledAt: since }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.candidates.length).toBe(1);
+      expect(result.candidates[0]!.rawPayload.companyName).toBe("AMD");
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it("aggregates candidates across multiple CIKs", async () => {
+      const since = new Date("2026-04-01T00:00:00Z");
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce({
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: async () =>
+            buildSubmissionsJson("NVIDIA CORP", [
+              { accessionNumber: "0001045810-26-000001", filingDate: "2026-04-15", form: "10-K", primaryDocument: "n.htm" },
+            ]),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: async () =>
+            buildSubmissionsJson("AMD", [
+              { accessionNumber: "0000002488-26-000001", filingDate: "2026-04-14", form: "8-K", primaryDocument: "a.htm" },
+            ]),
+        } as unknown as Response);
+      global.fetch = fetchMock;
+
+      const result = await secEdgarJsonAdapter(
+        makeCtx({ config: { ciks: ["0001045810", "0000002488"] }, lastPolledAt: since }),
+      );
+      expect(result.candidates.length).toBe(2);
+      expect(result.candidates.map((c) => c.rawPayload.companyName)).toEqual([
+        "NVIDIA CORP",
+        "AMD",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Closes 12e.5d.

- Migration 0026: sec-edgar-full adapter_type corrected to 'rss' (endpoint returns Atom XML); sec-edgar-semis config populated with 12 chip-company CIKs (NVDA/AMD/TSMC/ASML/Intel/Qualcomm/Broadcom/Marvell/Micron/AMAT/LRCX/KLA)
- arxivAtom adapter: volume cap 20/cycle, arXiv ID extraction (strips version suffix), isoDate publishedAt, summary fallback chain corrected for rss-parser Atom field mapping
- secEdgarJson adapter: per-CIK EDGAR submissions JSON fetch, RELEVANT_FORMS filter (10-K/10-Q/8-K/S-1/20-F), recency gate, 150ms inter-CIK delay, one-CIK failure isolation
- Registry: arxiv_atom + sec_edgar_json slots wired; void suppressions removed
- Tests: +20 (11 arXiv, 9 EDGAR) across 2 new suites