### PR TITLE
feat(feed): 12f rules-based ranking v1

### DIFF
--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -12,6 +12,16 @@ import {
 } from "../db/schema";
 import { AppError } from "../middleware/errorHandler";
 import { personalizeStory } from "../services/personalizationService";
+import {
+  EDGAR_PENALTY,
+  EDGAR_SOURCE_SLUGS,
+  FEED_MAX_STORIES,
+  FRESHNESS_BONUS,
+  FRESHNESS_QUALITY_THRESHOLD,
+  FRESHNESS_WINDOW_HOURS,
+  W1,
+  W2,
+} from "../feed/rankingConstants";
 
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 10;
@@ -129,6 +139,10 @@ interface EventRow {
   isSaved: boolean;
   saveCount: number;
   commentCount: number;
+  // Phase 12f — ranking score computed in SQL. Used by the merge step
+  // to sort events vs. legacy stories on a unified scale. Never sent
+  // to the wire (shapeEvent strips it).
+  effectiveScore: number;
 }
 
 interface EventSourceRow {
@@ -205,6 +219,123 @@ function eventCommentCountExpr(): ReturnType<typeof sql<number>> {
   return sql<number>`(SELECT COUNT(*)::int FROM comments c WHERE c.event_id = ${events.id} AND c.deleted_at IS NULL)`;
 }
 
+// Phase 12f — ranking expressions for the events query. Each helper is
+// a SQL fragment, composable inside the SELECT list and the ORDER BY.
+// The composite `eventEffectiveScoreExpr()` mirrors the TS function
+// `calculateEffectiveScore` in src/feed/calculateEffectiveScore.ts —
+// the TS function exists for unit tests; the SQL is canonical for
+// production. Keep them in lockstep.
+
+/**
+ * Quality score of the event's primary source, looked up via the
+ * `role='primary'` event_sources row. Falls back to 5 (the schema
+ * default on ingestion_sources.quality_score) when no primary source
+ * row exists, which is rare but possible for legacy event rows.
+ */
+function eventQualityScoreExpr(): ReturnType<typeof sql<number>> {
+  return sql<number>`COALESCE(
+    (SELECT isrc.quality_score
+       FROM event_sources es
+       JOIN ingestion_sources isrc ON isrc.id = es.ingestion_source_id
+       WHERE es.event_id = ${events.id} AND es.role = 'primary'
+       LIMIT 1),
+    5
+  )`;
+}
+
+/**
+ * Number of *alternate* event_sources attached to this event. Equal to
+ * (total event_sources rows − 1); a solo event passes 0. Guarded by
+ * GREATEST so an orphaned event with zero sources doesn't underflow.
+ */
+function eventAlternatesCountExpr(): ReturnType<typeof sql<number>> {
+  return sql<number>`GREATEST(0, (SELECT COUNT(*)::int - 1 FROM event_sources es WHERE es.event_id = ${events.id}))`;
+}
+
+/**
+ * Age of the event in hours since published_at (or created_at if
+ * published_at is null). Float — fractional hours preserved.
+ */
+function eventAgeHoursExpr(): ReturnType<typeof sql<number>> {
+  return sql<number>`(EXTRACT(EPOCH FROM (NOW() - COALESCE(${events.publishedAt}, ${events.createdAt}))) / 3600.0)`;
+}
+
+/**
+ * True iff the event has exactly one event_sources row AND that
+ * source's slug is in EDGAR_SOURCE_SLUGS. Used as the first half of
+ * the EDGAR-penalty gate.
+ */
+function eventIsEdgarSoleSourceExpr(): ReturnType<typeof sql<boolean>> {
+  const slugList = sql.join(
+    EDGAR_SOURCE_SLUGS.map((slug) => sql`${slug}`),
+    sql`, `,
+  );
+  return sql<boolean>`(
+    (SELECT COUNT(*) FROM event_sources es WHERE es.event_id = ${events.id}) = 1
+    AND EXISTS (
+      SELECT 1 FROM event_sources es
+        JOIN ingestion_sources isrc ON isrc.id = es.ingestion_source_id
+        WHERE es.event_id = ${events.id} AND isrc.slug IN (${slugList})
+    )
+  )`;
+}
+
+/**
+ * True iff at least one ingestion_candidate resolved to this event has
+ * non-empty body_text. False = body enrichment never produced usable
+ * text, which (combined with `isEdgarSoleSource`) triggers the EDGAR
+ * penalty.
+ */
+function eventBodyTextPresentExpr(): ReturnType<typeof sql<boolean>> {
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM ingestion_candidates ic
+      WHERE ic.resolved_event_id = ${events.id}
+        AND ic.body_text IS NOT NULL
+        AND ic.body_text <> ''
+  )`;
+}
+
+/**
+ * Composite effective_score expression. Used both as a SELECT column
+ * (so the row carries its score for downstream sort/inspection) and in
+ * the ORDER BY clause.
+ */
+function eventEffectiveScoreExpr(): ReturnType<typeof sql<number>> {
+  const quality = eventQualityScoreExpr();
+  const alternates = eventAlternatesCountExpr();
+  const ageHours = eventAgeHoursExpr();
+  const isEdgarSole = eventIsEdgarSoleSourceExpr();
+  const bodyPresent = eventBodyTextPresentExpr();
+
+  return sql<number>`(
+    ${quality}::numeric
+    + ${W1}::numeric * LN(1 + ${alternates}::numeric)
+    - ${W2}::numeric * ${ageHours}::numeric
+    + CASE
+        WHEN ${quality}::numeric >= ${FRESHNESS_QUALITY_THRESHOLD}::numeric
+          AND ${ageHours}::numeric <= ${FRESHNESS_WINDOW_HOURS}::numeric
+        THEN ${FRESHNESS_BONUS}::numeric
+        ELSE 0::numeric
+      END
+    - CASE
+        WHEN ${isEdgarSole} AND NOT ${bodyPresent}
+        THEN ${EDGAR_PENALTY}::numeric
+        ELSE 0::numeric
+      END
+  )`;
+}
+
+/**
+ * Static baseline score assigned to legacy hand-curated stories so
+ * they sort coherently against ranked events in the merge step.
+ * Stories are evergreen seed content (the 20 rows in
+ * seed-data/stories.json) and don't have ingestion_sources rows to
+ * derive a quality_score from. Pegged at the editorial mid-tier so
+ * they surface above low-quality events but below freshness-bonused
+ * primary-lab events.
+ */
+const STORY_BASELINE_EFFECTIVE_SCORE = 7;
+
 const baseStoryColumns = {
   id: stories.id,
   sector: stories.sector,
@@ -235,16 +366,20 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
     const profileSectors = profile?.sectors ?? [];
     const sectorsFilter = requestedSectors.length > 0 ? requestedSectors : profileSectors;
 
-    if (sectorsFilter.length === 0) {
-      res.json({ data: { stories: [], total: 0, has_more: false, limit, offset } });
-      return;
-    }
+    // Phase 12f — sector filter is a *hard* WHERE (applied before
+    // ranking). An empty `sectorsFilter` means the user hasn't picked
+    // any sectors and didn't pass a `?sectors=` query param; in that
+    // case we return all sectors rather than empty (CLAUDE.md feed
+    // behavior).
+    const storiesSectorWhere =
+      sectorsFilter.length > 0 ? inArray(stories.sector, sectorsFilter) : undefined;
+    const eventsSectorWhere =
+      sectorsFilter.length > 0 ? inArray(events.sector, sectorsFilter) : undefined;
 
-    // Phase 12e.7a — dual-read across `stories` (legacy hand-curated)
-    // and `events` (ingestion-written). Each table is queried with the
-    // same limit/offset; the two pages are merged client-side and sliced
-    // back to `limit` before shaping. `total` is the union row count
-    // (sum across both tables) so `has_more` reflects the union.
+    // Phase 12e.7a — dual-read across `stories` (legacy hand-curated,
+    // 20 rows) and `events` (ingestion-written, the bulk). Stories keep
+    // their chronological order (no ranking inputs apply); events are
+    // ranked via the 12f effective_score expression.
     const storyRows = (await db
       .select({
         ...baseStoryColumns,
@@ -254,11 +389,16 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
       })
       .from(stories)
       .leftJoin(writers, eq(writers.id, stories.authorId))
-      .where(inArray(stories.sector, sectorsFilter))
+      .where(storiesSectorWhere)
       .orderBy(desc(sql`COALESCE(${stories.publishedAt}, ${stories.createdAt})`))
       .limit(limit)
       .offset(offset)) as StoryRow[];
 
+    // Phase 12f — events query is ranked by effective_score DESC and
+    // capped at FEED_MAX_STORIES (the top-N pool). User-supplied limit
+    // and offset paginate the merged result downstream; the SQL-level
+    // cap is the candidate pool size, not the page size.
+    const eventEffectiveScore = eventEffectiveScoreExpr();
     const eventRows = (await db
       .select({
         id: events.id,
@@ -277,22 +417,38 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
         isSaved: isEventSavedExpr(userId),
         saveCount: eventSaveCountExpr(),
         commentCount: eventCommentCountExpr(),
+        effectiveScore: eventEffectiveScore,
       })
       .from(events)
       .leftJoin(writers, eq(writers.id, events.authorId))
-      .where(inArray(events.sector, sectorsFilter))
-      .orderBy(desc(sql`COALESCE(${events.publishedAt}, ${events.createdAt})`))
-      .limit(limit)
-      .offset(offset)) as EventRow[];
+      .where(eventsSectorWhere)
+      .orderBy(desc(eventEffectiveScore))
+      .limit(FEED_MAX_STORIES)) as EventRow[];
 
     type MergedItem =
-      | { _type: "story"; row: StoryRow }
-      | { _type: "event"; row: EventRow };
+      | { _type: "story"; row: StoryRow; sortKey: number }
+      | { _type: "event"; row: EventRow; sortKey: number };
     const merged: MergedItem[] = [
-      ...storyRows.map((row): MergedItem => ({ _type: "story", row })),
-      ...eventRows.map((row): MergedItem => ({ _type: "event", row })),
+      ...storyRows.map(
+        (row): MergedItem => ({
+          _type: "story",
+          row,
+          sortKey: STORY_BASELINE_EFFECTIVE_SCORE,
+        }),
+      ),
+      ...eventRows.map(
+        (row): MergedItem => ({
+          _type: "event",
+          row,
+          // `effectiveScore` comes back as numeric → string from pg in
+          // some configurations; coerce defensively.
+          sortKey: Number(row.effectiveScore),
+        }),
+      ),
     ];
     merged.sort((a, b) => {
+      if (b.sortKey !== a.sortKey) return b.sortKey - a.sortKey;
+      // Stable tiebreaker: newer first.
       const aTs = (a.row.publishedAt ?? a.row.createdAt).getTime();
       const bTs = (b.row.publishedAt ?? b.row.createdAt).getTime();
       return bTs - aTs;
@@ -302,7 +458,7 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
     // Batch-fetch event_sources for whichever event items survived the
     // merge slice. Skip the round-trip when no events are on the page.
     const eventIds = pageItems
-      .filter((m): m is { _type: "event"; row: EventRow } => m._type === "event")
+      .filter((m): m is { _type: "event"; row: EventRow; sortKey: number } => m._type === "event")
       .map((m) => m.row.id);
     const allSources =
       eventIds.length > 0
@@ -324,14 +480,16 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
     }
 
     // Counts: union total = stories matching sectors + events matching sectors.
+    // Same optional-WHERE semantics as the main queries above: when the
+    // user has no sectors, count all rows.
     const [storiesCountRow] = await db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(stories)
-      .where(inArray(stories.sector, sectorsFilter));
+      .where(storiesSectorWhere);
     const [eventsCountRow] = await db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(events)
-      .where(inArray(events.sector, sectorsFilter));
+      .where(eventsSectorWhere);
     const total =
       Number(storiesCountRow?.count ?? 0) + Number(eventsCountRow?.count ?? 0);
 

--- a/backend/src/feed/calculateEffectiveScore.ts
+++ b/backend/src/feed/calculateEffectiveScore.ts
@@ -1,0 +1,60 @@
+// Phase 12f — TS mirror of the SQL ranking expression used in
+// `storyController.getFeed`. Exists so the formula can be exercised
+// in unit tests without standing up Postgres + mockDb plumbing for
+// every weight tweak. The SQL expression in the controller is the
+// canonical implementation; this function must stay in lockstep with
+// it. When you change one, change the other and update
+// `tests/feed/ranking.test.ts`.
+
+import {
+  EDGAR_PENALTY,
+  FRESHNESS_BONUS,
+  FRESHNESS_QUALITY_THRESHOLD,
+  FRESHNESS_WINDOW_HOURS,
+  W1,
+  W2,
+} from "./rankingConstants";
+
+export interface EffectiveScoreInputs {
+  /** Per-source editorial weighting from ingestion_sources.quality_score (1–10). */
+  qualityScore: number;
+  /**
+   * Count of *alternate* event_sources rows attached to the event (i.e.
+   * total event_sources − 1 for the primary). Solo events pass 0.
+   */
+  sourcesAttachedCount: number;
+  /** Age of the event in hours since published_at (or created_at). */
+  ageHours: number;
+  /**
+   * True iff the event has exactly one event_sources row AND that
+   * source's slug is in EDGAR_SOURCE_SLUGS. Pre-computed by the SQL
+   * subquery in the controller; tests pass it directly.
+   */
+  isEdgarSoleSource: boolean;
+  /**
+   * True iff any ingestion_candidate with resolved_event_id = event.id
+   * has non-empty body_text. False = body enrichment never landed
+   * usable text, which is what gates the EDGAR penalty.
+   */
+  bodyTextPresent: boolean;
+}
+
+export function calculateEffectiveScore(input: EffectiveScoreInputs): number {
+  const clusterAmplification = W1 * Math.log(1 + input.sourcesAttachedCount);
+  const recencyDecay = W2 * input.ageHours;
+  const freshnessBonus =
+    input.qualityScore >= FRESHNESS_QUALITY_THRESHOLD &&
+    input.ageHours <= FRESHNESS_WINDOW_HOURS
+      ? FRESHNESS_BONUS
+      : 0;
+  const edgarPenalty =
+    input.isEdgarSoleSource && !input.bodyTextPresent ? EDGAR_PENALTY : 0;
+
+  return (
+    input.qualityScore +
+    clusterAmplification -
+    recencyDecay +
+    freshnessBonus -
+    edgarPenalty
+  );
+}

--- a/backend/src/feed/rankingConstants.ts
+++ b/backend/src/feed/rankingConstants.ts
@@ -1,0 +1,69 @@
+// Phase 12f — rules-based feed ranking v1. Tunable constants used by
+// both the SQL ORDER BY expression in `storyController.getFeed` and
+// the parallel TS implementation in `calculateEffectiveScore` (which
+// exists so the formula can be unit-tested independently of the DB).
+//
+// Formula (mirror of the SQL expression):
+//   effective_score
+//     = quality_score
+//     + ln(1 + sources_attached_count) * W1
+//     - age_hours * W2
+//     + freshness_bonus
+//     - edgar_penalty
+//
+// `quality_score` (1–10) is per-source editorial weighting seeded on
+// `ingestion_sources.quality_score` in migration 0014.
+// `sources_attached_count` is the number of *alternate* event_sources
+// rows for the event (= total event_sources − 1). A solo event scores
+// ln(1+0)=0 amplification; a cluster of 3 sources scores ln(3)*W1.
+
+/**
+ * W1 — cluster amplification weight. Multiplied by ln(1 + alternates).
+ */
+export const W1 = 2.0;
+
+/**
+ * W2 — recency decay per hour. With age_hours * W2 subtracted, W2=0.15
+ * yields roughly a 12-hour half-life relative to the cluster + quality
+ * base. Tune during the soak.
+ */
+export const W2 = 0.15;
+
+/**
+ * Freshness bonus applied to events whose primary source has
+ * quality_score ≥ FRESHNESS_QUALITY_THRESHOLD and that were published
+ * within the last FRESHNESS_WINDOW_HOURS. Intended to surface first-
+ * party labs (Anthropic / OpenAI / DeepMind / etc.), primary regulator
+ * filings (Fed / BIS / SEC primary), and top analysts (SemiAnalysis,
+ * Money Stuff) when they ship something material.
+ */
+export const FRESHNESS_BONUS = 3.0;
+export const FRESHNESS_WINDOW_HOURS = 6;
+export const FRESHNESS_QUALITY_THRESHOLD = 9;
+
+/**
+ * EDGAR penalty applied to events whose sole event_sources row points
+ * at one of the EDGAR slugs AND whose body enrichment never produced
+ * usable body_text. Caps raw EDGAR filings below editorial content
+ * until issue #86 (machine-format title/excerpt) is fixed.
+ */
+export const EDGAR_PENALTY = 4.0;
+
+/**
+ * Slugs whose presence as the *sole* source of an event qualifies the
+ * event for the EDGAR penalty. Matches ingestion_sources.slug values
+ * seeded by migration 0014.
+ */
+export const EDGAR_SOURCE_SLUGS = ["sec-edgar-full", "sec-edgar-semis"] as const;
+
+/**
+ * Top-N cap on ranked events returned by the feed. Configurable via
+ * env var FEED_MAX_STORIES; falls back to 100. Read once at module
+ * load — server restart picks up env changes.
+ */
+export const FEED_MAX_STORIES: number = (() => {
+  const raw = process.env.FEED_MAX_STORIES;
+  if (!raw) return 100;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 100;
+})();

--- a/backend/tests/feed/ranking.test.ts
+++ b/backend/tests/feed/ranking.test.ts
@@ -1,0 +1,313 @@
+// Phase 12f — ranking tests.
+//
+// The first three cases exercise `calculateEffectiveScore` directly —
+// it's the TS mirror of the SQL ORDER BY expression and the canonical
+// place to assert formula correctness. Tests (a), (b), and (c) cover:
+//   (a) EDGAR-without-body penalty pushes editorial above EDGAR
+//   (b) freshness bonus boundary (in-window vs out-of-window)
+//   (c) cluster amplification monotonically increases score
+//
+// Test (d) covers the sector filter at the controller level. The
+// SQL WHERE clause itself can't be exercised against the mockDb chain
+// (it ignores WHERE), so this test pins the controller's filter
+// *selection* logic: empty user sectors → no early-return, all sectors
+// flow through (a behavior change from the prior implementation).
+
+import request from "supertest";
+import { createMockDb } from "../helpers/mockDb";
+
+const mock = createMockDb();
+
+jest.mock("../../src/db", () => ({
+  __esModule: true,
+  get db() {
+    return mock.db;
+  },
+  schema: {},
+  pool: {},
+}));
+
+import { createApp } from "../../src/app";
+import { generateToken } from "../../src/services/authService";
+import { calculateEffectiveScore } from "../../src/feed/calculateEffectiveScore";
+import {
+  EDGAR_PENALTY,
+  FRESHNESS_BONUS,
+  FRESHNESS_QUALITY_THRESHOLD,
+  FRESHNESS_WINDOW_HOURS,
+  W1,
+  W2,
+} from "../../src/feed/rankingConstants";
+
+const app = createApp();
+const userId = "33333333-3333-3333-3333-333333333333";
+
+function auth(token: string): [string, string] {
+  return ["Authorization", `Bearer ${token}`];
+}
+
+describe("calculateEffectiveScore — Phase 12f ranking formula", () => {
+  describe("(a) EDGAR-without-body penalty", () => {
+    it("ranks an EDGAR-only event with empty body BELOW an editorial event of the same age and quality", () => {
+      // Same quality_score and age — only difference is the EDGAR
+      // gate. The editorial event should out-rank.
+      const ageHours = 2;
+      const editorial = calculateEffectiveScore({
+        qualityScore: 9,
+        sourcesAttachedCount: 0,
+        ageHours,
+        isEdgarSoleSource: false,
+        bodyTextPresent: false, // editorial may or may not have body; penalty doesn't apply
+      });
+      const edgarUnenriched = calculateEffectiveScore({
+        qualityScore: 9,
+        sourcesAttachedCount: 0,
+        ageHours,
+        isEdgarSoleSource: true,
+        bodyTextPresent: false, // body enrichment didn't land
+      });
+      expect(editorial).toBeGreaterThan(edgarUnenriched);
+      // Penalty magnitude matches the constant.
+      expect(editorial - edgarUnenriched).toBeCloseTo(EDGAR_PENALTY, 5);
+    });
+
+    it("does NOT apply the penalty once body enrichment lands", () => {
+      const ageHours = 2;
+      const editorial = calculateEffectiveScore({
+        qualityScore: 9,
+        sourcesAttachedCount: 0,
+        ageHours,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      });
+      const edgarEnriched = calculateEffectiveScore({
+        qualityScore: 9,
+        sourcesAttachedCount: 0,
+        ageHours,
+        isEdgarSoleSource: true,
+        bodyTextPresent: true, // body enrichment succeeded
+      });
+      expect(editorial).toBeCloseTo(edgarEnriched, 5);
+    });
+  });
+
+  describe("(b) freshness bonus", () => {
+    it("applies when quality_score >= threshold AND age <= window", () => {
+      const within = calculateEffectiveScore({
+        qualityScore: FRESHNESS_QUALITY_THRESHOLD,
+        sourcesAttachedCount: 0,
+        ageHours: FRESHNESS_WINDOW_HOURS - 0.1,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      });
+      const justOutside = calculateEffectiveScore({
+        qualityScore: FRESHNESS_QUALITY_THRESHOLD,
+        sourcesAttachedCount: 0,
+        ageHours: FRESHNESS_WINDOW_HOURS + 0.1,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      });
+      // Difference between just-inside and just-outside should equal
+      // the bonus minus the small decay delta over 0.2h.
+      const bonusContribution = within - justOutside;
+      expect(bonusContribution).toBeGreaterThan(FRESHNESS_BONUS - 1);
+      expect(bonusContribution).toBeLessThan(FRESHNESS_BONUS + 1);
+    });
+
+    it("does NOT apply when quality_score is below threshold, even if fresh", () => {
+      const lowQualityFresh = calculateEffectiveScore({
+        qualityScore: FRESHNESS_QUALITY_THRESHOLD - 1,
+        sourcesAttachedCount: 0,
+        ageHours: 0,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      });
+      // Expected: just quality_score (no bonus, no decay at age 0).
+      expect(lowQualityFresh).toBeCloseTo(FRESHNESS_QUALITY_THRESHOLD - 1, 5);
+    });
+
+    it("does NOT apply at age == window boundary + epsilon", () => {
+      const ageJustOver = FRESHNESS_WINDOW_HOURS + 0.0001;
+      const score = calculateEffectiveScore({
+        qualityScore: FRESHNESS_QUALITY_THRESHOLD,
+        sourcesAttachedCount: 0,
+        ageHours: ageJustOver,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      });
+      const expected = FRESHNESS_QUALITY_THRESHOLD - W2 * ageJustOver;
+      expect(score).toBeCloseTo(expected, 5);
+    });
+  });
+
+  describe("(c) cluster amplification", () => {
+    it("strictly increases score as sources_attached_count grows", () => {
+      const base = {
+        qualityScore: 7,
+        ageHours: 1,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      };
+      const solo = calculateEffectiveScore({ ...base, sourcesAttachedCount: 0 });
+      const oneAttached = calculateEffectiveScore({ ...base, sourcesAttachedCount: 1 });
+      const threeAttached = calculateEffectiveScore({ ...base, sourcesAttachedCount: 3 });
+      expect(oneAttached).toBeGreaterThan(solo);
+      expect(threeAttached).toBeGreaterThan(oneAttached);
+    });
+
+    it("amplification magnitude matches W1 * ln(1 + count)", () => {
+      const base = {
+        qualityScore: 7,
+        ageHours: 0,
+        isEdgarSoleSource: false,
+        bodyTextPresent: true,
+      };
+      const solo = calculateEffectiveScore({ ...base, sourcesAttachedCount: 0 });
+      const fourAttached = calculateEffectiveScore({ ...base, sourcesAttachedCount: 4 });
+      const delta = fourAttached - solo;
+      expect(delta).toBeCloseTo(W1 * Math.log(1 + 4), 5);
+    });
+  });
+});
+
+describe("getFeed — sector filter (Phase 12f)", () => {
+  beforeEach(() => {
+    mock.reset();
+  });
+
+  it("(d) when the user has no sectors set, does NOT short-circuit to empty — returns events instead", async () => {
+    const token = generateToken(userId, "user@example.com");
+
+    // requireProfile lookup — return a completed profile with NO sectors.
+    mock.queueSelect([{ completedAt: new Date("2026-04-01T00:00:00Z") }]);
+    // getFeed profile lookup — sectors=[], role=null.
+    mock.queueSelect([{ sectors: [], role: null }]);
+    // stories query (chronological).
+    mock.queueSelect([]);
+    // events query (ranked) — return one event of sector 'ai' and one of
+    // sector 'finance'. With the prior behavior (early-return on empty
+    // sectorsFilter), neither would appear; with the 12f behavior, both
+    // pass the no-filter path.
+    mock.queueSelect([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        sector: "ai",
+        headline: "An AI event",
+        context: "ctx",
+        whyItMatters: "wim",
+        whyItMattersTemplate: null,
+        primarySourceUrl: "https://example.com/a",
+        primarySourceName: "Example AI",
+        publishedAt: new Date("2026-05-04T00:00:00Z"),
+        createdAt: new Date("2026-05-04T00:00:00Z"),
+        authorId: null,
+        authorName: null,
+        authorBio: null,
+        isSaved: false,
+        saveCount: 0,
+        commentCount: 0,
+        effectiveScore: 8.5,
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        sector: "finance",
+        headline: "A finance event",
+        context: "ctx",
+        whyItMatters: "wim",
+        whyItMattersTemplate: null,
+        primarySourceUrl: "https://example.com/f",
+        primarySourceName: "Example Fin",
+        publishedAt: new Date("2026-05-04T00:00:00Z"),
+        createdAt: new Date("2026-05-04T00:00:00Z"),
+        authorId: null,
+        authorName: null,
+        authorBio: null,
+        isSaved: false,
+        saveCount: 0,
+        commentCount: 0,
+        effectiveScore: 7.0,
+      },
+    ]);
+    // event_sources batch fetch (for the two ids on the page).
+    mock.queueSelect([]);
+    // storiesCountRow.
+    mock.queueSelect([{ count: 0 }]);
+    // eventsCountRow.
+    mock.queueSelect([{ count: 2 }]);
+
+    const res = await request(app)
+      .get("/api/v1/stories/feed")
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.stories).toHaveLength(2);
+    // Verify both sectors flow through — the empty-sectors path is
+    // "return all," not "return none."
+    const sectors = (res.body.data.stories as Array<{ sector: string }>)
+      .map((s) => s.sector)
+      .sort();
+    expect(sectors).toEqual(["ai", "finance"]);
+  });
+
+  it("ranks the higher-effective_score event above the lower one in the merged page", async () => {
+    const token = generateToken(userId, "user@example.com");
+    mock.queueSelect([{ completedAt: new Date("2026-04-01T00:00:00Z") }]);
+    mock.queueSelect([{ sectors: ["ai"], role: null }]);
+    mock.queueSelect([]);
+    // Two events with different effectiveScore — verify the merge
+    // sorts by score DESC.
+    mock.queueSelect([
+      {
+        id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        sector: "ai",
+        headline: "Lower-score event",
+        context: "ctx",
+        whyItMatters: "wim",
+        whyItMattersTemplate: null,
+        primarySourceUrl: "https://example.com/lo",
+        primarySourceName: null,
+        publishedAt: new Date("2026-05-04T00:00:00Z"),
+        createdAt: new Date("2026-05-04T00:00:00Z"),
+        authorId: null,
+        authorName: null,
+        authorBio: null,
+        isSaved: false,
+        saveCount: 0,
+        commentCount: 0,
+        effectiveScore: 3.0,
+      },
+      {
+        id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        sector: "ai",
+        headline: "Higher-score event",
+        context: "ctx",
+        whyItMatters: "wim",
+        whyItMattersTemplate: null,
+        primarySourceUrl: "https://example.com/hi",
+        primarySourceName: null,
+        publishedAt: new Date("2026-05-04T00:00:00Z"),
+        createdAt: new Date("2026-05-04T00:00:00Z"),
+        authorId: null,
+        authorName: null,
+        authorBio: null,
+        isSaved: false,
+        saveCount: 0,
+        commentCount: 0,
+        effectiveScore: 11.5,
+      },
+    ]);
+    mock.queueSelect([]);
+    mock.queueSelect([{ count: 0 }]);
+    mock.queueSelect([{ count: 2 }]);
+
+    const res = await request(app)
+      .get("/api/v1/stories/feed")
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    const headlines = (res.body.data.stories as Array<{ headline: string }>).map(
+      (s) => s.headline,
+    );
+    expect(headlines).toEqual(["Higher-score event", "Lower-score event"]);
+  });
+});

--- a/backend/tests/stories.integration.test.ts
+++ b/backend/tests/stories.integration.test.ts
@@ -148,22 +148,25 @@ describe("stories endpoints", () => {
       expect(res.body.data.offset).toBe(0);
     });
 
-    // Phase 12e.7a — dual-read merged sort. Verifies that an events row
-    // newer than every story comes first in the merged page, event_sources
-    // are batched + attached, and multi-source attribution surfaces on
-    // the wire shape of both event items and legacy story items.
-    it("merges stories + events sorted by published_at DESC and attaches sources", async () => {
+    // Phase 12e.7a / 12f — dual-read merged sort. Verifies that an
+    // event with a higher effective_score lands first in the merged
+    // page (the 12f sort key replaced the pre-12f published_at DESC
+    // sort), event_sources are batched + attached, and multi-source
+    // attribution surfaces on the wire shape of both event items and
+    // legacy story items.
+    it("merges stories + events sorted by effective_score DESC and attaches sources", async () => {
       queueOnboarded();
       mock.queueSelect([{ sectors: ["ai"], role: "engineer" }]);
-      // stories: one row at 2026-04-01
-      mock.queueSelect([makeRow({ headline: "Older story" })]);
-      // events: one row at 2026-04-10 (newer) — should land first
+      // stories: one row — legacy stories sort against the
+      // STORY_BASELINE_EFFECTIVE_SCORE constant (currently 7).
+      mock.queueSelect([makeRow({ headline: "Lower-ranked story" })]);
+      // events: one row with effective_score 9.5 — should land first.
       const eventId = "33333333-3333-3333-3333-333333333333";
       mock.queueSelect([
         {
           id: eventId,
           sector: "ai",
-          headline: "Newer event",
+          headline: "Higher-ranked event",
           context: "Event context",
           whyItMatters: "Event WIM",
           whyItMattersTemplate: null,
@@ -177,6 +180,7 @@ describe("stories endpoints", () => {
           isSaved: false,
           saveCount: 0,
           commentCount: 0,
+          effectiveScore: 9.5,
         },
       ]);
       // event_sources batch: two rows for the one event (primary + alternate)
@@ -203,15 +207,15 @@ describe("stories endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.stories).toHaveLength(2);
-      // Newer event lands first.
+      // Higher-ranked event lands first (effective_score 9.5 vs. story baseline 7).
       expect(res.body.data.stories[0].id).toBe(eventId);
-      expect(res.body.data.stories[0].headline).toBe("Newer event");
+      expect(res.body.data.stories[0].headline).toBe("Higher-ranked event");
       expect(res.body.data.stories[0].sources).toHaveLength(2);
       expect(res.body.data.stories[0].primary_source_url).toBe(
         "https://primary.example.com",
       );
-      // Older story second; legacy stories carry a synthetic single-element sources array.
-      expect(res.body.data.stories[1].headline).toBe("Older story");
+      // Story second; legacy stories carry a synthetic single-element sources array.
+      expect(res.body.data.stories[1].headline).toBe("Lower-ranked story");
       expect(res.body.data.stories[1].sources).toHaveLength(1);
       expect(res.body.data.stories[1].sources[0].role).toBe("primary");
       expect(res.body.data.total).toBe(2);


### PR DESCRIPTION
## Summary

Replaces the chronological ORDER BY on the events side of `/api/v1/stories/feed` with a query-time ranking formula. Sector filter is now a hard WHERE applied before scoring; empty user sectors return all sectors (was: empty result).

## Formula

For each event (computed in SQL, mirrored in TS for testing):

\`\`\`
effective_score = quality_score
                + ln(1 + sources_attached_count) * W1     -- W1 = 2.0   (cluster amplification)
                - age_hours * W2                          -- W2 = 0.15  (~12h half-life)
                + freshness_bonus                         -- +3.0 when quality_score >= 9 AND age <= 6h
                - edgar_penalty                           -- -4.0 when sole source is EDGAR AND no body_text
\`\`\`

- \`quality_score\` is looked up on the primary \`event_sources\` row → \`ingestion_sources.quality_score\` (fallback 5).
- \`sources_attached_count\` = number of *alternate* event_sources rows = total − 1. Solo event = 0 (ln(1)=0, no boost).
- \`edgar_penalty\` gate is intentionally narrow: applies only when (a) event has exactly one source row, (b) that source's slug is \`sec-edgar-full\` or \`sec-edgar-semis\`, and (c) no candidate that resolved to this event has non-empty body_text. Caps raw EDGAR below editorial until #86 ships.

## What changed

- \`backend/src/feed/rankingConstants.ts\` — W1, W2, FRESHNESS_BONUS, FRESHNESS_WINDOW_HOURS, FRESHNESS_QUALITY_THRESHOLD, EDGAR_PENALTY, EDGAR_SOURCE_SLUGS, FEED_MAX_STORIES (env-configurable, fallback 100).
- \`backend/src/feed/calculateEffectiveScore.ts\` — pure TS mirror of the SQL formula (canonical: SQL; TS exists for unit testing without DB).
- \`backend/src/controllers/storyController.ts\` — events query gets the ranking SQL helpers, ORDER BY effective_score DESC, LIMIT FEED_MAX_STORIES. Stories query stays chronological with a baseline score (7) in the merge sort. Sector filter: empty sectors no longer short-circuits to empty.
- \`backend/tests/feed/ranking.test.ts\` — new (+9 tests).
- \`backend/tests/stories.integration.test.ts\` — existing merge-sort test reframed for new ordering semantics (added \`effectiveScore\` to mocked event row, retitled).

## Scope notes (NOT in this PR)

- **Dual-read pagination semantics**: stories paginate chronologically (existing behavior); events return their top-FEED_MAX_STORIES ranked pool. Caller's \`offset\` no longer steps through events. A future v2 may unify pagination over a UNION query — flagged here, not solved.
- **Legacy stories ranking**: the 20 hand-curated stories from seed-data/stories.json don't have ingestion_sources rows, so they get a static \`STORY_BASELINE_EFFECTIVE_SCORE = 7\` in the merge sort. No recency decay applied (they're evergreen seed content).
- **v2 public API (\`/api/v2/stories\`)**: unchanged — that controller reads only the legacy \`stories\` table and isn't part of the events feed.
- **Per-user role/seniority re-ranking**: deferred to v2 per spec.

## Test plan

- [x] \`npm run build\` (tsc + migration copy)
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest\` → 70 suites pass, 969 tests passing, 1 skipped (no new failures; +9 net)
- [ ] Manual: hit \`/api/v1/stories/feed\` on prod after deploy, confirm response \`stories[]\` is ordered by ranked score not timestamp (smoke against soak data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)