### PR TITLE
feat(ingestion): Hacker News adapter, wire registry (12e.5e)

### DIFF
--- a/backend/src/jobs/ingestion/adapters/hackerNews.ts
+++ b/backend/src/jobs/ingestion/adapters/hackerNews.ts
@@ -1,9 +1,121 @@
-// Hacker News API adapter — stub. Implementation lands in 12e.5e
-// (pull /v0/topstories, filter by domain whitelist + minimum score,
-// 4-hour cadence).
+// Hacker News API adapter (Phase 12e.5e).
+//
+// Two-phase fetch: topstories list → per-item detail. Filters to
+// story-type items with score >= HN_MIN_SCORE and an external URL.
+// No domain whitelist — the LLM relevance gate (12e.4) handles
+// off-sector filtering.
+//
+// Concurrency: item fetches run in batches of HN_FETCH_CONCURRENCY to
+// stay within Firebase's undocumented rate limits while keeping the
+// 4-hour poll cycle fast enough to matter.
+//
+// Failure strings: timeout | network | http_4xx | http_5xx | parse_error
 
-import type { AdapterContext, AdapterResult } from "../types";
+import crypto from "node:crypto";
+import type { AdapterContext, AdapterResult, Candidate } from "../types";
+
+const FETCH_TIMEOUT_MS = 30_000;
+const USER_AGENT = "SIGNAL/12e.5e (+contact@signal.so)";
+const HN_MIN_SCORE = 100;
+const HN_TOP_IDS_CAP = 150;
+const HN_FETCH_CONCURRENCY = 10;
+const HN_BASE = "https://hacker-news.firebaseio.com/v0";
+
+function sha256Truncated(input: string): string {
+  return crypto.createHash("sha256").update(input, "utf8").digest("hex").slice(0, 32);
+}
+
+function classifyFetchError(err: unknown): "timeout" | "network" {
+  return (err as { name?: string }).name === "AbortError" ? "timeout" : "network";
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+        signal: ctrl.signal,
+      });
+    } catch (err) {
+      throw new Error(classifyFetchError(err));
+    }
+    if (res.status >= 400 && res.status < 500) throw new Error("http_4xx");
+    if (res.status >= 500) throw new Error("http_5xx");
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface HnItem {
+  id: number;
+  type?: string;
+  title?: string;
+  url?: string;
+  score?: number;
+  time?: number;
+  dead?: boolean;
+  deleted?: boolean;
+}
+
+function isUsableItem(item: HnItem): boolean {
+  if (item.dead || item.deleted) return false;
+  if (item.type !== "story") return false;
+  if (!item.url || item.url.trim().length === 0) return false;
+  if ((item.score ?? 0) < HN_MIN_SCORE) return false;
+  return true;
+}
+
+async function fetchItemBatch(ids: number[]): Promise<HnItem[]> {
+  const results = await Promise.allSettled(
+    ids.map((id) => fetchJson<HnItem>(`${HN_BASE}/item/${id}.json`)),
+  );
+  return results
+    .filter((r): r is PromiseFulfilledResult<HnItem> => r.status === "fulfilled")
+    .map((r) => r.value)
+    .filter((item): item is HnItem => item !== null);
+}
 
 export async function hackerNewsAdapter(_ctx: AdapterContext): Promise<AdapterResult> {
-  throw new Error("hackernews_api adapter not yet implemented (Phase 12e.5e)");
+  // Fetch topstory IDs.
+  let topIds: number[];
+  try {
+    topIds = await fetchJson<number[]>(`${HN_BASE}/topstories.json`);
+  } catch (err) {
+    // Re-throw with stable failure string so sourcePollJob classifies correctly.
+    throw err instanceof Error ? err : new Error("network");
+  }
+
+  if (!Array.isArray(topIds)) throw new Error("parse_error");
+
+  const candidateIds = topIds.slice(0, HN_TOP_IDS_CAP);
+
+  // Fetch item details in concurrent batches.
+  const candidates: Candidate[] = [];
+  for (let i = 0; i < candidateIds.length; i += HN_FETCH_CONCURRENCY) {
+    const batch = candidateIds.slice(i, i + HN_FETCH_CONCURRENCY);
+    const items = await fetchItemBatch(batch);
+    for (const item of items) {
+      if (!isUsableItem(item)) continue;
+      const url = item.url!;
+      const title = item.title ?? null;
+      const externalId = String(item.id);
+      const publishedAt = item.time ? new Date(item.time * 1000) : null;
+      const contentHash = sha256Truncated(`${url}\n${title ?? ""}`);
+      candidates.push({
+        externalId,
+        url,
+        title,
+        summary: null,
+        publishedAt,
+        contentHash,
+        rawPayload: item as unknown as Record<string, unknown>,
+      });
+    }
+  }
+
+  return { candidates };
 }

