### PR TITLE
fix(feed): exclude events from disabled sources

### DIFF
--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -296,6 +296,25 @@ function eventBodyTextPresentExpr(): ReturnType<typeof sql<boolean>> {
 }
 
 /**
+ * WHERE-clause predicate: event has at least one event_source whose
+ * `ingestion_sources.enabled = true`. Used to exclude events whose every
+ * source is currently disabled — when sources are taken offline via SQL
+ * (e.g. sec-edgar-full / sec-edgar-semis on 2026-05-11, see GH #88),
+ * already-ingested events from those sources must stop appearing in the
+ * feed even though the source row itself is kept (preserves attribution
+ * history). An orphaned event with zero event_sources rows fails the
+ * EXISTS — intentional; orphan-recovery is out of scope here.
+ */
+export function eventHasEnabledSourceExpr(): ReturnType<typeof sql<boolean>> {
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM event_sources es
+      JOIN ingestion_sources s ON s.id = es.ingestion_source_id
+      WHERE es.event_id = ${events.id}
+        AND s.enabled = true
+  )`;
+}
+
+/**
  * Composite effective_score expression. Used both as a SELECT column
  * (so the row carries its score for downstream sort/inspection) and in
  * the ORDER BY clause.
@@ -375,6 +394,10 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
       sectorsFilter.length > 0 ? inArray(stories.sector, sectorsFilter) : undefined;
     const eventsSectorWhere =
       sectorsFilter.length > 0 ? inArray(events.sector, sectorsFilter) : undefined;
+    // Hotfix (GH #88) — exclude events whose every source is disabled.
+    // `and(undefined, x)` collapses to `x` in Drizzle, so this composes
+    // cleanly whether or not sectorsFilter is empty.
+    const eventsWhere = and(eventsSectorWhere, eventHasEnabledSourceExpr());
 
     // Phase 12e.7a — dual-read across `stories` (legacy hand-curated,
     // 20 rows) and `events` (ingestion-written, the bulk). Stories keep
@@ -421,7 +444,7 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
       })
       .from(events)
       .leftJoin(writers, eq(writers.id, events.authorId))
-      .where(eventsSectorWhere)
+      .where(eventsWhere)
       .orderBy(desc(eventEffectiveScore))
       .limit(FEED_MAX_STORIES)) as EventRow[];
 
@@ -489,7 +512,7 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
     const [eventsCountRow] = await db
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(events)
-      .where(eventsSectorWhere);
+      .where(eventsWhere);
     const total =
       Number(storiesCountRow?.count ?? 0) + Number(eventsCountRow?.count ?? 0);
 

--- a/backend/tests/feed/ranking.test.ts
+++ b/backend/tests/feed/ranking.test.ts
@@ -27,9 +27,12 @@ jest.mock("../../src/db", () => ({
   pool: {},
 }));
 
+import { PgDialect } from "drizzle-orm/pg-core";
+
 import { createApp } from "../../src/app";
 import { generateToken } from "../../src/services/authService";
 import { calculateEffectiveScore } from "../../src/feed/calculateEffectiveScore";
+import { eventHasEnabledSourceExpr } from "../../src/controllers/storyController";
 import {
   EDGAR_PENALTY,
   FRESHNESS_BONUS,
@@ -309,5 +312,78 @@ describe("getFeed — sector filter (Phase 12f)", () => {
       (s) => s.headline,
     );
     expect(headlines).toEqual(["Higher-score event", "Lower-score event"]);
+  });
+});
+
+// Hotfix (GH #88) — the feed query now also filters out events whose
+// every source is currently disabled (`ingestion_sources.enabled =
+// false`). This is a WHERE-clause predicate composed into the events
+// query alongside the sector filter. The mockDb chain doesn't apply
+// WHERE, so we test the SQL fragment directly via PgDialect.sqlToQuery
+// — verifying the builder produces the expected `EXISTS (... enabled
+// = true ...)` predicate. Behavior at the live-DB layer is a function
+// of that fragment plus Postgres semantics.
+describe("eventHasEnabledSourceExpr — disabled-source filter (hotfix #88)", () => {
+  it("produces an EXISTS subquery joining event_sources and ingestion_sources with enabled = true", () => {
+    const dialect = new PgDialect();
+    const { sql: rendered } = dialect.sqlToQuery(eventHasEnabledSourceExpr());
+
+    // Whitespace-collapse for resilient substring assertions.
+    const collapsed = rendered.replace(/\s+/g, " ").toLowerCase();
+
+    expect(collapsed).toContain("exists");
+    expect(collapsed).toContain("event_sources");
+    expect(collapsed).toContain("ingestion_sources");
+    expect(collapsed).toMatch(/s\.enabled\s*=\s*true/);
+    // The subquery is correlated on the outer events row.
+    expect(collapsed).toContain("es.event_id");
+  });
+
+  it("getFeed filters events when the SQL-side filter has already excluded the disabled-source rows", async () => {
+    // mockDb can't enforce the WHERE itself — but the test still
+    // documents the contract end-to-end: the controller takes the
+    // post-filter events result from the DB and emits exactly those
+    // rows on the wire. If the SQL filter were ever dropped, the
+    // PgDialect test above would still pass on the helper, but a
+    // future integration test against a real Postgres would catch
+    // the regression.
+    const token = generateToken(userId, "user@example.com");
+    mock.queueSelect([{ completedAt: new Date("2026-04-01T00:00:00Z") }]);
+    mock.queueSelect([{ sectors: ["ai"], role: null }]);
+    mock.queueSelect([]); // stories
+    // events: the SQL filter would have excluded any disabled-source
+    // events; we return only the surviving enabled-source event.
+    mock.queueSelect([
+      {
+        id: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        sector: "ai",
+        headline: "Enabled-source event",
+        context: "ctx",
+        whyItMatters: "wim",
+        whyItMattersTemplate: null,
+        primarySourceUrl: "https://example.com/a",
+        primarySourceName: "Editorial",
+        publishedAt: new Date("2026-05-12T00:00:00Z"),
+        createdAt: new Date("2026-05-12T00:00:00Z"),
+        authorId: null,
+        authorName: null,
+        authorBio: null,
+        isSaved: false,
+        saveCount: 0,
+        commentCount: 0,
+        effectiveScore: 8.0,
+      },
+    ]);
+    mock.queueSelect([]); // event_sources batch
+    mock.queueSelect([{ count: 0 }]); // stories count
+    mock.queueSelect([{ count: 1 }]); // events count (post-filter)
+
+    const res = await request(app)
+      .get("/api/v1/stories/feed")
+      .set(...auth(token));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.stories).toHaveLength(1);
+    expect(res.body.data.stories[0].headline).toBe("Enabled-source event");
   });
 });