--- a/backend/src/jobs/ingestion/adapters/index.ts
+++ b/backend/src/jobs/ingestion/adapters/index.ts
@@ -17,14 +17,13 @@ const REGISTRY: Record<IngestionAdapterType, AdapterFn | null> = {
   rss: rssAdapter,
   arxiv_atom: arxivAtomAdapter,
   sec_edgar_json: secEdgarJsonAdapter,
-  hackernews_api: null,
+  hackernews_api: hackerNewsAdapter,
   reddit_api: null,
 };
 
-// Suppress "imported but not yet wired" noise — the per-adapter modules
-// are kept linked here so 12e.5e only needs to flip the registry entry
-// rather than hunt down both an import and a map slot.
-void hackerNewsAdapter;
+// Suppress "imported but not yet wired" noise — the reddit adapter
+// stays linked here so a future phase only needs to flip the registry
+// entry rather than hunt down both an import and a map slot.
 void redditAdapter;
 
 export function getAdapter(type: IngestionAdapterType): AdapterFn | null {

--- a/backend/tests/ingestion/hackerNewsAdapter.test.ts
+++ b/backend/tests/ingestion/hackerNewsAdapter.test.ts
@@ -1,0 +1,205 @@
+import { hackerNewsAdapter } from "../../src/jobs/ingestion/adapters/hackerNews";
+import type { AdapterContext } from "../../src/jobs/ingestion/types";
+
+const HN_BASE = "https://hacker-news.firebaseio.com/v0";
+
+function makeCtx(overrides: Partial<AdapterContext> = {}): AdapterContext {
+  return {
+    sourceId: "00000000-0000-0000-0000-000000000003",
+    slug: "hackernews",
+    adapterType: "hackernews_api",
+    endpoint: `${HN_BASE}/topstories.json`,
+    config: {},
+    lastPolledAt: null,
+    ...overrides,
+  };
+}
+
+interface HnItemFixture {
+  id: number;
+  type?: string;
+  title?: string;
+  url?: string;
+  score?: number;
+  time?: number;
+  dead?: boolean;
+  deleted?: boolean;
+}
+
+interface MockHnArgs {
+  topIds: number[] | { status: number };
+  items?: Record<number, HnItemFixture | { reject: true } | null>;
+}
+
+// Routes fetch calls by URL: topstories or item/{id}.
+function mockHn({ topIds, items = {} }: MockHnArgs): jest.Mock {
+  const fn = jest.fn(async (url: string) => {
+    if (url.endsWith("/topstories.json")) {
+      if (!Array.isArray(topIds) && typeof topIds === "object" && "status" in topIds) {
+        return {
+          status: topIds.status,
+          headers: { get: () => "text/plain" },
+          json: async () => null,
+        } as unknown as Response;
+      }
+      return {
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: async () => topIds,
+      } as unknown as Response;
+    }
+    const m = /\/item\/(\d+)\.json$/.exec(url);
+    if (!m) throw new Error(`unexpected url: ${url}`);
+    const id = Number(m[1]);
+    const fixture = items[id];
+    if (fixture && typeof fixture === "object" && "reject" in fixture && fixture.reject) {
+      throw new Error("ENOTFOUND");
+    }
+    return {
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => fixture ?? null,
+    } as unknown as Response;
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+function story(id: number, overrides: Partial<HnItemFixture> = {}): HnItemFixture {
+  return {
+    id,
+    type: "story",
+    title: `Story ${id}`,
+    url: `https://example.com/${id}`,
+    score: 200,
+    time: 1714000000,
+    ...overrides,
+  };
+}
+
+describe("hackerNewsAdapter", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  describe("happy path", () => {
+    it("emits one candidate per usable story and filters the rest", async () => {
+      mockHn({
+        topIds: [1, 2, 3, 4, 5],
+        items: {
+          1: story(1, { score: 250 }),
+          2: story(2, { type: "job" }),
+          3: story(3, { score: 50 }),
+          4: story(4, { url: "" }),
+          5: story(5, { dead: true }),
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates.length).toBe(1);
+      expect(result.candidates[0]!.externalId).toBe("1");
+      expect(result.candidates[0]!.url).toBe("https://example.com/1");
+      expect(result.candidates[0]!.title).toBe("Story 1");
+      expect(result.candidates[0]!.summary).toBeNull();
+    });
+
+    it("emits 32-char hex contentHash and Date for publishedAt", async () => {
+      mockHn({
+        topIds: [42],
+        items: { 42: story(42, { time: 1714000000 }) },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates[0]!.contentHash).toMatch(/^[0-9a-f]{32}$/);
+      expect(result.candidates[0]!.publishedAt).toBeInstanceOf(Date);
+      expect(result.candidates[0]!.publishedAt!.toISOString()).toBe(
+        new Date(1714000000 * 1000).toISOString(),
+      );
+    });
+  });
+
+  describe("volume cap", () => {
+    it("fetches only the first 150 IDs even when topstories returns 300", async () => {
+      const ids = Array.from({ length: 300 }, (_, i) => i + 1);
+      const items: Record<number, HnItemFixture> = {};
+      for (const id of ids) items[id] = story(id);
+      const fetchMock = mockHn({ topIds: ids, items });
+
+      const result = await hackerNewsAdapter(makeCtx());
+      // 1 topstories call + 150 item calls = 151.
+      expect(fetchMock).toHaveBeenCalledTimes(151);
+      expect(result.candidates.length).toBe(150);
+      expect(result.candidates[0]!.externalId).toBe("1");
+      expect(result.candidates[149]!.externalId).toBe("150");
+    });
+  });
+
+  describe("filter exclusions", () => {
+    it("excludes dead:true items", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { dead: true }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it("excludes deleted:true items", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { deleted: true }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it('excludes type:"job"', async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { type: "job" }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it("excludes items with no url (Ask HN / Show HN with no link)", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { url: undefined }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it("excludes items with score below 100", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { score: 99 }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it("includes items at exactly score 100", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { score: 100 }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates.length).toBe(1);
+    });
+  });
+
+  describe("topstories failure", () => {
+    it("throws http_4xx when topstories returns 404", async () => {
+      mockHn({ topIds: { status: 404 } });
+      await expect(hackerNewsAdapter(makeCtx())).rejects.toThrow("http_4xx");
+    });
+
+    it("throws parse_error when topstories returns non-array", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: async () => ({ not: "an array" }),
+      } as unknown as Response);
+      await expect(hackerNewsAdapter(makeCtx())).rejects.toThrow("parse_error");
+    });
+  });
+
+  describe("individual item fetch failure", () => {
+    it("silently drops the failing item and emits the rest", async () => {
+      mockHn({
+        topIds: [1, 2, 3],
+        items: {
+          1: story(1),
+          2: { reject: true },
+          3: story(3),
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates.length).toBe(2);
+      expect(result.candidates.map((c) => c.externalId)).toEqual(["1", "3"]);
+    });
+  });
+});


### PR DESCRIPTION
Closes 12e.5e (partial — Reddit deferred pending OAuth credentials).

- hackerNews adapter: two-phase fetch (topstories list → per-item detail), score>=100 filter, story-type + external-url gates, dead/deleted skip, 150-ID cap, 10-item concurrent batches
- Registry: hackernews_api slot wired; void suppression removed
- reddit_api slot remains null pending credentials
- Tests: +12 (happy path, volume cap, 6 filter exclusions, topstories failure, item-failure resilience)