### PR DESCRIPTION
## Summary

Hotfix for [#88](https://github.com/omarelkhateeb06-tech/signal-app/issues/88). The feed query in \`getFeed\` was never checking \`ingestion_sources.enabled\` — events from manually-disabled sources (the two SEC EDGAR rows disabled on 2026-05-11) continued surfacing on the wire.

Adds a WHERE-clause \`EXISTS\` predicate to the events query: keep an event iff at least one of its \`event_sources\` rows points at an \`ingestion_source\` where \`enabled = true\`. An event whose every source is currently disabled is excluded.

## Implementation

- New helper \`eventHasEnabledSourceExpr()\` in \`storyController.ts\` (sibling to the existing \`eventQualityScoreExpr\` / \`eventIsEdgarSoleSourceExpr\` / etc.). Exported so the unit test can render its SQL via \`PgDialect.sqlToQuery\`.
- Composed into the WHERE clause via \`and(eventsSectorWhere, eventHasEnabledSourceExpr())\`. Drizzle's \`and()\` collapses \`undefined\` to the surviving operand, so the empty-sectors path still works.
- Applied to both the main events query and the events-count query (so \`total\` reflects post-filter state).
- No schema migration; no other file touched.

## Tests (+2 in \`tests/feed/ranking.test.ts\`)

1. **SQL-fragment assertion** via \`PgDialect.sqlToQuery\` — verifies the rendered SQL contains \`EXISTS\`, references \`event_sources\` and \`ingestion_sources\`, contains \`s.enabled = true\`, and is correlated on the outer event row. Catches a regression that drops or weakens the predicate.
2. **Controller behavior test** — mockDb returns post-filter events; controller emits them on the wire unchanged. Documents the contract end-to-end.

mockDb can't enforce WHERE clauses, so the SQL-fragment test is the canonical regression catch for this fix. A future integration test against a live Postgres would close the gap entirely.

## Gates

- [x] \`npm run build\` (tsc + migration copy)
- [x] \`npm run lint\` clean
- [x] \`npx jest\` → 70/70 suites, 971 tests passing (+2 new), 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)