### PR TITLE
feat(design): Phase 12j chunks 1–4 — design system foundation + Feed surface

### DIFF
--- a/frontend/src/app/(app)/feed/page.tsx
+++ b/frontend/src/app/(app)/feed/page.tsx
@@ -1,17 +1,47 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { RefreshCw } from "lucide-react";
 import { useStories } from "@/hooks/useStories";
 import { useTeams } from "@/hooks/useTeams";
 import { useTeamsStore } from "@/store/teamsStore";
+import { useProfile } from "@/hooks/useProfile";
 import { StoryCard } from "@/components/stories/StoryCard";
 import { GatedStoryCard } from "@/components/stories/GatedStoryCard";
 import { SectorFilter } from "@/components/feed/SectorFilter";
+import { SectorBadge } from "@/components/stories/SectorBadge";
 import { extractApiError } from "@/lib/api";
 import { isGatedFeedItem } from "@/types/story";
+
+// Phase 12j — feed page. "Your Briefing" page header in serif
+// display, a personalization meta line under it (role · sectors),
+// today's date in mono, then the SectorFilter, then the feed.
+//
+// Skeleton state for initial load (warm shimmer), empty state with
+// inviting copy, and the existing infinite-scroll sentinel.
+
+const ROLE_LABELS: Record<string, string> = {
+  founder: "Founder",
+  engineer: "Engineer",
+  investor: "Investor",
+  vc: "Venture investor",
+  analyst: "Analyst",
+  researcher: "Researcher",
+  operator: "Operator",
+  product_manager: "Product manager",
+  executive: "Executive",
+};
+
+function todayLabel(): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date());
+}
 
 export default function FeedPage(): JSX.Element {
   const router = useRouter();
@@ -41,10 +71,10 @@ export default function FeedPage(): JSX.Element {
     fetchNextPage,
   } = useStories({ sectors });
 
+  const profileQuery = useProfile();
+  const profile = profileQuery.data?.profile ?? null;
+
   const queryClient = useQueryClient();
-  // Prefix-match: any in-flight ["feed", …] query — including the
-  // initial load, sector-switch refetches, and the manual invalidation
-  // below — keeps the icon spinning.
   const isFetchingFeed = useIsFetching({ queryKey: ["feed"] }) > 0;
   const handleRefresh = (): void => {
     void queryClient.invalidateQueries({ queryKey: ["feed"] });
@@ -62,26 +92,31 @@ export default function FeedPage(): JSX.Element {
           void fetchNextPage();
         }
       },
-      { rootMargin: "200px" },
+      { rootMargin: "400px" },
     );
     observer.observe(el);
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const stories = data?.pages.flatMap((p) => p.stories) ?? [];
-  const total = data?.pages[0]?.total ?? 0;
+
+  const date = useMemo(() => todayLabel(), []);
+  const roleLabel = profile?.role ? ROLE_LABELS[profile.role] ?? profile.role : null;
+  const userSectors = profile?.sectors ?? [];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8 py-6">
       <header className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="text-2xl font-bold tracking-tight text-slate-900">Your feed</h1>
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-display text-[36px] font-semibold leading-tight tracking-tight text-ink">
+            Your Briefing
+          </h1>
           <button
             type="button"
             onClick={handleRefresh}
             disabled={isFetchingFeed}
             aria-label="Refresh feed"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-md border bg-white text-slate-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-line bg-surface text-ink-muted transition-colors hover:border-ink-muted hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
           >
             <RefreshCw
               className={`h-4 w-4 ${isFetchingFeed ? "animate-spin" : ""}`}
@@ -89,36 +124,59 @@ export default function FeedPage(): JSX.Element {
             />
           </button>
         </div>
-        <SectorFilter selected={sectors} onChange={setSectors} />
-        {!isLoading && (
-          <p className="text-xs text-slate-500">
-            {total} {total === 1 ? "story" : "stories"}
-          </p>
+        {(roleLabel || userSectors.length > 0) && (
+          <div className="flex flex-wrap items-center gap-2 text-sm text-ink-muted">
+            {roleLabel && <span>{roleLabel}</span>}
+            {roleLabel && userSectors.length > 0 && (
+              <span className="text-line">·</span>
+            )}
+            {userSectors.map((s) => (
+              <SectorBadge key={s} sector={s} />
+            ))}
+          </div>
         )}
+        <p className="font-mono text-[11px] uppercase tracking-wider text-ink-muted">
+          {date}
+        </p>
+        <div className="pt-2">
+          <SectorFilter selected={sectors} onChange={setSectors} />
+        </div>
       </header>
 
       {isLoading && (
-        <div className="py-12 text-center text-sm text-slate-500">Loading stories…</div>
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="skeleton h-44 rounded-md border border-line"
+            />
+          ))}
+        </div>
       )}
 
       {error && (
-        <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+        <div className="rounded-md border border-err/40 bg-err/5 p-4 text-sm text-err">
           {extractApiError(error, "Failed to load feed.")}
         </div>
       )}
 
       {!isLoading && !error && stories.length === 0 && (
-        <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center text-sm text-slate-500">
-          No stories yet. Try adjusting your sectors.
+        <div className="rounded-md border border-dashed border-line bg-surface p-12 text-center">
+          <p className="font-display text-lg text-ink">
+            Your briefing is being prepared.
+          </p>
+          <p className="mt-1 text-sm text-ink-muted">
+            Check back shortly — or adjust your sectors above.
+          </p>
         </div>
       )}
 
       <div className="space-y-4">
-        {stories.map((story) =>
+        {stories.map((story, i) =>
           isGatedFeedItem(story) ? (
-            <GatedStoryCard key={story.id} story={story} />
+            <GatedStoryCard key={story.id} story={story} index={i} />
           ) : (
-            <StoryCard key={story.id} story={story} />
+            <StoryCard key={story.id} story={story} index={i} />
           ),
         )}
       </div>
@@ -126,11 +184,15 @@ export default function FeedPage(): JSX.Element {
       <div ref={sentinelRef} className="h-8" />
 
       {isFetchingNextPage && (
-        <div className="py-4 text-center text-xs text-slate-500">Loading more…</div>
+        <div className="py-4 text-center text-xs text-ink-muted">
+          Loading more stories…
+        </div>
       )}
 
       {!hasNextPage && stories.length > 0 && (
-        <div className="py-4 text-center text-xs text-slate-400">You&apos;re all caught up.</div>
+        <div className="py-4 text-center text-xs text-ink-muted">
+          You&apos;re all caught up.
+        </div>
       )}
     </div>
   );

--- a/frontend/src/app/(app)/saved/page.tsx
+++ b/frontend/src/app/(app)/saved/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import clsx from "clsx";
 import { useSavedStories } from "@/hooks/useSavedStories";
 import { StoryCard } from "@/components/stories/StoryCard";
 import { SectorFilter } from "@/components/feed/SectorFilter";
+import { Button } from "@/components/ui/Button";
 import { extractApiError } from "@/lib/api";
 import type { SavedStory } from "@/types/story";
 
@@ -44,12 +44,14 @@ export default function SavedPage(): JSX.Element {
   const total = data?.pages[0]?.total ?? 0;
 
   return (
-    <div className="space-y-6">
-      <header className="space-y-3">
-        <h1 className="text-2xl font-bold tracking-tight text-slate-900">Saved</h1>
+    <div className="space-y-8 py-6">
+      <header className="space-y-4">
+        <h1 className="font-display text-[36px] font-semibold leading-tight tracking-tight text-ink">
+          Saved
+        </h1>
         <SectorFilter selected={sectors} onChange={setSectors} />
-        <div className="flex items-center gap-2 text-xs">
-          <span className="text-slate-500">Sort by:</span>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="text-ink-muted">Sort by:</span>
           {(
             [
               { value: "saved_at", label: "Date saved" },
@@ -60,58 +62,65 @@ export default function SavedPage(): JSX.Element {
               key={option.value}
               type="button"
               onClick={() => setSort(option.value)}
-              className={clsx(
-                "rounded-full border px-3 py-1 font-medium transition-colors",
+              className={[
+                "rounded-pill border px-3 py-1 font-medium transition-colors",
                 sort === option.value
-                  ? "border-slate-900 bg-slate-900 text-white"
-                  : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50",
-              )}
+                  ? "border-ink bg-ink text-bg"
+                  : "border-line bg-surface text-ink-muted hover:border-ink-muted hover:text-ink",
+              ].join(" ")}
             >
               {option.label}
             </button>
           ))}
         </div>
         {!isLoading && (
-          <p className="text-xs text-slate-500">
+          <p className="font-mono text-[11px] uppercase tracking-wider text-ink-muted">
             {total} saved {total === 1 ? "story" : "stories"}
           </p>
         )}
       </header>
 
       {isLoading && (
-        <div className="py-12 text-center text-sm text-slate-500">Loading…</div>
+        <div className="py-12 text-center text-sm text-ink-muted">Loading…</div>
       )}
 
       {error && (
-        <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+        <div className="rounded-md border border-err/40 bg-err/5 p-4 text-sm text-err">
           {extractApiError(error, "Failed to load saved stories.")}
         </div>
       )}
 
       {!isLoading && !error && stories.length === 0 && (
-        <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center text-sm text-slate-500">
-          {total === 0
-            ? "You haven't saved any stories yet."
-            : "No saved stories match the current filters."}
+        <div className="rounded-md border border-dashed border-line bg-surface p-12 text-center">
+          <p className="font-display text-lg text-ink">
+            {total === 0
+              ? "No saved stories yet."
+              : "No saved stories match the current filters."}
+          </p>
+          {total === 0 && (
+            <p className="mt-1 text-sm text-ink-muted">
+              Tap the bookmark icon on any story to save it here.
+            </p>
+          )}
         </div>
       )}
 
       <div className="space-y-4">
-        {stories.map((story) => (
-          <StoryCard key={story.id} story={story} />
+        {stories.map((story, i) => (
+          <StoryCard key={story.id} story={story} index={i} />
         ))}
       </div>
 
       {hasNextPage && (
         <div className="flex justify-center">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => void fetchNextPage()}
             disabled={isFetchingNextPage}
-            className="rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
           >
             {isFetchingNextPage ? "Loading…" : "Load more"}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/app/(app)/search/page.tsx
+++ b/frontend/src/app/(app)/search/page.tsx
@@ -9,9 +9,12 @@ import {
   saveRecentSearch,
   useSearch,
 } from "@/hooks/useSearch";
+import { useTier } from "@/hooks/useTier";
 import { SearchFilters } from "@/components/search/SearchFilters";
 import { SearchResultCard } from "@/components/search/SearchResultCard";
 import { SearchLimitModal } from "@/components/search/SearchLimitModal";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
 import { extractApiError } from "@/lib/api";
 import { extractHighlightTerms } from "@/lib/highlight";
 import { SECTORS } from "@/lib/onboarding";
@@ -64,14 +67,12 @@ export default function SearchPage(): JSX.Element {
     offset,
   });
 
-  // Phase 12g — search-limit gate envelope from a free user's 4th
-  // query. Surfaced as a dismissable modal; the modal can be closed
-  // (dismiss handler clears `dismissedGate`) but the search results
-  // stay empty until the day's counter rolls.
+  const tierQuery = useTier();
+  const isFree = tierQuery.data?.tier === "free";
+
   const gate = isGatePayload(searchQuery.data) ? searchQuery.data : null;
   const [dismissedGate, setDismissedGate] = useState(false);
   useEffect(() => {
-    // Re-show the modal on each fresh gated response.
     if (gate) setDismissedGate(false);
   }, [gate]);
 
@@ -115,32 +116,45 @@ export default function SearchPage(): JSX.Element {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 py-6">
       <header className="space-y-3">
-        <h1 className="text-2xl font-bold tracking-tight text-slate-900">Search</h1>
-        <div className="relative">
-          <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-          <input
-            ref={inputRef}
-            type="search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search stories by keyword or phrase..."
-            className="w-full rounded-md border border-slate-300 bg-white py-2 pl-9 pr-9 text-sm text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
-            aria-label="Search stories"
-            autoFocus
-          />
-          {query && (
-            <button
-              type="button"
-              onClick={clearQuery}
-              aria-label="Clear search"
-              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          )}
-        </div>
+        <h1 className="font-display text-[36px] font-semibold leading-tight tracking-tight text-ink">
+          Search
+        </h1>
+        <Input
+          ref={inputRef}
+          inputSize="lg"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search your briefing…"
+          aria-label="Search stories"
+          autoFocus
+          leadingIcon={<SearchIcon className="h-4 w-4" />}
+          trailingSlot={
+            query ? (
+              <button
+                type="button"
+                onClick={clearQuery}
+                aria-label="Clear search"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-ink-muted hover:bg-line/60 hover:text-ink"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            ) : null
+          }
+        />
+        {/* Phase 12g — free-tier search counter. Hidden for pro and
+            during the initial useTier fetch to avoid flashing chrome. */}
+        {isFree && tierQuery.data && (
+          <p className="text-xs text-ink-muted">
+            {/* Counter is a UI affordance only — the server enforces the
+                actual cap (chunk 4). At present we don't surface a
+                per-day usage number from the API, so we show the cap
+                as guidance. */}
+            3 free searches per day.
+          </p>
+        )}
       </header>
 
       <div className="grid gap-6 md:grid-cols-[220px_1fr]">
@@ -159,16 +173,15 @@ export default function SearchPage(): JSX.Element {
         <section className="space-y-4">
           {!enabled && (
             <div className="space-y-6">
-              <div className="rounded-lg border border-dashed border-slate-300 bg-white p-8 text-center text-sm text-slate-500">
-                Start typing to search. Use quotes for exact phrases, e.g.
-                {" "}
-                <span className="font-mono text-slate-700">&quot;reasoning models&quot;</span>.
+              <div className="rounded-md border border-dashed border-line bg-surface p-8 text-center text-sm text-ink-muted">
+                Start typing to search. Use quotes for exact phrases, e.g.{" "}
+                <span className="font-mono text-ink">&quot;reasoning models&quot;</span>.
               </div>
 
               {recent.length > 0 && (
                 <div>
                   <div className="mb-2 flex items-center justify-between">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <h2 className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
                       Recent searches
                     </h2>
                     <button
@@ -177,7 +190,7 @@ export default function SearchPage(): JSX.Element {
                         clearRecentSearches();
                         setRecent([]);
                       }}
-                      className="text-xs text-slate-500 hover:text-slate-900"
+                      className="text-xs text-ink-muted transition-colors hover:text-ink"
                     >
                       Clear
                     </button>
@@ -188,7 +201,7 @@ export default function SearchPage(): JSX.Element {
                         key={term}
                         type="button"
                         onClick={() => applyRecent(term)}
-                        className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 hover:bg-slate-50"
+                        className="rounded-pill border border-line bg-surface px-3 py-1 text-xs text-ink-muted transition-colors hover:border-ink-muted hover:text-ink"
                       >
                         {term}
                       </button>
@@ -198,7 +211,7 @@ export default function SearchPage(): JSX.Element {
               )}
 
               <div>
-                <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <h2 className="mb-2 font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
                   Browse sectors
                 </h2>
                 <div className="flex flex-wrap gap-2">
@@ -207,7 +220,7 @@ export default function SearchPage(): JSX.Element {
                       key={sector.value}
                       type="button"
                       onClick={() => applySectorSuggestion(sector.value)}
-                      className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 hover:bg-slate-50"
+                      className="rounded-pill border border-line bg-surface px-3 py-1 text-xs text-ink-muted transition-colors hover:border-ink-muted hover:text-ink"
                     >
                       {sector.label}
                     </button>
@@ -220,16 +233,13 @@ export default function SearchPage(): JSX.Element {
           {enabled && searchQuery.isLoading && (
             <div className="space-y-3">
               {Array.from({ length: 3 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="h-32 animate-pulse rounded-lg border border-slate-200 bg-white"
-                />
+                <div key={i} className="skeleton h-32 rounded-md border border-line" />
               ))}
             </div>
           )}
 
           {enabled && searchQuery.error && (
-            <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+            <div className="rounded-md border border-err/40 bg-err/5 p-4 text-sm text-err">
               {extractApiError(searchQuery.error, "Search failed.")}
             </div>
           )}
@@ -237,12 +247,12 @@ export default function SearchPage(): JSX.Element {
           {enabled && !searchQuery.isLoading && !searchQuery.error && results && (
             <>
               <div className="flex items-center justify-between">
-                <p className="text-sm text-slate-600">
+                <p className="text-sm text-ink-muted">
                   Found {total} {total === 1 ? "story" : "stories"}
                   {results.query && (
                     <>
                       {" for "}
-                      <span className="font-medium text-slate-900">
+                      <span className="font-medium text-ink">
                         &ldquo;{results.query}&rdquo;
                       </span>
                     </>
@@ -251,42 +261,43 @@ export default function SearchPage(): JSX.Element {
               </div>
 
               {results.stories.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center text-sm text-slate-500">
+                <div className="rounded-md border border-dashed border-line bg-surface p-12 text-center text-sm text-ink-muted">
                   No stories found. Try different keywords.
                 </div>
               ) : (
                 <div className="space-y-4">
-                  {results.stories.map((story) => (
+                  {results.stories.map((story, i) => (
                     <SearchResultCard
                       key={story.id}
                       story={story}
                       terms={terms}
+                      index={i}
                     />
                   ))}
                 </div>
               )}
 
               <div className="flex items-center justify-between pt-2 text-xs">
-                <button
-                  type="button"
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
                   disabled={offset === 0}
-                  className="rounded-md border border-slate-200 bg-white px-3 py-1 text-slate-700 hover:bg-slate-50 disabled:opacity-50"
                 >
                   Previous
-                </button>
-                <span className="text-slate-500">
+                </Button>
+                <span className="text-ink-muted">
                   Showing {results.stories.length > 0 ? offset + 1 : 0}–
                   {offset + results.stories.length} of {total}
                 </span>
-                <button
-                  type="button"
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => setOffset(offset + PAGE_SIZE)}
                   disabled={!hasMore}
-                  className="rounded-md border border-slate-200 bg-white px-3 py-1 text-slate-700 hover:bg-slate-50 disabled:opacity-50"
                 >
                   Next
-                </button>
+                </Button>
               </div>
             </>
           )}

--- a/frontend/src/app/(app)/stories/[id]/page.tsx
+++ b/frontend/src/app/(app)/stories/[id]/page.tsx
@@ -8,8 +8,20 @@ import { StoryDetail } from "@/components/stories/StoryDetail";
 import { StoryCard } from "@/components/stories/StoryCard";
 import { UpgradeCtaButton } from "@/components/stories/UpgradeCta";
 import { CommentsSection } from "@/components/comments/CommentsSection";
+import { Card } from "@/components/ui/Card";
 import { extractApiError } from "@/lib/api";
 import { isGatePayload } from "@/types/story";
+
+function BackLink(): JSX.Element {
+  return (
+    <Link
+      href="/feed"
+      className="inline-flex items-center gap-1 text-sm text-ink-muted transition-colors hover:text-ink hover:no-underline"
+    >
+      <ArrowLeft className="h-4 w-4" /> Back to briefing
+    </Link>
+  );
+}
 
 export default function StoryPage(): JSX.Element {
   const params = useParams<{ id: string }>();
@@ -18,19 +30,16 @@ export default function StoryPage(): JSX.Element {
   const relatedQuery = useRelatedStories(id);
 
   if (storyQuery.isLoading) {
-    return <div className="py-12 text-center text-sm text-slate-500">Loading…</div>;
+    return (
+      <div className="py-12 text-center text-sm text-ink-muted">Loading…</div>
+    );
   }
 
   if (storyQuery.error || !storyQuery.data) {
     return (
-      <div className="space-y-4">
-        <Link
-          href="/feed"
-          className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-violet-700"
-        >
-          <ArrowLeft className="h-4 w-4" /> Back to feed
-        </Link>
-        <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+      <div className="space-y-6 py-6">
+        <BackLink />
+        <div className="rounded-md border border-err/40 bg-err/5 p-4 text-sm text-err">
           {extractApiError(storyQuery.error, "Story not found.")}
         </div>
       </div>
@@ -40,33 +49,33 @@ export default function StoryPage(): JSX.Element {
   // Phase 12g — gate envelope when the user is over the daily story
   // cap. Headline + first line stay visible per spec; the rest of the
   // surface (comments, related) is suppressed because there's no
-  // canonical story id to thread them off (the envelope replaces the
-  // full row entirely on this endpoint).
+  // canonical story id to thread them off.
   if (isGatePayload(storyQuery.data)) {
     const gate = storyQuery.data;
     return (
-      <div className="space-y-6">
-        <Link
-          href="/feed"
-          className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-violet-700"
-        >
-          <ArrowLeft className="h-4 w-4" /> Back to feed
-        </Link>
-        <article className="rounded-lg border border-slate-200 bg-white p-8">
-          <h1 className="mb-3 text-2xl font-bold leading-tight text-slate-900">
+      <div className="space-y-6 py-6">
+        <BackLink />
+        <Card className="p-8">
+          <h1 className="mb-3 font-display text-[28px] font-semibold leading-tight text-ink">
             {gate.teaser.headline}
           </h1>
-          <p className="mb-6 text-base leading-relaxed text-slate-700">
+          <p className="mb-6 text-base leading-relaxed text-ink-muted">
             {gate.teaser.first_line}
           </p>
-          <div className="flex flex-col items-start gap-4 rounded-md border border-violet-200 bg-violet-50 p-5">
-            <div className="flex items-start gap-2 text-sm text-violet-900">
-              <Lock className="mt-0.5 h-4 w-4 flex-none" aria-hidden />
+          <div
+            className="flex flex-col items-start gap-4 rounded-md border border-line p-5"
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--accent) 6%, var(--surface))",
+            }}
+          >
+            <div className="flex items-start gap-2 text-sm text-ink">
+              <Lock className="mt-0.5 h-4 w-4 flex-none text-accent" aria-hidden />
               <span>{gate.upgrade_cta.message}</span>
             </div>
             <UpgradeCtaButton cta={gate.upgrade_cta} />
           </div>
-        </article>
+        </Card>
       </div>
     );
   }
@@ -75,26 +84,23 @@ export default function StoryPage(): JSX.Element {
   const related = relatedQuery.data ?? [];
 
   return (
-    <div className="space-y-10">
-      <Link
-        href="/feed"
-        className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-violet-700"
-      >
-        <ArrowLeft className="h-4 w-4" /> Back to feed
-      </Link>
+    <div className="space-y-10 py-6">
+      <BackLink />
 
       <StoryDetail story={story} />
 
-      <section className="border-t border-slate-200 pt-8">
+      <section className="border-t border-line pt-8">
         <CommentsSection storyId={story.id} />
       </section>
 
       {related.length > 0 && (
-        <section className="space-y-4 border-t border-slate-200 pt-8">
-          <h2 className="text-lg font-semibold text-slate-900">Related stories</h2>
+        <section className="space-y-4 border-t border-line pt-8">
+          <h2 className="font-display text-lg font-semibold text-ink">
+            Related stories
+          </h2>
           <div className="space-y-4">
-            {related.map((s) => (
-              <StoryCard key={s.id} story={s} />
+            {related.map((s, i) => (
+              <StoryCard key={s.id} story={s} index={i} />
             ))}
           </div>
         </section>

--- a/frontend/src/app/(app)/upgrade/page.tsx
+++ b/frontend/src/app/(app)/upgrade/page.tsx
@@ -3,82 +3,142 @@
 import Link from "next/link";
 import { ArrowLeft, Check } from "lucide-react";
 import { useTier } from "@/hooks/useTier";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
 
-// Phase 12g — /upgrade placeholder. Lists Pro tier features +
-// pricing. Payment integration is 12h (Stripe). The button reads
-// "Coming soon" until 12h replaces it with the actual Stripe
-// checkout flow.
+// Phase 12g — /upgrade placeholder. Phase 12j — restyled as the
+// marketing-style surface in the design brief: serif headline,
+// two-column Free-vs-Pro comparison cards, prominent pricing, single
+// large CTA. Payment integration is 12h.
+
+const FREE_FEATURES: ReadonlyArray<string> = [
+  "15 stories per day",
+  "Accessible depth only",
+  "General commentary",
+  "3 searches per day",
+];
 
 const PRO_FEATURES: ReadonlyArray<string> = [
-  "Personalized commentary at your role and seniority",
-  "Briefed and Technical depth tiers on every story",
-  "Unlimited stories per day",
-  "Unlimited searches",
+  "Unlimited stories",
+  "All depth tiers — Accessible · Briefed · Technical",
+  "Personalized commentary",
+  "Unlimited search",
   "Daily digest email",
 ];
+
+function PlanCard({
+  name,
+  features,
+  emphasized,
+}: {
+  name: string;
+  features: ReadonlyArray<string>;
+  emphasized?: boolean;
+}): JSX.Element {
+  return (
+    <Card
+      flat={!emphasized}
+      className="flex flex-col gap-4 p-6"
+      style={
+        emphasized
+          ? {
+              borderColor: "color-mix(in srgb, var(--accent) 35%, var(--line))",
+              boxShadow: "0 1px 2px rgba(26,24,22,0.04), 0 4px 12px rgba(10,109,121,0.07)",
+            }
+          : undefined
+      }
+    >
+      <header>
+        <p
+          className={
+            emphasized
+              ? "font-mono text-[11px] uppercase tracking-[0.12em] text-accent"
+              : "font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted"
+          }
+        >
+          {emphasized ? "Recommended" : "Today"}
+        </p>
+        <h3 className="mt-1 font-display text-xl font-semibold text-ink">{name}</h3>
+      </header>
+      <ul className="space-y-2">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-start gap-2 text-sm text-ink">
+            <Check
+              className={`mt-0.5 h-4 w-4 flex-none ${emphasized ? "text-accent" : "text-ink-muted"}`}
+              aria-hidden
+            />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
 
 export default function UpgradePage(): JSX.Element {
   const tierQuery = useTier();
   const tier = tierQuery.data?.tier;
   const days = tierQuery.data?.trial_days_remaining ?? null;
+  const trialAvailable = tierQuery.data?.trial_available ?? false;
+
+  const ctaLabel = trialAvailable
+    ? "Start Free Trial — 7 days free"
+    : "Coming Soon";
 
   return (
-    <div className="mx-auto max-w-2xl space-y-8">
+    <div className="mx-auto max-w-[600px] space-y-10 py-8">
       <Link
         href="/feed"
-        className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-violet-700"
+        className="inline-flex items-center gap-1 text-sm text-ink-muted transition-colors hover:text-ink hover:no-underline"
       >
-        <ArrowLeft className="h-4 w-4" /> Back to feed
+        <ArrowLeft className="h-4 w-4" /> Back to briefing
       </Link>
 
-      <header className="space-y-2">
-        <h1 className="text-3xl font-bold tracking-tight text-slate-900">Upgrade to Pro</h1>
-        <p className="text-base text-slate-600">
-          The 10 stories per day that matter — with commentary tailored to your role.
+      <header className="space-y-3 text-center">
+        <h1 className="font-display text-[36px] font-semibold leading-tight tracking-tight text-ink">
+          Read smarter, not more.
+        </h1>
+        <p className="text-base leading-relaxed text-ink-muted">
+          SIGNAL Pro gives you personalized intelligence tailored to your role
+          and expertise.
         </p>
       </header>
 
       {tier === "pro_trial" && days !== null && (
-        <div className="rounded-md border border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-900">
+        <div
+          className="rounded-md border px-4 py-3 text-center text-sm text-ink"
+          style={{
+            backgroundColor:
+              "color-mix(in srgb, var(--accent) 6%, var(--surface))",
+            borderColor: "color-mix(in srgb, var(--accent) 25%, var(--line))",
+          }}
+        >
           {days > 0
-            ? `Your Pro trial has ${days} day${days === 1 ? "" : "s"} left.`
-            : "Your Pro trial expires today."}
+            ? `Your trial expires in ${days} day${days === 1 ? "" : "s"}.`
+            : "Your trial expires today."}
         </div>
       )}
       {tier === "free" && (
-        <div className="rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
-          Your Pro trial has expired. Upgrade to keep personalized commentary.
+        <div className="rounded-md border border-line bg-surface px-4 py-3 text-center text-sm text-ink-muted">
+          Your trial has ended. Upgrade to keep personalized commentary.
         </div>
       )}
 
-      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="mb-4 flex items-baseline justify-between">
-          <h2 className="text-xl font-semibold text-slate-900">Pro</h2>
-          <div className="text-right">
-            <div className="text-2xl font-bold text-slate-900">$10/mo</div>
-            <div className="text-xs text-slate-500">or $96/yr (save 20%)</div>
-          </div>
+      <section className="grid gap-4 md:grid-cols-2">
+        <PlanCard name="Free" features={FREE_FEATURES} />
+        <PlanCard name="Pro" features={PRO_FEATURES} emphasized />
+      </section>
+
+      <section className="space-y-4 text-center">
+        <div>
+          <p className="font-display text-[28px] font-semibold text-ink">$10/month</p>
+          <p className="text-sm text-ink-muted">or $96/year — save 20%</p>
         </div>
-
-        <ul className="mb-6 space-y-2">
-          {PRO_FEATURES.map((feature) => (
-            <li key={feature} className="flex items-start gap-2 text-sm text-slate-700">
-              <Check className="mt-0.5 h-4 w-4 flex-none text-violet-700" aria-hidden />
-              <span>{feature}</span>
-            </li>
-          ))}
-        </ul>
-
-        <button
-          type="button"
-          disabled
-          aria-disabled
-          className="w-full cursor-not-allowed rounded-md bg-violet-700/60 px-4 py-2 text-sm font-medium text-white"
-        >
-          Coming soon
-        </button>
-        <p className="mt-2 text-center text-xs text-slate-500">
-          Payment integration ships in the next release.
+        <Button size="lg" disabled className="w-full">
+          {ctaLabel}
+        </Button>
+        <p className="text-xs text-ink-muted">
+          Payment integration ships in the next release. Cancel anytime.
         </p>
       </section>
     </div>

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -4,8 +4,13 @@ import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
+import { Card } from "@/components/ui/Card";
 
-export default function AuthLayout({ children }: { children: React.ReactNode }): JSX.Element {
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
   const router = useRouter();
   const { isAuthenticated, hasHydrated } = useAuth();
 
@@ -16,18 +21,21 @@ export default function AuthLayout({ children }: { children: React.ReactNode }):
   }, [hasHydrated, isAuthenticated, router]);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
-      <div className="w-full max-w-md space-y-6 rounded-lg border bg-card p-8 shadow-sm">
+    <main className="flex min-h-screen items-center justify-center bg-bg px-4 py-12">
+      <Card className="w-full max-w-[400px] space-y-6 p-8">
         <div className="text-center">
-          <Link href="/" className="inline-block">
-            <h1 className="text-3xl font-bold tracking-tight">SIGNAL</h1>
+          <Link
+            href="/"
+            className="inline-block font-display text-xl font-semibold tracking-[0.18em] text-ink hover:no-underline"
+          >
+            SIGNAL
           </Link>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p className="mt-2 text-sm text-ink-muted">
             Professional intelligence, tailored to you.
           </p>
         </div>
         {children}
-      </div>
+      </Card>
     </main>
   );
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -7,6 +7,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
 import { extractApiError } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 
 const loginSchema = z.object({
   email: z.string().email("Enter a valid email"),
@@ -43,56 +45,54 @@ export default function LoginPage(): JSX.Element {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-semibold">Log in</h2>
-        <p className="text-sm text-muted-foreground">Welcome back.</p>
+        <h2 className="font-display text-[24px] font-semibold leading-tight text-ink">
+          Welcome back
+        </h2>
+        <p className="text-sm text-ink-muted">Log in to your briefing.</p>
       </div>
       <form onSubmit={onSubmit} className="space-y-4" noValidate>
         <div className="space-y-1">
-          <label htmlFor="email" className="text-sm font-medium">
+          <label htmlFor="email" className="text-sm font-medium text-ink">
             Email
           </label>
-          <input
+          <Input
             id="email"
             type="email"
             autoComplete="email"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus-visible:ring-2"
+            invalid={Boolean(errors.email)}
             {...register("email")}
           />
           {errors.email && (
-            <p className="text-xs text-destructive">{errors.email.message}</p>
+            <p className="text-xs text-err">{errors.email.message}</p>
           )}
         </div>
         <div className="space-y-1">
-          <label htmlFor="password" className="text-sm font-medium">
+          <label htmlFor="password" className="text-sm font-medium text-ink">
             Password
           </label>
-          <input
+          <Input
             id="password"
             type="password"
             autoComplete="current-password"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus-visible:ring-2"
+            invalid={Boolean(errors.password)}
             {...register("password")}
           />
           {errors.password && (
-            <p className="text-xs text-destructive">{errors.password.message}</p>
+            <p className="text-xs text-err">{errors.password.message}</p>
           )}
         </div>
         {submitError && (
-          <p role="alert" className="text-sm text-destructive">
+          <p role="alert" className="text-sm text-err">
             {submitError}
           </p>
         )}
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
-        >
-          {isSubmitting ? "Logging in..." : "Log in"}
-        </button>
+        <Button type="submit" disabled={isSubmitting} className="w-full">
+          {isSubmitting ? "Logging in…" : "Log in"}
+        </Button>
       </form>
-      <p className="text-center text-sm text-muted-foreground">
+      <p className="text-center text-sm text-ink-muted">
         New to SIGNAL?{" "}
-        <Link href="/signup" className="font-medium text-foreground underline-offset-4 hover:underline">
+        <Link href="/signup" className="font-medium text-accent hover:underline">
           Create an account
         </Link>
       </p>

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -7,6 +7,8 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
 import { extractApiError } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 
 const signupSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -44,67 +46,65 @@ export default function SignupPage(): JSX.Element {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-semibold">Create your account</h2>
-        <p className="text-sm text-muted-foreground">Start your SIGNAL briefing.</p>
+        <h2 className="font-display text-[24px] font-semibold leading-tight text-ink">
+          Create your account
+        </h2>
+        <p className="text-sm text-ink-muted">Start your SIGNAL briefing.</p>
       </div>
       <form onSubmit={onSubmit} className="space-y-4" noValidate>
         <div className="space-y-1">
-          <label htmlFor="name" className="text-sm font-medium">
+          <label htmlFor="name" className="text-sm font-medium text-ink">
             Name
           </label>
-          <input
+          <Input
             id="name"
             type="text"
             autoComplete="name"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus-visible:ring-2"
+            invalid={Boolean(errors.name)}
             {...register("name")}
           />
-          {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
+          {errors.name && <p className="text-xs text-err">{errors.name.message}</p>}
         </div>
         <div className="space-y-1">
-          <label htmlFor="email" className="text-sm font-medium">
+          <label htmlFor="email" className="text-sm font-medium text-ink">
             Email
           </label>
-          <input
+          <Input
             id="email"
             type="email"
             autoComplete="email"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus-visible:ring-2"
+            invalid={Boolean(errors.email)}
             {...register("email")}
           />
-          {errors.email && <p className="text-xs text-destructive">{errors.email.message}</p>}
+          {errors.email && <p className="text-xs text-err">{errors.email.message}</p>}
         </div>
         <div className="space-y-1">
-          <label htmlFor="password" className="text-sm font-medium">
+          <label htmlFor="password" className="text-sm font-medium text-ink">
             Password
           </label>
-          <input
+          <Input
             id="password"
             type="password"
             autoComplete="new-password"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus-visible:ring-2"
+            invalid={Boolean(errors.password)}
             {...register("password")}
           />
           {errors.password && (
-            <p className="text-xs text-destructive">{errors.password.message}</p>
+            <p className="text-xs text-err">{errors.password.message}</p>
           )}
         </div>
         {submitError && (
-          <p role="alert" className="text-sm text-destructive">
+          <p role="alert" className="text-sm text-err">
             {submitError}
           </p>
         )}
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
-        >
-          {isSubmitting ? "Creating account..." : "Create account"}
-        </button>
+        <Button type="submit" disabled={isSubmitting} className="w-full">
+          {isSubmitting ? "Creating account…" : "Create account"}
+        </Button>
       </form>
-      <p className="text-center text-sm text-muted-foreground">
+      <p className="text-center text-sm text-ink-muted">
         Already have an account?{" "}
-        <Link href="/login" className="font-medium text-foreground underline-offset-4 hover:underline">
+        <Link href="/login" className="font-medium text-accent hover:underline">
           Log in
         </Link>
       </p>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,58 +2,140 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Phase 12j — design tokens.
+ *
+ *   Page bg          #FAF7F2   warm cream
+ *   Surface          #FFFFFF
+ *   Ink primary      #1A1816   warm near-black (16:1 on cream)
+ *   Ink muted        #6B655C   warm gray (5.2:1 on cream)
+ *   Line             #E8E2D7   warm light border
+ *   Accent           #0A6D79   warm blue-teal (5.55:1 on cream, AA)
+ *   AI sector        #5B4FD9   warm indigo (5.34:1 on cream, AA)
+ *   Finance sector   #0C7259   emerald-teal (5.43:1 on cream, AA)
+ *   Semis sector     #A04D17   burnt orange (5.31:1 on cream, AA)
+ *   Success / warn / err — sparingly.
+ *
+ * Dark mode is deliberately not wired (post-launch). The .dark block
+ * below stays for the shadcn-style legacy variables only.
+ */
+
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* ----- New design tokens (12j) ----- */
+    --bg: #faf7f2;
+    --surface: #ffffff;
+    --ink: #1a1816;
+    --ink-muted: #6b655c;
+    --line: #e8e2d7;
+    --accent: #0a6d79;
+    --accent-hover: #085a64;
+    --accent-fg: #ffffff;
+    --ai: #5b4fd9;
+    --finance: #0c7259;
+    --semis: #a04d17;
+    --ok: #1f8a4c;
+    --warn: #c77d14;
+    --err: #b83a3a;
+
+    /* ----- Legacy shadcn tokens, redirected to the new palette ----- */
+    /*  bg/cream → background; ink → foreground; accent → primary; etc. */
+    --background: 40 33% 96%;
+    --foreground: 30 8% 9%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 30 8% 9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
+    --popover-foreground: 30 8% 9%;
+    --primary: 186 85% 26%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 40 25% 90%;
+    --secondary-foreground: 30 8% 9%;
+    --muted: 40 22% 92%;
+    --muted-foreground: 30 7% 39%;
+    --accent-h: 186 85% 26%;
+    --accent-foreground: 0 0% 100%;
+    --destructive: 0 56% 48%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 40 25% 87%;
+    --input: 40 25% 87%;
+    --ring: 186 85% 26%;
+    --radius: 8px;
   }
 
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+  /* Global resets / defaults */
+  * {
+    border-color: var(--line);
+  }
+
+  html {
+    color-scheme: light;
+  }
+
+  body {
+    background-color: var(--bg);
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Selection: accent-tinted highlight */
+  ::selection {
+    background-color: color-mix(in srgb, var(--accent) 22%, transparent);
+    color: var(--ink);
+  }
+
+  /* Focus rings: 2px accent, offset for keyboard nav */
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* Scrollbar (WebKit only — Firefox/Safari fall through to UA) */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: var(--bg);
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--line);
+    border: 2px solid var(--bg);
+    border-radius: 8px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--ink-muted) 40%, var(--line));
+  }
+
+  /* Link defaults — accent color, underline on hover only */
+  a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
   }
 }
 
-@layer base {
-  * {
-    @apply border-border;
+@layer utilities {
+  /* Card shimmer for skeleton states. Warm gray, not cold. */
+  .skeleton {
+    background-image: linear-gradient(
+      90deg,
+      var(--line) 0%,
+      color-mix(in srgb, var(--line) 40%, var(--surface)) 50%,
+      var(--line) 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer-x 1.6s linear infinite;
   }
-  body {
-    @apply bg-background text-foreground;
+
+  /* Gated-card blur: applied to the body region under the upgrade
+     overlay. backdrop-filter for the overlay itself is set inline. */
+  .gate-blur {
+    filter: blur(6px);
+    pointer-events: none;
+    user-select: none;
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,40 @@
 import type { Metadata } from "next";
+import { IBM_Plex_Sans, JetBrains_Mono, Newsreader } from "next/font/google";
 import "./globals.css";
 import { QueryProvider } from "@/components/providers/QueryProvider";
+
+// Phase 12j — design system. Three Google Fonts via next/font for
+// zero-runtime-cost subsetting + zero FOIT. The CSS variables flow
+// into Tailwind's font-family theme extension and the globals.css
+// utility classes (.font-display, etc.).
+//
+//   Newsreader     — editorial serif. Display headlines, page titles,
+//                    auth-card headings. "Variable" weight axis is
+//                    used between 400 and 700.
+//   IBM Plex Sans  — humanist body sans. Default for UI + reading.
+//                    Carries tech credibility without sacrificing warmth.
+//   JetBrains Mono — numeric / timestamp / SIGNAL-rating contexts.
+//                    Used sparingly per the brief.
+const fontSerif = Newsreader({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-serif",
+  weight: ["400", "500", "600", "700"],
+});
+
+const fontSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-sans",
+  weight: ["400", "500", "600", "700"],
+});
+
+const fontMono = JetBrains_Mono({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-mono",
+  weight: ["400", "500"],
+});
 
 export const metadata: Metadata = {
   title: "SIGNAL",
@@ -13,8 +47,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }): JSX.Element {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-background text-foreground antialiased">
+    <html
+      lang="en"
+      className={`${fontSerif.variable} ${fontSans.variable} ${fontMono.variable}`}
+    >
+      <body className="min-h-screen bg-bg font-sans text-ink antialiased">
         <QueryProvider>{children}</QueryProvider>
       </body>
     </html>

--- a/frontend/src/app/onboarding/[step]/page.tsx
+++ b/frontend/src/app/onboarding/[step]/page.tsx
@@ -3,10 +3,10 @@
 import { notFound, useParams, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { OnboardingShell } from "@/components/onboarding/OnboardingShell";
+import { DepthToggle } from "@/components/stories/DepthToggle";
 import { useOnboardingStore } from "@/store/onboardingStore";
 import {
   DEPTH_PREFERENCES,
-  DIGEST_PREFERENCES,
   GOALS,
   ROLES,
   SECTORS,
@@ -71,12 +71,30 @@ function Screen1(): JSX.Element {
       <div className="space-y-3">
         {SECTORS.map((s) => {
           const checked = sectors.includes(s.value);
+          // Phase 12j — sector accent color on the selected state.
+          // Each sector card lights up with its design-system color
+          // so the user previews the in-app sector treatment.
+          const sectorVar =
+            s.value === "ai"
+              ? "var(--ai)"
+              : s.value === "finance"
+                ? "var(--finance)"
+                : s.value === "semiconductors"
+                  ? "var(--semis)"
+                  : "var(--accent)";
           return (
             <label
               key={s.value}
-              className={`flex cursor-pointer items-start gap-3 rounded-md border p-4 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-              }`}
+              className="flex cursor-pointer items-start gap-3 rounded-md border p-4 transition-colors"
+              style={
+                checked
+                  ? {
+                      borderColor: sectorVar,
+                      backgroundColor: `color-mix(in srgb, ${sectorVar} 6%, var(--surface))`,
+                      boxShadow: `inset 0 0 0 1px ${sectorVar}`,
+                    }
+                  : { borderColor: "var(--line)" }
+              }
             >
               <input
                 type="checkbox"
@@ -85,8 +103,8 @@ function Screen1(): JSX.Element {
                 onChange={() => toggle(s.value)}
               />
               <div>
-                <p className="font-medium">{s.label}</p>
-                <p className="text-sm text-muted-foreground">{s.description}</p>
+                <p className="font-medium text-ink">{s.label}</p>
+                <p className="text-sm text-ink-muted">{s.description}</p>
               </div>
             </label>
           );
@@ -152,7 +170,7 @@ function Screen2(): JSX.Element {
     >
       <div className="space-y-6">
         <fieldset className="space-y-2">
-          <legend className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          <legend className="text-sm font-semibold uppercase tracking-wide text-ink-muted">
             Your role
           </legend>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -162,7 +180,7 @@ function Screen2(): JSX.Element {
                 <label
                   key={r.value}
                   className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
-                    checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                    checked ? "border-accent ring-1 ring-accent/40" : "border-line hover:border-ink-muted hover:bg-bg"
                   }`}
                 >
                   <input
@@ -181,10 +199,10 @@ function Screen2(): JSX.Element {
         </fieldset>
 
         <fieldset className="space-y-2">
-          <legend className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          <legend className="text-sm font-semibold uppercase tracking-wide text-ink-muted">
             What field do you work in?
           </legend>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-ink-muted">
             Pick the closest match. Options are scoped to your selected
             sectors — choose &ldquo;General / Not sure&rdquo; if nothing
             fits.
@@ -232,7 +250,7 @@ function Screen3(): JSX.Element {
             <label
               key={s.value}
               className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                checked ? "border-accent ring-1 ring-accent/40" : "border-line hover:border-ink-muted hover:bg-bg"
               }`}
             >
               <input
@@ -305,7 +323,7 @@ function Screen4(): JSX.Element {
     >
       <div className="space-y-6">
         {sectors.length === 0 && (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-ink-muted">
             Pick a sector on step 1 first.
           </p>
         )}
@@ -314,7 +332,7 @@ function Screen4(): JSX.Element {
           const sectorLabel = SECTORS.find((s) => s.value === sector)?.label ?? sector;
           return (
             <div key={sector} className="space-y-2">
-              <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              <p className="text-sm font-semibold uppercase tracking-wide text-ink-muted">
                 {sectorLabel}
               </p>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -324,7 +342,7 @@ function Screen4(): JSX.Element {
                     <label
                       key={`${sector}:${t.value}`}
                       className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
-                        checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                        checked ? "border-accent ring-1 ring-accent/40" : "border-line hover:border-ink-muted hover:bg-bg"
                       }`}
                     >
                       <input
@@ -388,7 +406,7 @@ function Screen5(): JSX.Element {
             <label
               key={g.value}
               className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+                checked ? "border-accent ring-1 ring-accent/40" : "border-line hover:border-ink-muted hover:bg-bg"
               }`}
             >
               <input
@@ -420,42 +438,32 @@ function Screen6(): JSX.Element {
   useScreenViewEvent(6);
   const nav = useOnboardingNav(6);
 
+  // Phase 12j — depth selection now uses the DepthToggle component
+  // so users learn the in-app interaction immediately. lockHigherTiers
+  // is false here: onboarding lets the user pick any depth (their tier
+  // gate fires at request time, not at preference-set time). Default
+  // to "accessible" if nothing's set so the toggle always has a
+  // controlled value.
+  const value = (depthPreference ?? "accessible") as DepthPreference;
+
   return (
     <OnboardingShell
       step={6}
       title="How deep do you want to go?"
-      description="The free tier defaults to Accessible. You can change this any time."
+      description="Pick the depth you'd like by default. You can switch on any story, and your tier may gate the higher tiers."
       canContinue={true}
       onContinue={() => nav.goNext(7)}
       onBack={nav.goBack}
     >
-      <div className="space-y-3">
-        {DEPTH_PREFERENCES.map((d) => {
-          const checked = depthPreference === d.value;
-          return (
-            <label
-              key={d.value}
-              className={`flex cursor-pointer items-start gap-3 rounded-md border p-4 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
-              }`}
-            >
-              <input
-                type="radio"
-                name="depth"
-                value={d.value}
-                className="mt-1 h-4 w-4"
-                checked={checked}
-                onChange={() => setDepthPreference(d.value as DepthPreference)}
-              />
-              <div>
-                <p className="font-medium">{d.label}</p>
-                {d.description && (
-                  <p className="text-sm text-muted-foreground">{d.description}</p>
-                )}
-              </div>
-            </label>
-          );
-        })}
+      <div className="flex justify-center py-2">
+        <DepthToggle
+          value={value as "accessible" | "briefed" | "technical"}
+          onSelect={(d) => setDepthPreference(d as DepthPreference)}
+          lockHigherTiers={false}
+        />
+      </div>
+      <div className="mt-4 space-y-2 text-center text-sm text-ink-muted">
+        {DEPTH_PREFERENCES.find((d) => d.value === value)?.description}
       </div>
     </OnboardingShell>
   );
@@ -551,7 +559,8 @@ function Screen7(): JSX.Element {
   return (
     <OnboardingShell
       step={7}
-      title="How often do you want a digest?"
+      title="Receive a daily digest email?"
+      description="A short, role-neutral roundup of the day's stories, sent in the morning."
       canContinue={canContinue}
       isSubmitting={complete.isPending}
       continueLabel="Finish"
@@ -559,36 +568,45 @@ function Screen7(): JSX.Element {
       onBack={nav.goBack}
       error={error}
     >
-      <div className="space-y-3">
-        {DIGEST_PREFERENCES.map((d) => {
-          const checked = store.digestPreference === d.value;
+      {/* Phase 12j — Pro-only digest is a single Yes/No toggle. The
+          legacy morning/evening/none triple is reduced to "daily"
+          (the canonical Pro cadence post-12i) vs "never". Default
+          to "daily" for fresh signups; users can flip off here. */}
+      <div className="grid grid-cols-2 gap-3">
+        {[
+          { value: "morning", label: "Yes, daily" },
+          { value: "none", label: "No, thanks" },
+        ].map((opt) => {
+          const checked = store.digestPreference === opt.value;
           return (
             <label
-              key={d.value}
-              className={`flex cursor-pointer items-center gap-3 rounded-md border p-3 transition-colors ${
-                checked ? "border-primary bg-accent" : "hover:bg-accent/50"
+              key={opt.value}
+              className={`flex cursor-pointer items-center justify-center gap-3 rounded-md border p-4 transition-colors ${
+                checked
+                  ? "border-accent ring-1 ring-accent/40"
+                  : "border-line hover:border-ink-muted hover:bg-bg"
               }`}
             >
               <input
                 type="radio"
                 name="digest"
-                value={d.value}
-                className="h-4 w-4"
+                value={opt.value}
+                className="sr-only"
                 checked={checked}
                 onChange={() =>
-                  store.setDigestPreference(d.value as DigestPreference)
+                  store.setDigestPreference(opt.value as DigestPreference)
                 }
               />
-              <span className="font-medium">{d.label}</span>
+              <span className="font-medium text-ink">{opt.label}</span>
             </label>
           );
         })}
-        {store.timezone && (
-          <p className="text-xs text-muted-foreground">
-            Detected timezone: {store.timezone}
-          </p>
-        )}
       </div>
+      {store.timezone && (
+        <p className="mt-4 text-center text-xs text-ink-muted">
+          Detected timezone: {store.timezone}
+        </p>
+      )}
     </OnboardingShell>
   );
 }

--- a/frontend/src/app/onboarding/layout.tsx
+++ b/frontend/src/app/onboarding/layout.tsx
@@ -25,15 +25,15 @@ export default function OnboardingLayout({
 
   if (!ready) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p className="text-sm text-muted-foreground">Loading…</p>
+      <div className="flex min-h-screen items-center justify-center bg-bg">
+        <p className="text-sm text-ink-muted">Loading…</p>
       </div>
     );
   }
 
   return (
-    <main className="flex min-h-screen items-start justify-center bg-background px-4 py-12">
-      <div className="w-full max-w-2xl space-y-6">{children}</div>
+    <main className="flex min-h-screen items-start justify-center bg-bg px-4 py-12">
+      <div className="w-full max-w-[640px] space-y-6">{children}</div>
     </main>
   );
 }

--- a/frontend/src/app/unsubscribe/page.tsx
+++ b/frontend/src/app/unsubscribe/page.tsx
@@ -5,6 +5,8 @@ import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { extractApiError, unsubscribeRequest } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
 
 type Status = "pending" | "success" | "error";
 
@@ -40,65 +42,77 @@ function UnsubscribeContent(): JSX.Element {
   }, [token]);
 
   return (
-    <div className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+    <Card className="w-full max-w-md p-8">
       <div className="mb-6 text-center">
-        <Link href="/" className="text-lg font-bold tracking-tight text-slate-900">
+        <Link
+          href="/"
+          className="font-display text-lg font-semibold tracking-[0.18em] text-ink hover:no-underline"
+        >
           SIGNAL
         </Link>
       </div>
       {status === "pending" && (
         <div className="flex flex-col items-center gap-3 text-center">
-          <Loader2 className="h-10 w-10 animate-spin text-violet-600" aria-hidden />
-          <p className="text-sm text-slate-600">Processing your unsubscribe...</p>
+          <Loader2 className="h-10 w-10 animate-spin text-accent" aria-hidden />
+          <p className="text-sm text-ink-muted">Processing your unsubscribe…</p>
         </div>
       )}
       {status === "success" && (
-        <div className="flex flex-col items-center gap-3 text-center">
-          <CheckCircle2 className="h-10 w-10 text-emerald-500" aria-hidden />
-          <h1 className="text-xl font-semibold text-slate-900">You&apos;ve been unsubscribed</h1>
-          <p className="text-sm text-slate-600">
-            We&apos;ll stop sending marketing emails{email ? ` to ${email}` : ""}. You can change this
-            any time from your settings.
+        <div className="flex flex-col items-center gap-4 text-center">
+          <CheckCircle2 className="h-10 w-10 text-ok" aria-hidden />
+          <h1 className="font-display text-[22px] font-semibold text-ink">
+            You&apos;ve been unsubscribed
+          </h1>
+          <p className="text-sm leading-relaxed text-ink-muted">
+            We&apos;ll stop sending the SIGNAL daily digest
+            {email ? ` to ${email}` : ""}. You can re-enable it any time from your
+            settings.
           </p>
           <Link
-            href="/settings"
-            className="mt-2 inline-flex items-center rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+            href="/feed"
+            className="mt-2 inline-flex h-10 items-center rounded-md bg-accent px-4 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-hover hover:no-underline"
           >
-            Manage email preferences
+            Back to SIGNAL →
           </Link>
         </div>
       )}
       {status === "error" && (
-        <div className="flex flex-col items-center gap-3 text-center">
-          <XCircle className="h-10 w-10 text-rose-500" aria-hidden />
-          <h1 className="text-xl font-semibold text-slate-900">Something went wrong</h1>
-          <p className="text-sm text-slate-600">{error}</p>
+        <div className="flex flex-col items-center gap-4 text-center">
+          <XCircle className="h-10 w-10 text-err" aria-hidden />
+          <h1 className="font-display text-[22px] font-semibold text-ink">
+            Something went wrong
+          </h1>
+          <p className="text-sm text-ink-muted">{error}</p>
           <Link
             href="/settings"
-            className="mt-2 inline-flex items-center rounded-md border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            className="mt-2 inline-flex h-10 items-center rounded-md border border-line bg-surface px-4 text-sm font-medium text-ink transition-colors hover:border-ink-muted hover:no-underline"
           >
             Go to settings
           </Link>
         </div>
       )}
-    </div>
+    </Card>
   );
 }
 
 function UnsubscribeFallback(): JSX.Element {
   return (
-    <div className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+    <Card className="w-full max-w-md p-8">
       <div className="flex flex-col items-center gap-3 text-center">
-        <Loader2 className="h-10 w-10 animate-spin text-violet-600" aria-hidden />
-        <p className="text-sm text-slate-600">Loading...</p>
+        <Loader2 className="h-10 w-10 animate-spin text-accent" aria-hidden />
+        <p className="text-sm text-ink-muted">Loading…</p>
       </div>
-    </div>
+    </Card>
   );
 }
 
 export default function UnsubscribePage(): JSX.Element {
+  // Touch Button so it stays in the import graph for future use in
+  // this file — currently the page renders Link-as-button. Lint
+  // configurations that drop unused imports can strip this.
+  void Button;
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-12">
+    <main className="flex min-h-screen items-center justify-center bg-bg px-4 py-12">
       <Suspense fallback={<UnsubscribeFallback />}>
         <UnsubscribeContent />
       </Suspense>

--- a/frontend/src/components/comments/CommentForm.tsx
+++ b/frontend/src/components/comments/CommentForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import clsx from "clsx";
+import { Button } from "@/components/ui/Button";
 
 const MAX = 2000;
 
@@ -15,6 +15,10 @@ interface CommentFormProps {
   autoFocus?: boolean;
 }
 
+// Phase 12j — restyled onto design tokens. Textarea uses the same
+// border / focus pattern as the Input primitive (Input itself is
+// single-line, so the textarea stays explicit). Submit + Cancel
+// use the Button primitive.
 export function CommentForm({
   placeholder = "Add a comment…",
   submitLabel = "Post",
@@ -43,39 +47,23 @@ export function CommentForm({
         placeholder={placeholder}
         rows={3}
         autoFocus={autoFocus}
-        className="w-full resize-y rounded-md border border-slate-200 bg-white p-3 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+        className="w-full resize-y rounded-md border border-line bg-surface p-3 text-sm text-ink placeholder:text-ink-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
       />
       <div className="flex items-center justify-between gap-2">
         <span
-          className={clsx(
-            "text-xs",
-            value.length > MAX ? "text-rose-600" : "text-slate-500",
-          )}
+          className={`text-xs ${value.length > MAX ? "text-err" : "text-ink-muted"}`}
         >
           {value.length}/{MAX}
         </span>
         <div className="flex items-center gap-2">
           {onCancel && (
-            <button
-              type="button"
-              onClick={onCancel}
-              className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50"
-            >
+            <Button variant="secondary" size="sm" onClick={onCancel}>
               Cancel
-            </button>
+            </Button>
           )}
-          <button
-            type="submit"
-            disabled={disabled}
-            className={clsx(
-              "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
-              disabled
-                ? "cursor-not-allowed bg-slate-200 text-slate-400"
-                : "bg-violet-600 text-white hover:bg-violet-700",
-            )}
-          >
+          <Button type="submit" size="sm" disabled={disabled}>
             {isSubmitting ? "Posting…" : submitLabel}
-          </button>
+          </Button>
         </div>
       </div>
     </form>

--- a/frontend/src/components/comments/CommentItem.tsx
+++ b/frontend/src/components/comments/CommentItem.tsx
@@ -48,12 +48,12 @@ export function CommentItem({
       />
       <div className="flex-1 space-y-2">
         <header className="flex items-center gap-2 text-xs">
-          <span className="font-medium text-slate-900">
+          <span className="font-medium text-ink">
             {comment.author.name ?? comment.author.email}
           </span>
-          <span className="text-slate-500">{timeAgo(comment.created_at)}</span>
+          <span className="text-ink-muted">{timeAgo(comment.created_at)}</span>
           {comment.updated_at !== comment.created_at && !comment.is_deleted && (
-            <span className="text-slate-400">(edited)</span>
+            <span className="text-ink-muted/70">(edited)</span>
           )}
         </header>
 
@@ -73,7 +73,7 @@ export function CommentItem({
           <p
             className={clsx(
               "whitespace-pre-wrap text-sm leading-relaxed",
-              comment.is_deleted ? "italic text-slate-400" : "text-slate-800",
+              comment.is_deleted ? "italic text-ink-muted/70" : "text-ink",
             )}
           >
             {comment.content}
@@ -81,12 +81,12 @@ export function CommentItem({
         )}
 
         {!editOpen && (
-          <div className="flex items-center gap-3 text-xs text-slate-500">
+          <div className="flex items-center gap-3 text-xs text-ink-muted">
             {isTopLevel && onReply && !comment.is_deleted && (
               <button
                 type="button"
                 onClick={() => setReplyOpen((v) => !v)}
-                className="hover:text-violet-700"
+                className="hover:text-accent"
               >
                 Reply
               </button>
@@ -95,7 +95,7 @@ export function CommentItem({
               <button
                 type="button"
                 onClick={() => setEditOpen(true)}
-                className="hover:text-violet-700"
+                className="hover:text-accent"
               >
                 Edit
               </button>
@@ -106,7 +106,7 @@ export function CommentItem({
                 onClick={() => {
                   void onDelete(comment.id);
                 }}
-                className="hover:text-rose-600"
+                className="hover:text-err"
               >
                 Delete
               </button>
@@ -130,11 +130,11 @@ export function CommentItem({
         )}
 
         {isTopLevel && comment.reply_count > 0 && (
-          <div className="space-y-3 border-l-2 border-slate-100 pl-4">
+          <div className="space-y-3 border-l-2 border-line pl-4">
             <button
               type="button"
               onClick={() => setShowReplies((v) => !v)}
-              className="text-xs font-medium text-violet-700 hover:underline"
+              className="text-xs font-medium text-accent hover:underline"
             >
               {showReplies
                 ? "Hide replies"
@@ -145,10 +145,10 @@ export function CommentItem({
             {showReplies && (
               <>
                 {replies.isLoading && (
-                  <p className="text-xs text-slate-500">Loading replies…</p>
+                  <p className="text-xs text-ink-muted">Loading replies…</p>
                 )}
                 {replies.error && (
-                  <p className="text-xs text-rose-600">
+                  <p className="text-xs text-err">
                     {extractApiError(replies.error, "Failed to load replies.")}
                   </p>
                 )}

--- a/frontend/src/components/comments/CommentsSection.tsx
+++ b/frontend/src/components/comments/CommentsSection.tsx
@@ -28,8 +28,8 @@ export function CommentsSection({ storyId }: CommentsSectionProps): JSX.Element 
   return (
     <section className="space-y-6">
       <div className="flex items-baseline justify-between">
-        <h2 className="text-lg font-semibold text-slate-900">
-          Comments {total > 0 && <span className="text-slate-400">({total})</span>}
+        <h2 className="font-display text-lg font-semibold text-ink">
+          Comments {total > 0 && <span className="text-ink-muted/70">({total})</span>}
         </h2>
       </div>
 
@@ -43,23 +43,23 @@ export function CommentsSection({ storyId }: CommentsSectionProps): JSX.Element 
       )}
 
       {create.error && (
-        <p className="text-sm text-rose-600">
+        <p className="text-sm text-err">
           {extractApiError(create.error, "Failed to post comment.")}
         </p>
       )}
 
       {query.isLoading && (
-        <p className="text-sm text-slate-500">Loading comments…</p>
+        <p className="text-sm text-ink-muted">Loading comments…</p>
       )}
 
       {query.error && (
-        <p className="text-sm text-rose-600">
+        <p className="text-sm text-err">
           {extractApiError(query.error, "Failed to load comments.")}
         </p>
       )}
 
       {!query.isLoading && comments.length === 0 && (
-        <p className="rounded-lg border border-dashed border-slate-200 bg-white p-8 text-center text-sm text-slate-500">
+        <p className="rounded-md border border-dashed border-line bg-surface p-8 text-center text-sm text-ink-muted">
           Be the first to comment.
         </p>
       )}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,10 +3,16 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { LogOut, Search, Settings, User as UserIcon } from "lucide-react";
+import { Bookmark, LogOut, Search, Settings, User as UserIcon } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { TeamSwitcher } from "@/components/layout/TeamSwitcher";
 import { TrialBadge } from "@/components/layout/TrialBadge";
+
+// Phase 12j — top navigation. Fixed top bar, full-width, page-bg
+// shaded one notch darker than the body so it visually separates
+// without a hard line. Wordmark left (serif "SIGNAL", tracked wide),
+// trial badge + search + saved + avatar right. Mobile: same right-
+// rail, no hamburger — at this surface count it's not warranted.
 
 function initials(name: string | null | undefined, email: string): string {
   const source = name?.trim() || email;
@@ -48,15 +54,17 @@ export function Header(): JSX.Element {
   };
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur">
-      <div className="container mx-auto flex h-14 items-center justify-between px-4">
-        <Link href="/feed" className="text-lg font-bold tracking-tight">
+    <header
+      className="sticky top-0 z-40 border-b border-line bg-bg/85 backdrop-blur supports-[backdrop-filter]:bg-bg/70"
+    >
+      <div className="mx-auto flex h-14 max-w-reading items-center justify-between px-4">
+        <Link
+          href="/feed"
+          className="font-display text-lg font-semibold tracking-[0.18em] text-ink hover:no-underline"
+        >
           SIGNAL
         </Link>
-        <nav className="flex items-center gap-4 text-sm">
-          <Link href="/feed" className="text-muted-foreground hover:text-foreground">
-            Feed
-          </Link>
+        <nav className="flex items-center gap-3 text-sm">
           {user && <TrialBadge />}
           {user && <TeamSwitcher />}
           <button
@@ -64,14 +72,24 @@ export function Header(): JSX.Element {
             onClick={() => router.push("/search")}
             aria-label="Search (Ctrl+K)"
             title="Search (Ctrl+K)"
-            className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+            className="inline-flex h-9 items-center gap-2 rounded-md border border-line bg-surface px-2.5 text-xs text-ink-muted transition-colors hover:border-ink-muted hover:text-ink"
           >
             <Search className="h-3.5 w-3.5" />
             <span className="hidden sm:inline">Search</span>
-            <kbd className="hidden rounded border border-slate-200 bg-slate-50 px-1 font-mono text-[10px] text-slate-500 sm:inline">
+            <kbd className="hidden rounded border border-line bg-bg px-1 font-mono text-[10px] text-ink-muted sm:inline">
               ⌘K
             </kbd>
           </button>
+          {user && (
+            <Link
+              href="/saved"
+              aria-label="Saved stories"
+              title="Saved"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md text-ink-muted hover:bg-line/60 hover:text-ink"
+            >
+              <Bookmark className="h-4 w-4" />
+            </Link>
+          )}
           {user && (
             <div className="relative" ref={menuRef}>
               <button
@@ -80,7 +98,7 @@ export function Header(): JSX.Element {
                 aria-expanded={open}
                 aria-label="Open profile menu"
                 onClick={() => setOpen((v) => !v)}
-                className="flex items-center gap-2 rounded-full border px-2 py-1 text-sm hover:bg-accent"
+                className="inline-flex items-center gap-2 rounded-pill border border-line bg-surface px-1 py-0.5 text-sm transition-colors hover:border-ink-muted"
               >
                 {user.profilePictureUrl ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -90,42 +108,41 @@ export function Header(): JSX.Element {
                     className="h-7 w-7 rounded-full object-cover"
                   />
                 ) : (
-                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-accent text-xs font-medium text-accent-fg">
                     {initials(user.name, user.email)}
                   </span>
                 )}
-                <span className="hidden sm:inline">{user.name ?? user.email}</span>
               </button>
               {open && (
                 <div
                   role="menu"
-                  className="absolute right-0 mt-2 w-48 overflow-hidden rounded-md border bg-card shadow-lg"
+                  className="absolute right-0 mt-2 w-48 overflow-hidden rounded-md border border-line bg-surface shadow-card animate-fade-up"
                 >
                   <Link
                     role="menuitem"
                     href="/settings"
                     onClick={() => setOpen(false)}
-                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-accent"
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-ink hover:bg-bg hover:no-underline"
                   >
-                    <Settings className="h-4 w-4" aria-hidden />
+                    <Settings className="h-4 w-4 text-ink-muted" aria-hidden />
                     Settings
                   </Link>
                   <Link
                     role="menuitem"
                     href="/onboarding"
                     onClick={() => setOpen(false)}
-                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-accent"
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-ink hover:bg-bg hover:no-underline"
                   >
-                    <UserIcon className="h-4 w-4" aria-hidden />
+                    <UserIcon className="h-4 w-4 text-ink-muted" aria-hidden />
                     Interests
                   </Link>
                   <button
                     role="menuitem"
                     type="button"
                     onClick={handleLogout}
-                    className="flex w-full items-center gap-2 border-t px-3 py-2 text-left text-sm hover:bg-accent"
+                    className="flex w-full items-center gap-2 border-t border-line px-3 py-2 text-left text-sm text-ink hover:bg-bg"
                   >
-                    <LogOut className="h-4 w-4" aria-hidden />
+                    <LogOut className="h-4 w-4 text-ink-muted" aria-hidden />
                     Log out
                   </button>
                 </div>

--- a/frontend/src/components/layout/TrialBadge.tsx
+++ b/frontend/src/components/layout/TrialBadge.tsx
@@ -3,50 +3,54 @@
 import Link from "next/link";
 import { useTier } from "@/hooks/useTier";
 
-// Phase 12g — header chip for the trial / free-tier status.
+// Phase 12j — trial-state chip in the top nav.
 //
-//   pro_trial → "Pro Trial — X days left". Visually urgent (amber)
-//               when ≤1 day remains, neutral otherwise.
-//   free      → "Free Plan" with an inline "Upgrade" link.
-//   pro       → no chip rendered.
-//   loading   → no chip rendered (chrome shouldn't flash a partial
-//               state on every page load).
+//   pro_trial      → "{N} days left on Pro" pill, accent tint by
+//                    default; amber + breathe animation when ≤1 day.
+//   free           → subtle "Upgrade to Pro" text link (not a banner).
+//   pro / loading  → nothing rendered.
+//
+// "loading" returns null so the chrome doesn't flash a partial state
+// during the initial useTier fetch.
+
 export function TrialBadge(): JSX.Element | null {
   const tierQuery = useTier();
   const data = tierQuery.data;
   if (!data) return null;
-
   if (data.tier === "pro") return null;
 
   if (data.tier === "pro_trial") {
     const days = data.trial_days_remaining ?? 0;
     const urgent = days <= 1;
+    const baseClasses =
+      "inline-flex items-center rounded-pill px-2.5 py-1 text-xs font-medium transition-colors";
+    const toneClasses = urgent
+      ? "border border-warn/40 bg-warn/10 text-warn animate-breathe"
+      : "border border-accent/30 text-accent";
     return (
       <Link
         href="/upgrade"
         data-testid="trial-badge"
-        className={
-          "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium " +
-          (urgent
-            ? "border-amber-300 bg-amber-50 text-amber-900"
-            : "border-violet-200 bg-violet-50 text-violet-900")
+        className={`${baseClasses} ${toneClasses}`}
+        style={
+          urgent
+            ? undefined
+            : { backgroundColor: "color-mix(in srgb, var(--accent) 10%, transparent)" }
         }
       >
-        Pro Trial — {days} day{days === 1 ? "" : "s"} left
+        {days} day{days === 1 ? "" : "s"} left on Pro
       </Link>
     );
   }
 
   // tier === "free"
   return (
-    <span
-      data-testid="free-plan-badge"
-      className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2.5 py-0.5 text-xs text-slate-600"
+    <Link
+      href="/upgrade"
+      data-testid="free-upgrade-link"
+      className="text-sm font-medium text-accent hover:underline"
     >
-      Free Plan
-      <Link href="/upgrade" className="font-medium text-violet-700 hover:underline">
-        Upgrade
-      </Link>
-    </span>
+      Upgrade to Pro
+    </Link>
   );
 }

--- a/frontend/src/components/onboarding/OnboardingShell.tsx
+++ b/frontend/src/components/onboarding/OnboardingShell.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
 
 export interface OnboardingShellProps {
   step: number;
@@ -12,9 +14,6 @@ export interface OnboardingShellProps {
   continueLabel?: string;
   onContinue: () => void | Promise<void>;
   onSkip?: () => void | Promise<void>;
-  // Optional override so the page can emit `screen_back` telemetry
-  // alongside the navigation. When omitted, the shell falls back to
-  // its own `router.push(previous-step)` behavior (no event).
   onBack?: () => void | Promise<void>;
   error?: string | null;
   children: ReactNode;
@@ -23,14 +22,11 @@ export interface OnboardingShellProps {
 const TOTAL_STEPS = 7;
 
 /**
- * Shared chrome for every onboarding screen: progress bar, title,
- * description, Back / Skip / Continue nav row. Screens plug their
- * content in via `children` and wire their step-specific validation
- * via `canContinue`.
- *
- * Back goes to `/onboarding/${step - 1}` except on step 1, where the
- * button is disabled (the user signed up — there's nowhere sensible
- * to go "back" to).
+ * Phase 12j — restyled shell. Same prop API, design-token visual
+ * layer. Progress is "Step N of M" in mono + a full-width accent
+ * progress bar above the title. The card body uses the Card
+ * primitive (drops the legacy shadcn `bg-card` semantics in favor of
+ * `bg-surface`).
  */
 export function OnboardingShell({
   step,
@@ -57,71 +53,71 @@ export function OnboardingShell({
 
   return (
     <>
-      <header className="space-y-2 text-center">
-        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+      <header className="space-y-4 text-center">
+        <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
           Step {step} of {TOTAL_STEPS}
         </p>
-        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
-        {description && (
-          <p className="text-sm text-muted-foreground">{description}</p>
-        )}
         <div
-          className="mx-auto h-1.5 w-full max-w-sm overflow-hidden rounded-full bg-muted"
+          className="mx-auto h-1 w-full max-w-sm overflow-hidden rounded-full bg-line"
           role="progressbar"
           aria-valuemin={1}
           aria-valuemax={TOTAL_STEPS}
           aria-valuenow={step}
         >
           <div
-            className="h-full bg-primary transition-all"
+            className="h-full bg-accent transition-all duration-300 ease-soft-out"
             style={{ width: `${(step / TOTAL_STEPS) * 100}%` }}
           />
         </div>
+        <h1 className="font-display text-[32px] font-semibold leading-tight tracking-tight text-ink">
+          {title}
+        </h1>
+        {description && (
+          <p className="mx-auto max-w-md text-sm leading-relaxed text-ink-muted">
+            {description}
+          </p>
+        )}
       </header>
 
-      <section className="rounded-lg border bg-card p-6 shadow-sm">
+      <Card className="p-6">
         {children}
         {error && (
-          <p role="alert" className="mt-4 text-sm text-destructive">
+          <p role="alert" className="mt-4 text-sm text-err">
             {error}
           </p>
         )}
-      </section>
+      </Card>
 
       <div className="flex items-center justify-between">
-        <button
-          type="button"
+        <Button
+          variant="secondary"
           onClick={back}
           disabled={step <= 1 || isSubmitting}
-          className="inline-flex h-10 items-center justify-center rounded-md border px-4 text-sm font-medium transition-colors hover:bg-accent disabled:opacity-40"
         >
           Back
-        </button>
+        </Button>
         <div className="flex items-center gap-3">
           {onSkip && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
               onClick={() => {
                 void onSkip();
               }}
               disabled={isSubmitting}
-              className="inline-flex h-10 items-center justify-center rounded-md px-4 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
             >
               Skip
-            </button>
+            </Button>
           )}
-          <button
-            type="button"
+          <Button
             onClick={() => {
               void onContinue();
             }}
             disabled={!canContinue || isSubmitting}
-            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-6 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
           >
             {isSubmitting
               ? "Saving…"
               : (continueLabel ?? (step === TOTAL_STEPS ? "Finish" : "Continue"))}
-          </button>
+          </Button>
         </div>
       </div>
     </>

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import clsx from "clsx";
 import { SECTORS } from "@/lib/onboarding";
 import type { SearchSort } from "@/types/story";
 
@@ -44,20 +43,20 @@ export function SearchFilters(props: SearchFiltersProps): JSX.Element {
   };
 
   return (
-    <aside className="space-y-6 rounded-lg border border-slate-200 bg-white p-4">
+    <aside className="space-y-6 rounded-md border border-line bg-surface p-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-slate-900">Filters</h2>
+        <h2 className="text-sm font-semibold text-ink">Filters</h2>
         <button
           type="button"
           onClick={onReset}
-          className="text-xs text-slate-500 hover:text-slate-900"
+          className="text-xs text-ink-muted transition-colors hover:text-ink"
         >
           Reset
         </button>
       </div>
 
       <section className="space-y-2">
-        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
           Sector
         </h3>
         <div className="space-y-1">
@@ -66,13 +65,13 @@ export function SearchFilters(props: SearchFiltersProps): JSX.Element {
             return (
               <label
                 key={sector.value}
-                className="flex cursor-pointer items-center gap-2 text-sm text-slate-700"
+                className="flex cursor-pointer items-center gap-2 text-sm text-ink"
               >
                 <input
                   type="checkbox"
                   checked={checked}
                   onChange={() => toggleSector(sector.value)}
-                  className="h-4 w-4 rounded border-slate-300 text-violet-600 focus:ring-violet-500"
+                  className="h-4 w-4 rounded border-line text-accent focus:ring-accent"
                 />
                 {sector.label}
               </label>
@@ -82,33 +81,33 @@ export function SearchFilters(props: SearchFiltersProps): JSX.Element {
       </section>
 
       <section className="space-y-2">
-        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
           Date range
         </h3>
         <div className="space-y-2">
-          <label className="block text-xs text-slate-600">
+          <label className="block text-xs text-ink-muted">
             From
             <input
               type="date"
               value={fromDate}
               onChange={(e) => onFromDateChange(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+              className="mt-1 block w-full rounded-md border border-line bg-surface px-2 py-1 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </label>
-          <label className="block text-xs text-slate-600">
+          <label className="block text-xs text-ink-muted">
             To
             <input
               type="date"
               value={toDate}
               onChange={(e) => onToDateChange(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+              className="mt-1 block w-full rounded-md border border-line bg-surface px-2 py-1 text-sm text-ink focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
           </label>
         </div>
       </section>
 
       <section className="space-y-2">
-        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
           Sort by
         </h3>
         <div className="flex flex-col gap-1">
@@ -119,12 +118,20 @@ export function SearchFilters(props: SearchFiltersProps): JSX.Element {
                 key={option.value}
                 type="button"
                 onClick={() => onSortChange(option.value)}
-                className={clsx(
+                className={[
                   "rounded-md px-3 py-1 text-left text-sm transition-colors",
                   active
-                    ? "bg-violet-50 font-medium text-violet-700"
-                    : "text-slate-700 hover:bg-slate-50",
-                )}
+                    ? "font-medium text-accent"
+                    : "text-ink-muted hover:bg-bg hover:text-ink",
+                ].join(" ")}
+                style={
+                  active
+                    ? {
+                        backgroundColor:
+                          "color-mix(in srgb, var(--accent) 8%, transparent)",
+                      }
+                    : undefined
+                }
               >
                 {option.label}
               </button>

--- a/frontend/src/components/search/SearchLimitModal.tsx
+++ b/frontend/src/components/search/SearchLimitModal.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { Lock, X } from "lucide-react";
+import { Lock } from "lucide-react";
+import { Modal } from "@/components/ui/Modal";
 import { UpgradeCtaButton } from "@/components/stories/UpgradeCta";
 import type { GatePayload } from "@/types/story";
 
-// Phase 12g — modal overlay shown when a free user submits a 4th
-// search in a day and gets a search_limit gate envelope. Per spec:
-// "You've used 3 of 3 searches today. {upgrade_cta.message}".
-// Dismissable (the dismiss button closes the overlay), but the
-// underlying search results stay empty until the day's counter rolls.
+// Phase 12j — search-limit modal. The 12g version had its own ad-hoc
+// overlay; this version composes the Modal primitive so focus
+// management, Escape-to-dismiss, and backdrop blur come for free.
+//
+// Per the 12j brief: "The modal should feel polite, not punitive."
+// Lock icon + headline + the gate's first_line as a single sentence;
+// CTA button next to a Dismiss button. No alarm-color treatment.
+
 export function SearchLimitModal({
   gate,
   onDismiss,
@@ -17,41 +21,26 @@ export function SearchLimitModal({
   onDismiss: () => void;
 }): JSX.Element {
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="search-limit-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
-    >
-      <div className="relative w-full max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-xl">
+    <Modal open onDismiss={onDismiss} size="md">
+      <div className="mb-4 flex items-center gap-2 text-ink">
+        <Lock className="h-5 w-5 text-accent" aria-hidden />
+        <h2 className="font-display text-lg font-semibold">
+          {gate.teaser.headline}
+        </h2>
+      </div>
+      <p className="mb-6 text-sm leading-relaxed text-ink-muted">
+        {gate.teaser.first_line} {gate.upgrade_cta.message}
+      </p>
+      <div className="flex items-center justify-end gap-3">
         <button
           type="button"
           onClick={onDismiss}
-          aria-label="Dismiss"
-          className="absolute right-3 top-3 rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          className="inline-flex h-10 items-center rounded-md border border-line bg-surface px-4 text-sm font-medium text-ink-muted hover:border-ink-muted hover:text-ink"
         >
-          <X className="h-4 w-4" />
+          Dismiss
         </button>
-        <div className="mb-4 flex items-center gap-2 text-slate-900">
-          <Lock className="h-5 w-5 text-violet-700" aria-hidden />
-          <h2 id="search-limit-title" className="text-lg font-semibold">
-            {gate.teaser.headline}
-          </h2>
-        </div>
-        <p className="mb-6 text-sm text-slate-700">
-          {gate.teaser.first_line} {gate.upgrade_cta.message}
-        </p>
-        <div className="flex items-center justify-end gap-3">
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
-          >
-            Dismiss
-          </button>
-          <UpgradeCtaButton cta={gate.upgrade_cta} />
-        </div>
+        <UpgradeCtaButton cta={gate.upgrade_cta} />
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/frontend/src/components/search/SearchResultCard.tsx
+++ b/frontend/src/components/search/SearchResultCard.tsx
@@ -1,68 +1,82 @@
 import Link from "next/link";
-import { ExternalLink, MessageSquare } from "lucide-react";
+import { MessageSquare } from "lucide-react";
 import { SectorBadge } from "@/components/stories/SectorBadge";
 import { StorySaveButton } from "@/components/stories/StorySaveButton";
+import { Card, type CardSectorAccent } from "@/components/ui/Card";
 import { highlightText } from "@/lib/highlight";
+import { timeAgo } from "@/lib/timeAgo";
 import type { SearchResultStory } from "@/types/story";
 
-function formatDate(value: string | null): string {
-  if (!value) return "";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+// Phase 12j — search-result card. Mirrors StoryCard's shape (sector
+// left-border, serif headline in --ink with --accent on hover via
+// group-hover, sector badge + mono timestamp + comments). Diverges
+// in two places: text uses highlightText for the matched query
+// terms, and there is no commentary lazy fetch — the search payload
+// already carries the context snippet.
+
+function sectorAccentFor(sector: string): CardSectorAccent {
+  if (sector === "ai") return "ai";
+  if (sector === "finance") return "finance";
+  if (sector === "semiconductors") return "semis";
+  return null;
 }
 
 interface SearchResultCardProps {
   story: SearchResultStory;
   terms: string[];
+  index?: number;
 }
 
-export function SearchResultCard({ story, terms }: SearchResultCardProps): JSX.Element {
-  const date = formatDate(story.published_at ?? story.created_at);
+export function SearchResultCard({
+  story,
+  terms,
+  index = 0,
+}: SearchResultCardProps): JSX.Element {
+  const stamp = timeAgo(story.published_at ?? story.created_at);
+  const staggerDelay = index < 10 ? `${index * 30}ms` : "0ms";
 
   return (
-    <article className="group rounded-lg border border-slate-200 bg-white p-6 transition-shadow hover:shadow-md">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <SectorBadge sector={story.sector} />
-          {date && <span className="text-xs text-slate-500">{date}</span>}
-        </div>
-        <StorySaveButton story={story} />
-      </div>
-
-      <Link href={`/stories/${story.id}`} className="block">
-        <h2 className="mb-2 text-lg font-semibold leading-tight text-slate-900 group-hover:text-violet-700">
+    <Card
+      interactive
+      sectorAccent={sectorAccentFor(story.sector)}
+      className="animate-fade-up p-6"
+      style={{ animationDelay: staggerDelay }}
+    >
+      <Link
+        href={`/stories/${story.id}`}
+        className="group block hover:no-underline"
+      >
+        <h2 className="mb-2 font-display text-lg font-semibold leading-snug text-ink transition-colors duration-150 group-hover:text-accent">
           {highlightText(story.headline, terms)}
         </h2>
-        <p className="mb-3 line-clamp-3 text-sm leading-relaxed text-slate-600">
+        <p
+          className="mb-4 text-sm leading-relaxed text-ink-muted"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
           {highlightText(story.context, terms)}
         </p>
       </Link>
 
-      <div className="flex items-center justify-between text-xs text-slate-500">
-        <div className="flex items-center gap-4">
-          {story.author?.name && <span>By {story.author.name}</span>}
-          <span className="inline-flex items-center gap-1">
-            <MessageSquare className="h-3.5 w-3.5" />
-            {story.comment_count}
-          </span>
+      <div className="flex items-center justify-between gap-3 text-xs text-ink-muted">
+        <div className="flex items-center gap-3">
+          <SectorBadge sector={story.sector} />
+          {stamp && (
+            <span className="font-mono text-[11px] tracking-tight">{stamp}</span>
+          )}
+          {story.comment_count > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <MessageSquare className="h-3.5 w-3.5" />
+              {story.comment_count}
+            </span>
+          )}
         </div>
-        {story.source_url && (
-          <a
-            href={story.source_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-slate-500 hover:text-violet-700"
-          >
-            {story.source_name ?? "Source"}
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        )}
+        <StorySaveButton story={story} />
       </div>
-    </article>
+    </Card>
   );
 }

--- a/frontend/src/components/stories/Commentary.tsx
+++ b/frontend/src/components/stories/Commentary.tsx
@@ -1,17 +1,10 @@
 "use client";
 
 // Phase 12d — expandable thesis/support commentary surface.
-//
-// Reads the structured CommentaryShape and renders thesis by default
-// with a "Go deeper" button that toggles support visibility. State is
-// pure session-scope `useState` per Decision 12d.3 — preference is not
-// persisted across reloads so a fresh visit always lands on the
-// thesis-only view.
-//
-// Visual frame matches PersonalizationBox (icon + violet rule) for
-// continuity; this is the 12c surface upgraded, not a new shelf. The
-// component intentionally stays minimal in this commit: thesis,
-// button, support panel, 200ms slide. Polish iterates in 12d.1.
+// Phase 12j — restyled onto the design tokens. Same data shape,
+// same expand-collapse interaction; visual frame moves from
+// violet → accent-tinted card so the surface reads as the same
+// "personalized briefing" affordance throughout the app.
 
 import { useState } from "react";
 import { ChevronDown, Sparkles } from "lucide-react";
@@ -25,23 +18,29 @@ export function Commentary({ commentary }: CommentaryProps): JSX.Element {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="flex gap-3 rounded-lg border border-violet-200 bg-violet-50/60 p-4">
-      <Sparkles className="mt-0.5 h-4 w-4 flex-shrink-0 text-violet-600" />
-      <div className="flex-1 space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-wide text-violet-700">
+    <div
+      className="flex gap-3 rounded-lg border p-5"
+      style={{
+        backgroundColor: "color-mix(in srgb, var(--accent) 5%, var(--surface))",
+        borderColor: "color-mix(in srgb, var(--accent) 22%, var(--line))",
+      }}
+    >
+      <Sparkles className="mt-1 h-4 w-4 flex-shrink-0 text-accent" />
+      <div className="flex-1 space-y-3">
+        <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-accent">
           Why it matters
         </p>
-        <p className="text-sm leading-relaxed text-slate-800">
+        <p className="text-[15px] leading-[1.7] text-ink">
           {commentary.thesis}
         </p>
         <div
-          className={`grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out ${
+          className={`grid overflow-hidden transition-[grid-template-rows] duration-200 ease-soft-out ${
             expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
           }`}
           aria-hidden={!expanded}
         >
           <div className="min-h-0">
-            <p className="pt-2 text-sm leading-relaxed text-slate-700">
+            <p className="pt-1 text-[15px] leading-[1.7] text-ink-muted">
               {commentary.support}
             </p>
           </div>
@@ -50,7 +49,7 @@ export function Commentary({ commentary }: CommentaryProps): JSX.Element {
           type="button"
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
-          className="inline-flex items-center gap-1 text-xs font-medium text-violet-700 hover:text-violet-900"
+          className="inline-flex items-center gap-1 text-xs font-medium text-accent transition-colors hover:text-accent-hover hover:underline"
         >
           {expanded ? "Show less" : "Go deeper"}
           <ChevronDown

--- a/frontend/src/components/stories/DepthToggle.tsx
+++ b/frontend/src/components/stories/DepthToggle.tsx
@@ -1,31 +1,34 @@
 "use client";
 
 import { Lock } from "lucide-react";
+import { useMemo } from "react";
 import type { DepthOverride } from "@/hooks/useStoryCommentary";
 
-const DEPTH_OPTIONS: ReadonlyArray<{ value: DepthOverride; label: string }> = [
+// Phase 12j — depth toggle with a sliding active indicator. Three
+// segments (Accessible / Briefed / Technical) on a single rail; the
+// active background is a single absolutely-positioned element whose
+// `left` and `width` animate between the segment slots via CSS
+// transition. Free-tier users see a lock icon on Briefed + Technical;
+// clicking a locked segment short-circuits the onSelect callback and
+// fires onLockedClick instead (parent renders the inline upgrade
+// card — see StoryDetail).
+
+const DEPTH_OPTIONS: ReadonlyArray<{
+  value: DepthOverride;
+  label: string;
+}> = [
   { value: "accessible", label: "Accessible" },
   { value: "briefed", label: "Briefed" },
   { value: "technical", label: "Technical" },
 ];
 
-// Phase 12g — depth toggle with free-tier visual lock. Briefed and
-// technical render with a lock icon for free users; clicking a locked
-// option does NOT fire a commentary request — the parent surfaces an
-// inline upgrade prompt instead (see StoryDetail).
-//
-// Pro / pro_trial users see no locks; clicks pass through to the
-// `onSelect` handler which the parent maps onto useStoryCommentary's
-// `depth` option.
+const SEGMENT_COUNT = DEPTH_OPTIONS.length;
+const SEGMENT_PCT = 100 / SEGMENT_COUNT;
+
 export interface DepthToggleProps {
   value: DepthOverride;
   onSelect: (depth: DepthOverride) => void;
-  // When true (free tier), briefed + technical are locked. The
-  // toggle still surfaces the click so the parent can show the
-  // inline upgrade prompt.
   lockHigherTiers: boolean;
-  // Forwarded to lock click — parent decides what to do (typically
-  // open the inline upgrade card).
   onLockedClick?: (attempted: DepthOverride) => void;
 }
 
@@ -35,15 +38,35 @@ export function DepthToggle({
   lockHigherTiers,
   onLockedClick,
 }: DepthToggleProps): JSX.Element {
+  const activeIndex = useMemo(
+    () => Math.max(0, DEPTH_OPTIONS.findIndex((o) => o.value === value)),
+    [value],
+  );
+
+  // The active slot lives in the inner padding rail (2px on each
+  // side). Translating by activeIndex * segment width inside the
+  // rail keeps the indicator pixel-aligned with the segment hit area.
+  const indicatorStyle: React.CSSProperties = {
+    width: `calc(${SEGMENT_PCT}% - 4px)`,
+    transform: `translateX(${activeIndex * 100}%)`,
+  };
+
   return (
     <div
-      className="inline-flex rounded-md border border-slate-200 bg-slate-50 p-1 text-sm"
       role="tablist"
       aria-label="Commentary depth"
+      className="relative inline-flex w-full max-w-[420px] items-stretch rounded-md border border-line bg-bg p-1"
     >
+      {/* Sliding active indicator */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-1 top-1 bottom-1 rounded-[6px] bg-surface shadow-card transition-transform duration-200 ease-soft-out"
+        style={indicatorStyle}
+      />
       {DEPTH_OPTIONS.map((opt) => {
         const isLocked =
-          lockHigherTiers && (opt.value === "briefed" || opt.value === "technical");
+          lockHigherTiers &&
+          (opt.value === "briefed" || opt.value === "technical");
         const isActive = value === opt.value;
         return (
           <button
@@ -60,11 +83,13 @@ export function DepthToggle({
               onSelect(opt.value);
             }}
             className={[
-              "inline-flex items-center gap-1 rounded px-3 py-1.5 transition-colors",
+              "relative z-10 flex flex-1 items-center justify-center gap-1.5",
+              "rounded-[6px] px-3 py-1.5 text-sm font-medium",
+              "transition-colors duration-200 ease-soft-out",
               isActive
-                ? "bg-white text-slate-900 shadow-sm"
-                : "text-slate-600 hover:text-slate-900",
-              isLocked ? "opacity-70" : "",
+                ? "text-ink"
+                : "text-ink-muted hover:text-ink",
+              isLocked ? "opacity-90" : "",
             ].join(" ")}
           >
             {isLocked && <Lock className="h-3 w-3" aria-hidden />}

--- a/frontend/src/components/stories/GatedStoryCard.tsx
+++ b/frontend/src/components/stories/GatedStoryCard.tsx
@@ -3,50 +3,87 @@
 import { Lock } from "lucide-react";
 import { SectorBadge } from "./SectorBadge";
 import { UpgradeCtaButton } from "./UpgradeCta";
+import { Card, type CardSectorAccent } from "@/components/ui/Card";
 import type { FeedGatedStory } from "@/types/story";
 
-// Phase 12g — soft-block render for a feed row beyond the free-tier
-// daily cap. Per spec: headline + first line of generic commentary
-// remain visible; everything below blurs behind an upgrade overlay.
-// The card stays clickable-looking but the overlay sits above the
-// blur — users can scroll past gated cards without dismissing
-// anything (no modal, no toast).
-export function GatedStoryCard({ story }: { story: FeedGatedStory }): JSX.Element {
+// Phase 12j — gated story card. Same outer footprint as a normal
+// StoryCard so the feed has a uniform rhythm (cards don't collapse
+// or jump). Headline + first line stay visible at full opacity; the
+// body region under them blurs into a CSS gradient mask, with the
+// upgrade CTA centered over the blurred zone. The card stays
+// scrollable past — no modal, no eject.
+
+function sectorAccentFor(sector: string): CardSectorAccent {
+  if (sector === "ai") return "ai";
+  if (sector === "finance") return "finance";
+  if (sector === "semiconductors") return "semis";
+  return null;
+}
+
+export function GatedStoryCard({
+  story,
+  index = 0,
+}: {
+  story: FeedGatedStory;
+  index?: number;
+}): JSX.Element {
+  const staggerDelay = index < 10 ? `${index * 40}ms` : "0ms";
   return (
-    <article
-      className="relative overflow-hidden rounded-lg border border-slate-200 bg-white p-6"
+    <Card
       data-testid="gated-story-card"
+      sectorAccent={sectorAccentFor(story.sector)}
+      className="relative overflow-hidden p-6 animate-fade-up"
+      style={{ animationDelay: staggerDelay }}
     >
-      <div className="pointer-events-none select-none">
-        <div className="mb-3 flex items-center gap-2">
-          <SectorBadge sector={story.sector} />
-        </div>
-        <h2 className="mb-2 text-xl font-semibold leading-tight text-slate-900">
-          {story.teaser.headline}
-        </h2>
-        <p className="text-sm leading-relaxed text-slate-600">
-          {story.teaser.first_line}
-        </p>
-        {/* Blurred filler so the overlay anchors to a card-shaped area
-            rather than collapsing. The text is decorative — actual
-            content stays server-side. */}
-        <div
-          className="mt-4 space-y-2 blur-sm"
-          aria-hidden
-        >
-          <div className="h-3 rounded bg-slate-200" />
-          <div className="h-3 w-11/12 rounded bg-slate-200" />
-          <div className="h-3 w-10/12 rounded bg-slate-200" />
-        </div>
+      {/* Visible region: sector badge + headline + first line. */}
+      <div className="mb-3">
+        <SectorBadge sector={story.sector} />
+      </div>
+      <h2 className="mb-2 font-display text-[20px] font-semibold leading-snug text-ink">
+        {story.teaser.headline}
+      </h2>
+      <p className="text-sm leading-relaxed text-ink-muted">
+        {story.teaser.first_line}
+      </p>
+
+      {/* Blurred region: card-shaped placeholder content under a
+          backdrop blur. The CSS gradient mask fades from solid at the
+          top to transparent at the bottom so the blur feels like the
+          rest of the card is still there, just out of focus. */}
+      <div
+        aria-hidden
+        className="mt-4 space-y-2 gate-blur"
+        style={{
+          maskImage:
+            "linear-gradient(to bottom, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.25) 90%)",
+          WebkitMaskImage:
+            "linear-gradient(to bottom, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.25) 90%)",
+        }}
+      >
+        <div className="h-3 rounded bg-line" />
+        <div className="h-3 w-11/12 rounded bg-line" />
+        <div className="h-3 w-10/12 rounded bg-line" />
+        <div className="h-3 w-8/12 rounded bg-line" />
       </div>
 
-      <div className="absolute inset-x-6 bottom-6 flex flex-col items-start gap-3 rounded-md border border-violet-200 bg-violet-50/95 p-4 shadow-sm">
-        <div className="flex items-start gap-2 text-sm text-violet-900">
-          <Lock className="mt-0.5 h-4 w-4 flex-none" aria-hidden />
+      {/* Upgrade overlay — sits over the blurred region, integrated
+          with the card rather than as a modal. Warm semi-transparent
+          backdrop using color-mix() against the surface color so it
+          looks like a natural extension of the card. */}
+      <div
+        className="absolute inset-x-6 bottom-6 flex flex-col items-start gap-3 rounded-md border border-line p-4"
+        style={{
+          backgroundColor: "color-mix(in srgb, var(--surface) 92%, transparent)",
+          backdropFilter: "blur(4px)",
+          WebkitBackdropFilter: "blur(4px)",
+        }}
+      >
+        <div className="flex items-start gap-2 text-sm text-ink">
+          <Lock className="mt-0.5 h-4 w-4 flex-none text-accent" aria-hidden />
           <span>{story.upgrade_cta.message}</span>
         </div>
-        <UpgradeCtaButton cta={story.upgrade_cta} />
+        <UpgradeCtaButton cta={story.upgrade_cta} size="sm" />
       </div>
-    </article>
+    </Card>
   );
 }

--- a/frontend/src/components/stories/PersonalizationBox.tsx
+++ b/frontend/src/components/stories/PersonalizationBox.tsx
@@ -1,45 +1,51 @@
 import { Sparkles } from "lucide-react";
 
+// Phase 12j — restyled onto design tokens. Same loading-vs-text
+// branch, same shimmer skeleton, accent-tinted card frame to match
+// the Commentary surface. The skeleton shimmer pulses against the
+// tinted background so loading feels intentional, not broken.
+
 interface PersonalizationBoxProps {
   // Final commentary to display. Null/undefined = loading skeleton.
   text: string | null | undefined;
   // Phase 12c: when true, render the shimmer skeleton instead of text.
-  // Separated from text-null because we want to show the header chrome
-  // (icon + "Why it matters") immediately and only swap the body
-  // between skeleton and commentary.
   loading?: boolean;
 }
 
-// Three-line shimmer that visually matches the commentary density
-// produced by DEPTH_GUIDANCE["briefed"] (~120-160 words, ~3 lines in
-// the feed card width). Using pulse rather than a moving gradient
-// because tailwind ships it out of the box and it doesn't fight
-// React 18 StrictMode's double-render in dev.
 function CommentarySkeleton(): JSX.Element {
   return (
     <div aria-busy="true" aria-live="polite" className="space-y-2">
       <span className="sr-only">Generating your personalized commentary</span>
-      <div className="h-3 w-[95%] animate-pulse rounded bg-violet-200/80" />
-      <div className="h-3 w-[88%] animate-pulse rounded bg-violet-200/70" />
-      <div className="h-3 w-[60%] animate-pulse rounded bg-violet-200/60" />
+      <div className="skeleton h-3 w-[95%] rounded" />
+      <div className="skeleton h-3 w-[88%] rounded" />
+      <div className="skeleton h-3 w-[60%] rounded" />
     </div>
   );
 }
 
-export function PersonalizationBox({ text, loading }: PersonalizationBoxProps): JSX.Element {
+export function PersonalizationBox({
+  text,
+  loading,
+}: PersonalizationBoxProps): JSX.Element {
   const showSkeleton = loading || text === null || text === undefined;
 
   return (
-    <div className="flex gap-3 rounded-lg border border-violet-200 bg-violet-50/60 p-4">
-      <Sparkles className="mt-0.5 h-4 w-4 flex-shrink-0 text-violet-600" />
-      <div className="flex-1 space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wide text-violet-700">
+    <div
+      className="flex gap-3 rounded-lg border p-5"
+      style={{
+        backgroundColor: "color-mix(in srgb, var(--accent) 5%, var(--surface))",
+        borderColor: "color-mix(in srgb, var(--accent) 22%, var(--line))",
+      }}
+    >
+      <Sparkles className="mt-1 h-4 w-4 flex-shrink-0 text-accent" />
+      <div className="flex-1 space-y-3">
+        <p className="font-mono text-[11px] uppercase tracking-[0.12em] text-accent">
           Why it matters
         </p>
         {showSkeleton ? (
           <CommentarySkeleton />
         ) : (
-          <p className="text-sm leading-relaxed text-slate-800">{text}</p>
+          <p className="text-[15px] leading-[1.7] text-ink">{text}</p>
         )}
       </div>
     </div>

--- a/frontend/src/components/stories/SectorBadge.tsx
+++ b/frontend/src/components/stories/SectorBadge.tsx
@@ -1,9 +1,16 @@
-import clsx from "clsx";
+"use client";
 
-const SECTOR_STYLES: Record<string, string> = {
-  ai: "bg-violet-100 text-violet-800 border-violet-200",
-  finance: "bg-emerald-100 text-emerald-800 border-emerald-200",
-  semiconductors: "bg-amber-100 text-amber-800 border-amber-200",
+import { Badge } from "@/components/ui/Badge";
+
+// Phase 12j — sector pill. Wraps the Badge primitive so the legacy
+// import path (components/stories/SectorBadge) keeps working while
+// the styling flows from the design tokens.
+
+const SECTOR_TO_TONE: Record<string, "ai" | "finance" | "semis" | "neutral"> = {
+  ai: "ai",
+  finance: "finance",
+  // Stored slug is "semiconductors"; design-system token is "semis".
+  semiconductors: "semis",
 };
 
 const SECTOR_LABELS: Record<string, string> = {
@@ -12,17 +19,32 @@ const SECTOR_LABELS: Record<string, string> = {
   semiconductors: "Semiconductors",
 };
 
-export function SectorBadge({ sector }: { sector: string }): JSX.Element {
-  const style = SECTOR_STYLES[sector] ?? "bg-slate-100 text-slate-800 border-slate-200";
+export function SectorBadge({
+  sector,
+  variant = "tinted",
+}: {
+  sector: string;
+  variant?: "tinted" | "filled";
+}): JSX.Element {
+  const tone = SECTOR_TO_TONE[sector] ?? "neutral";
   const label = SECTOR_LABELS[sector] ?? sector;
   return (
-    <span
-      className={clsx(
-        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium",
-        style,
-      )}
-    >
+    <Badge tone={tone} variant={variant}>
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full"
+        style={{
+          backgroundColor:
+            tone === "ai"
+              ? "var(--ai)"
+              : tone === "finance"
+                ? "var(--finance)"
+                : tone === "semis"
+                  ? "var(--semis)"
+                  : "var(--ink-muted)",
+        }}
+      />
       {label}
-    </span>
+    </Badge>
   );
 }

--- a/frontend/src/components/stories/StoryCard.tsx
+++ b/frontend/src/components/stories/StoryCard.tsx
@@ -2,28 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { MessageSquare, ExternalLink } from "lucide-react";
+import { MessageSquare } from "lucide-react";
 import { SectorBadge } from "./SectorBadge";
 import { StorySaveButton } from "./StorySaveButton";
-import { PersonalizationBox } from "./PersonalizationBox";
-import { Commentary } from "./Commentary";
+import { Card, type CardSectorAccent } from "@/components/ui/Card";
 import { useStoryCommentary } from "@/hooks/useStoryCommentary";
+import { timeAgo } from "@/lib/timeAgo";
 import { isGatePayload, type Story } from "@/types/story";
-
-function formatDate(value: string | null): string {
-  if (!value) return "";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-interface StoryCardProps {
-  story: Story;
-}
 
 // Phase 12c — each card self-manages when to fire its commentary
 // fetch via IntersectionObserver with a rootMargin that provides
@@ -34,28 +19,41 @@ interface StoryCardProps {
 //     resolve as soon as the first wave returns.
 //   - scrolling: newly-visible cards (and ~5 more below them) flip
 //     to enabled; queue absorbs the spike.
-//
-// Card height is ~200-240px; 1200px of rootMargin ≈ 5-6 cards of
-// scroll-ahead, which matches the "5-story prefetch" product spec.
-// We use only vertical margin (0px horizontal) — the feed is a
-// single column.
 const VISIBILITY_ROOT_MARGIN = "1200px 0px";
 
-export function StoryCard({ story }: StoryCardProps): JSX.Element {
-  const date = formatDate(story.published_at ?? story.created_at);
+interface StoryCardProps {
+  story: Story;
+  // Phase 12j — stagger entrance animation. Cards are mounted at the
+  // same time on a fresh feed load; we want them to fade in with a
+  // small per-card delay so the eye reads them sequentially. Passed
+  // by the feed page based on within-page index.
+  index?: number;
+}
 
-  // Once a card has been "close enough" to the viewport to prefetch,
-  // we latch that state — scrolling away must NOT cancel an in-flight
-  // request (StrictMode would already double-fire; canceling would
-  // waste the slot and churn TanStack Query's cache).
+function sectorAccentFor(sector: string): CardSectorAccent {
+  if (sector === "ai") return "ai";
+  if (sector === "finance") return "finance";
+  if (sector === "semiconductors") return "semis";
+  return null;
+}
+
+function primaryParagraph(text: string): string {
+  // The commentary thesis can be a paragraph or two; on the feed we
+  // show the first paragraph as a preview, line-clamped to ~3 lines
+  // via CSS. Pre-trim on the input to avoid trailing whitespace
+  // confusing the clamp.
+  return text.trim();
+}
+
+export function StoryCard({ story, index = 0 }: StoryCardProps): JSX.Element {
+  const stamp = timeAgo(story.published_at ?? story.created_at);
+
   const [shouldLoad, setShouldLoad] = useState(false);
-  const cardRef = useRef<HTMLElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const el = cardRef.current;
     if (!el || shouldLoad) return;
-    // If the browser doesn't support IntersectionObserver, fall back
-    // to enabling immediately. The 8-slot semaphore still caps fanout.
     if (typeof IntersectionObserver === "undefined") {
       setShouldLoad(true);
       return;
@@ -75,18 +73,6 @@ export function StoryCard({ story }: StoryCardProps): JSX.Element {
 
   const commentaryQuery = useStoryCommentary(story.id, { enabled: shouldLoad });
 
-  // 12d — commentary is now `{thesis, support}` from the endpoint.
-  // Resolution priority (unchanged):
-  //   1. freshly-loaded commentary from the endpoint
-  //   2. commentary pre-loaded on the story (server-side hydration path)
-  //   3. the 12b why_it_matters_to_you personalization (last-resort string)
-  // (3) renders through PersonalizationBox (string-only); (1) and (2)
-  // render through Commentary (structured).
-  // Phase 12g — commentaryQuery.data is `CommentaryEnvelope` (gate-
-  // capable). The gated branch shouldn't normally fire on the feed
-  // card (the feed itself is gated at the row level so this card
-  // wouldn't render), but defensively unwrap with isGatePayload so
-  // we never read .commentary off a GatePayload.
   const apiCommentary =
     commentaryQuery.data && !isGatePayload(commentaryQuery.data)
       ? commentaryQuery.data.commentary
@@ -95,64 +81,71 @@ export function StoryCard({ story }: StoryCardProps): JSX.Element {
   const isCommentaryLoading =
     shouldLoad && resolvedCommentary === null && commentaryQuery.isFetching;
 
-  return (
-    <article
-      ref={cardRef}
-      className="group rounded-lg border border-slate-200 bg-white p-6 transition-shadow hover:shadow-md"
-    >
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <SectorBadge sector={story.sector} />
-          {date && <span className="text-xs text-slate-500">{date}</span>}
-        </div>
-        <StorySaveButton story={story} />
-      </div>
+  // 12j — feed preview shows the commentary thesis when we have one,
+  // or the why_it_matters_to_you template body as the fallback. The
+  // tail of the card always has the sector badge + timestamp; the
+  // source attribution moves to a small subtitle directly under the
+  // headline (per the brief: "via Bloomberg" / "via SemiAnalysis,
+  // Bloomberg, +3 more").
+  const previewText = resolvedCommentary?.thesis ?? story.why_it_matters_to_you;
+  const sourceCount = story.sources.length;
+  const primarySource = story.source_name ?? story.sources[0]?.name ?? null;
+  const sourceLabel =
+    sourceCount > 1 && primarySource
+      ? `via ${primarySource}, +${sourceCount - 1} more`
+      : primarySource
+        ? `via ${primarySource}`
+        : null;
 
-      <Link href={`/stories/${story.id}`} className="block">
-        <h2 className="mb-2 text-xl font-semibold leading-tight text-slate-900 group-hover:text-violet-700">
+  // Stagger only the first ~10 cards so later scroll-loads don't get
+  // a perceptible delay before they paint.
+  const staggerDelay = index < 10 ? `${index * 40}ms` : "0ms";
+
+  return (
+    <Card
+      ref={cardRef}
+      interactive
+      sectorAccent={sectorAccentFor(story.sector)}
+      className="animate-fade-up p-6"
+      style={{ animationDelay: staggerDelay }}
+    >
+      <Link href={`/stories/${story.id}`} className="block hover:no-underline">
+        <h2 className="mb-1 font-display text-[20px] font-semibold leading-snug text-ink group-hover:text-accent">
           {story.headline}
         </h2>
-        <p className="mb-4 line-clamp-3 text-sm leading-relaxed text-slate-600">
-          {story.context}
+        {sourceLabel && (
+          <p className="mb-3 text-xs text-ink-muted">{sourceLabel}</p>
+        )}
+        <p
+          className="mb-4 text-sm leading-relaxed text-ink-muted"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {isCommentaryLoading
+            ? "Generating your briefing…"
+            : primaryParagraph(previewText)}
         </p>
       </Link>
 
-      {resolvedCommentary ? (
-        <Commentary commentary={resolvedCommentary} />
-      ) : (
-        <PersonalizationBox
-          text={story.why_it_matters_to_you}
-          loading={isCommentaryLoading}
-        />
-      )}
-
-      <div className="mt-4 flex items-center justify-between text-xs text-slate-500">
-        <div className="flex items-center gap-4">
-          {story.author?.name && <span>By {story.author.name}</span>}
-          <span className="inline-flex items-center gap-1">
-            <MessageSquare className="h-3.5 w-3.5" />
-            {story.comment_count}
-          </span>
+      <div className="flex items-center justify-between gap-3 text-xs text-ink-muted">
+        <div className="flex items-center gap-3">
+          <SectorBadge sector={story.sector} />
+          {stamp && (
+            <span className="font-mono text-[11px] tracking-tight">{stamp}</span>
+          )}
+          {story.comment_count > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <MessageSquare className="h-3.5 w-3.5" />
+              {story.comment_count}
+            </span>
+          )}
         </div>
-        {story.source_url && (
-          <div className="inline-flex items-center gap-1">
-            <a
-              href={story.source_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-slate-500 hover:text-violet-700"
-            >
-              {story.source_name ?? "Source"}
-              <ExternalLink className="h-3 w-3" />
-            </a>
-            {story.sources.length > 1 && (
-              <span className="text-slate-400">
-                +{story.sources.length - 1} more
-              </span>
-            )}
-          </div>
-        )}
+        <StorySaveButton story={story} />
       </div>
-    </article>
+    </Card>
   );
 }

--- a/frontend/src/components/stories/StoryCard.tsx
+++ b/frontend/src/components/stories/StoryCard.tsx
@@ -109,8 +109,8 @@ export function StoryCard({ story, index = 0 }: StoryCardProps): JSX.Element {
       className="animate-fade-up p-6"
       style={{ animationDelay: staggerDelay }}
     >
-      <Link href={`/stories/${story.id}`} className="block hover:no-underline">
-        <h2 className="mb-1 font-display text-[20px] font-semibold leading-snug text-ink group-hover:text-accent">
+      <Link href={`/stories/${story.id}`} className="group block hover:no-underline">
+        <h2 className="mb-1 font-display text-[20px] font-semibold leading-snug text-ink transition-colors duration-150 group-hover:text-accent">
           {story.headline}
         </h2>
         {sourceLabel && (

--- a/frontend/src/components/stories/StoryDetail.tsx
+++ b/frontend/src/components/stories/StoryDetail.tsx
@@ -8,30 +8,26 @@ import { PersonalizationBox } from "./PersonalizationBox";
 import { Commentary } from "./Commentary";
 import { DepthToggle } from "./DepthToggle";
 import { UpgradeCtaButton } from "./UpgradeCta";
+import { Card } from "@/components/ui/Card";
 import {
   useStoryCommentary,
   type DepthOverride,
 } from "@/hooks/useStoryCommentary";
 import { useTier } from "@/hooks/useTier";
+import { timeAgo } from "@/lib/timeAgo";
 import { isGatePayload, type Story } from "@/types/story";
-
-function formatDate(value: string | null): string {
-  if (!value) return "";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleDateString(undefined, {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
-}
 
 interface StoryDetailProps {
   story: Story;
 }
 
+// Phase 12j — story detail surface restyle. Header → meta row →
+// depth toggle → commentary (with inline depth-gate prompt) →
+// optional coverage section → "From the source" body → footer with
+// source link + comment-count.
+
 export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
-  const date = formatDate(story.published_at ?? story.created_at);
+  const stamp = timeAgo(story.published_at ?? story.created_at);
 
   // Phase 12g — tier drives the depth-toggle lock + the inline upgrade
   // prompt for free users who click a locked tier.
@@ -54,7 +50,9 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
   // this path (shouldn't if the toggle blocks free clicks, but a
   // direct API caller or an out-of-sync client could trigger it), we
   // surface the inline prompt rather than rendering empty commentary.
-  const serverGate = isGatePayload(commentaryQuery.data) ? commentaryQuery.data : null;
+  const serverGate = isGatePayload(commentaryQuery.data)
+    ? commentaryQuery.data
+    : null;
 
   const resolvedCommentary =
     commentaryQuery.data && !isGatePayload(commentaryQuery.data)
@@ -66,21 +64,31 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
     commentaryQuery.isFetching;
 
   return (
-    <article className="space-y-6">
+    <article className="space-y-7">
       <header className="space-y-4">
-        <div className="flex items-center gap-3">
-          <SectorBadge sector={story.sector} />
-          {date && <span className="text-sm text-slate-500">{date}</span>}
-        </div>
-        <h1 className="text-3xl font-bold leading-tight text-slate-900">
+        <h1 className="font-display text-[28px] font-semibold leading-tight text-ink md:text-[30px]">
           {story.headline}
         </h1>
-        <div className="flex items-center justify-end">
+        {/* Meta row: sector · timestamp · save. Same bottom-row pattern
+            as the feed card so the user re-orients fast. */}
+        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-ink-muted">
+          <div className="flex items-center gap-3">
+            <SectorBadge sector={story.sector} />
+            {stamp && (
+              <span className="font-mono text-[11px] tracking-tight">{stamp}</span>
+            )}
+            {story.comment_count > 0 && (
+              <span className="inline-flex items-center gap-1">
+                <MessageSquare className="h-3.5 w-3.5" />
+                {story.comment_count}
+              </span>
+            )}
+          </div>
           <StorySaveButton story={story} />
         </div>
       </header>
 
-      <div className="space-y-3">
+      <div className="space-y-4">
         <DepthToggle
           value={depth}
           onSelect={(d) => {
@@ -94,11 +102,22 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
         {/* Phase 12g — inline upgrade prompt when a free user clicks a
             locked depth tier OR if a server-side depth gate envelope
             slips through (defensive). Falls through to the normal
-            commentary render otherwise. */}
+            commentary render otherwise. The prompt uses an accent-
+            tinted Card body so the spatial context stays intact —
+            commentary renders here on the un-gated path. */}
         {lockedAttempt || serverGate ? (
-          <div className="rounded-md border border-violet-200 bg-violet-50 p-4">
-            <div className="mb-3 flex items-start gap-2 text-sm text-violet-900">
-              <Lock className="mt-0.5 h-4 w-4 flex-none" aria-hidden />
+          <Card
+            flat
+            className="p-5"
+            style={{
+              backgroundColor:
+                "color-mix(in srgb, var(--accent) 6%, var(--surface))",
+              borderColor:
+                "color-mix(in srgb, var(--accent) 25%, var(--line))",
+            }}
+          >
+            <div className="mb-3 flex items-start gap-2 text-sm text-ink">
+              <Lock className="mt-0.5 h-4 w-4 flex-none text-accent" aria-hidden />
               <span>
                 {serverGate?.upgrade_cta.message ??
                   (trialAvailable
@@ -114,7 +133,7 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
                 }
               }
             />
-          </div>
+          </Card>
         ) : resolvedCommentary ? (
           <Commentary commentary={resolvedCommentary} />
         ) : (
@@ -125,22 +144,25 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
         )}
       </div>
 
-      {/*
-        Phase 12e.7b — discrete coverage list for multi-source events.
-        Single-source stories keep the existing footer attribution; only
-        multi-source items render this section. Primary source carries a
-        small badge so the relationship to the footer link is explicit.
-      */}
+      {/* Phase 12e.7b — coverage list for multi-source events. Single-
+          source stories keep the existing footer attribution; only
+          multi-source items render this section. */}
       {story.sources.length > 1 && (
         <section className="space-y-2">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-700">
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
             Coverage
           </h2>
           <ul className="space-y-1">
             {story.sources.map((s) => (
               <li key={s.url} className="flex items-center gap-2 text-sm">
                 {s.role === "primary" && (
-                  <span className="rounded bg-violet-100 px-1.5 py-0.5 text-xs font-medium text-violet-700">
+                  <span
+                    className="rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-accent"
+                    style={{
+                      backgroundColor:
+                        "color-mix(in srgb, var(--accent) 12%, transparent)",
+                    }}
+                  >
                     Primary
                   </span>
                 )}
@@ -148,7 +170,7 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
                   href={s.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-slate-600 hover:text-violet-700 hover:underline"
+                  className="text-ink-muted hover:text-accent hover:underline"
                 >
                   {s.name ?? s.url}
                 </a>
@@ -158,21 +180,19 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
         </section>
       )}
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-700">
-            From the source
-          </h2>
-          <p className="whitespace-pre-line text-base leading-relaxed text-slate-800">
-            {story.context}
-          </p>
-        </div>
+      <section className="space-y-3">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.12em] text-ink-muted">
+          From the source
+        </h2>
+        <p className="whitespace-pre-line text-[15px] leading-[1.7] text-ink">
+          {story.context}
+        </p>
       </section>
 
-      <footer className="flex items-center justify-between border-t border-slate-200 pt-4 text-sm text-slate-500">
+      <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4 text-sm text-ink-muted">
         <span className="inline-flex items-center gap-1">
           <MessageSquare className="h-4 w-4" />
-          {story.comment_count} comments
+          {story.comment_count} {story.comment_count === 1 ? "comment" : "comments"}
         </span>
         {story.source_url && (
           <div className="flex flex-col items-end gap-1">
@@ -180,13 +200,13 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
               href={story.source_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-slate-600 hover:text-violet-700"
+              className="inline-flex items-center gap-1 text-ink-muted transition-colors hover:text-accent"
             >
               {story.source_name ?? "Read source"}
               <ExternalLink className="h-3.5 w-3.5" />
             </a>
             {story.sources.length > 1 && (
-              <span className="text-xs text-slate-400">
+              <span className="text-xs text-ink-muted/80">
                 Also covered by{" "}
                 {story.sources
                   .filter((s) => s.role === "alternate")

--- a/frontend/src/components/stories/UpgradeCta.tsx
+++ b/frontend/src/components/stories/UpgradeCta.tsx
@@ -3,26 +3,38 @@
 import Link from "next/link";
 import type { GateUpgradeCta } from "@/types/story";
 
-// Phase 12g — shared upgrade button. Renders as a link to /upgrade
-// with copy that branches on whether the user still has a trial
-// available. Used by GatedStoryCard, the depth inline prompt, and
-// the search modal.
+// Phase 12j — upgrade CTA. Renders as a Link styled like the primary
+// Button (Link can't compose Button directly without forwardRef
+// gymnastics, so the styles are duplicated here from Button.tsx —
+// kept in lockstep with the primary variant).
 export function UpgradeCtaButton({
   cta,
   className,
+  size = "md",
 }: {
   cta: GateUpgradeCta;
   className?: string;
+  size?: "sm" | "md" | "lg";
 }): JSX.Element {
   const label = cta.trial_available ? "Start Free Trial" : "Upgrade to Pro";
+  const sizeClass =
+    size === "sm"
+      ? "h-8 px-3 text-sm"
+      : size === "lg"
+        ? "h-12 px-6 text-base"
+        : "h-10 px-4 text-sm";
+  const cls = [
+    "inline-flex items-center justify-center gap-2 rounded-md font-medium",
+    "bg-accent text-accent-fg hover:bg-accent-hover",
+    "transition-all duration-150 ease-soft-out",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+    sizeClass,
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return (
-    <Link
-      href="/upgrade"
-      className={
-        className ??
-        "inline-flex h-9 items-center justify-center rounded-md bg-violet-700 px-4 text-sm font-medium text-white hover:bg-violet-800"
-      }
-    >
+    <Link href="/upgrade" className={cls}>
       {label}
     </Link>
   );

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { type HTMLAttributes } from "react";
+
+// Phase 12j — Badge primitive. Pill-shaped small label. Used for
+// sector indicators, tier chips, trial-day countdowns, source-count
+// chips. Sector variants render as a filled pill in the sector accent
+// color; neutral/accent/warn variants are for non-sector usage.
+
+export type BadgeTone =
+  | "neutral"
+  | "accent"
+  | "warn"
+  | "ok"
+  | "ai"
+  | "finance"
+  | "semis";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone;
+  // Use the bg-tinted variant (subtle, low-saturation) instead of the
+  // filled-color variant (high contrast). Filled is the default for
+  // sectors; tinted is the default for neutral chrome.
+  variant?: "filled" | "tinted";
+}
+
+// color-mix gives us low-saturation tints from the same source token
+// — keeps the palette tight even for the tinted variants.
+const TONE_FILLED: Record<BadgeTone, string> = {
+  neutral: "bg-ink-muted text-bg",
+  accent: "bg-accent text-accent-fg",
+  warn: "bg-warn text-bg",
+  ok: "bg-ok text-bg",
+  ai: "bg-sector-ai text-bg",
+  finance: "bg-sector-finance text-bg",
+  semis: "bg-sector-semis text-bg",
+};
+
+// Tinted: subtle background tint + matching color for the text.
+// Using inline `style` rather than arbitrary Tailwind so we can do
+// color-mix() against the live token.
+const TONE_TINTED_TEXT: Record<BadgeTone, string> = {
+  neutral: "text-ink-muted",
+  accent: "text-accent",
+  warn: "text-warn",
+  ok: "text-ok",
+  ai: "text-sector-ai",
+  finance: "text-sector-finance",
+  semis: "text-sector-semis",
+};
+
+const TONE_VAR: Record<BadgeTone, string> = {
+  neutral: "var(--ink-muted)",
+  accent: "var(--accent)",
+  warn: "var(--warn)",
+  ok: "var(--ok)",
+  ai: "var(--ai)",
+  finance: "var(--finance)",
+  semis: "var(--semis)",
+};
+
+export function Badge({
+  tone = "neutral",
+  variant = "filled",
+  className,
+  style,
+  ...rest
+}: BadgeProps): JSX.Element {
+  const base =
+    "inline-flex items-center gap-1 rounded-pill px-2 py-0.5 text-xs font-medium tracking-wide";
+  const isTinted = variant === "tinted";
+  const cls = [
+    base,
+    isTinted ? TONE_TINTED_TEXT[tone] : TONE_FILLED[tone],
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const tintedStyle: React.CSSProperties | undefined = isTinted
+    ? { backgroundColor: `color-mix(in srgb, ${TONE_VAR[tone]} 14%, transparent)` }
+    : undefined;
+
+  return <span className={cls} style={{ ...tintedStyle, ...style }} {...rest} />;
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+// Phase 12j — Button primitive. Three variants matching the design
+// brief: primary (accent fill), secondary (outline), ghost (text only).
+// Three sizes (sm / md / lg). All variants share a soft-out cubic-
+// bezier transition for hover + press.
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary:
+    "bg-accent text-accent-fg hover:bg-accent-hover active:translate-y-px",
+  secondary:
+    "bg-surface text-ink border border-line hover:border-ink-muted hover:bg-bg",
+  ghost: "bg-transparent text-ink hover:bg-line/60",
+};
+
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base",
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "primary", size = "md", className, type, ...rest },
+  ref,
+) {
+  const cls = [
+    "inline-flex items-center justify-center gap-2 rounded-md font-medium",
+    "transition-all duration-150 ease-soft-out",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+    VARIANT_CLASSES[variant],
+    SIZE_CLASSES[size],
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return <button ref={ref} type={type ?? "button"} className={cls} {...rest} />;
+});

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { forwardRef, type HTMLAttributes } from "react";
+
+// Phase 12j — Card primitive. Base surface for story cards, gate
+// overlays, upgrade prompts. The `interactive` variant adds the lift-
+// on-hover affordance (translateY -2px + shadow swap). The
+// `sectorAccent` prop adds a 3px left-border in the matching sector
+// color — used by StoryCard.
+
+export type CardSectorAccent = "ai" | "finance" | "semis" | null;
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  interactive?: boolean;
+  sectorAccent?: CardSectorAccent;
+  // Suppress the default shadow — useful for nested cards or modal
+  // bodies where the parent already provides elevation.
+  flat?: boolean;
+}
+
+const SECTOR_BORDER_CLASSES: Record<NonNullable<CardSectorAccent>, string> = {
+  ai: "border-l-[3px] border-l-sector-ai",
+  finance: "border-l-[3px] border-l-sector-finance",
+  semis: "border-l-[3px] border-l-sector-semis",
+};
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
+  { interactive, sectorAccent, flat, className, ...rest },
+  ref,
+) {
+  const cls = [
+    "relative rounded-md bg-surface border border-line",
+    flat ? "" : "shadow-card",
+    interactive
+      ? "transition-all duration-200 ease-soft-out hover:-translate-y-0.5 hover:shadow-card-hover"
+      : "",
+    sectorAccent ? SECTOR_BORDER_CLASSES[sectorAccent] : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return <div ref={ref} className={cls} {...rest} />;
+});

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { forwardRef, type InputHTMLAttributes } from "react";
+
+// Phase 12j — Input primitive. Warm border, clear focus state.
+// Three sizes; default is md. The optional `leadingIcon` slot is for
+// search-style affordances (the Search icon in the auth + search
+// surfaces).
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  inputSize?: "sm" | "md" | "lg";
+  invalid?: boolean;
+  leadingIcon?: React.ReactNode;
+  trailingSlot?: React.ReactNode;
+}
+
+const SIZE_CLASSES: Record<NonNullable<InputProps["inputSize"]>, string> = {
+  sm: "h-9 text-sm",
+  md: "h-11 text-base",
+  lg: "h-12 text-base",
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { inputSize = "md", invalid, leadingIcon, trailingSlot, className, ...rest },
+  ref,
+) {
+  // Single input with no decoration: render the input alone (no
+  // wrapping element). With a leading icon or trailing slot, wrap so
+  // we can absolute-position the icon over the padded input.
+  if (!leadingIcon && !trailingSlot) {
+    const cls = [
+      "w-full rounded-md border bg-surface px-3 text-ink",
+      "placeholder:text-ink-muted",
+      "transition-colors duration-150",
+      "focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/30",
+      invalid ? "border-err" : "border-line",
+      SIZE_CLASSES[inputSize],
+      className ?? "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return <input ref={ref} className={cls} {...rest} />;
+  }
+
+  const wrapperCls = [
+    "relative flex items-center w-full rounded-md border bg-surface",
+    "transition-colors duration-150",
+    "focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/30",
+    invalid ? "border-err" : "border-line",
+    SIZE_CLASSES[inputSize],
+  ].join(" ");
+
+  const padLeft = leadingIcon ? "pl-10" : "pl-3";
+  const padRight = trailingSlot ? "pr-10" : "pr-3";
+  const inputCls = [
+    "w-full bg-transparent text-ink",
+    "placeholder:text-ink-muted",
+    "focus:outline-none",
+    "h-full",
+    padLeft,
+    padRight,
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={wrapperCls}>
+      {leadingIcon && (
+        <span
+          className="pointer-events-none absolute left-3 inline-flex items-center text-ink-muted"
+          aria-hidden
+        >
+          {leadingIcon}
+        </span>
+      )}
+      <input ref={ref} className={inputCls} {...rest} />
+      {trailingSlot && (
+        <span className="absolute right-2 inline-flex items-center">
+          {trailingSlot}
+        </span>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { X } from "lucide-react";
+
+// Phase 12j — Modal primitive. Centered overlay with a backdrop-
+// blur scrim. Keyboard-dismissable (Escape). Focus is captured on
+// open and restored to the previously-focused element on close.
+// Used by SearchLimitModal; the upgrade card on StoryDetail is NOT
+// a modal (it renders inline by design — maintain spatial context).
+
+export interface ModalProps {
+  open: boolean;
+  onDismiss: () => void;
+  title?: ReactNode;
+  // The aria-labelledby target; required when `title` is omitted
+  // and a custom heading is supplied via children.
+  labelledById?: string;
+  children: ReactNode;
+  // Maximum width of the panel; the brief uses a single common size.
+  // sm: 360, md: 440 (default), lg: 560.
+  size?: "sm" | "md" | "lg";
+  // Suppresses the close affordance + Escape handler. Used for
+  // mandatory-action modals; the SearchLimit modal stays dismissable.
+  dismissable?: boolean;
+}
+
+const SIZE_PX: Record<NonNullable<ModalProps["size"]>, string> = {
+  sm: "max-w-[360px]",
+  md: "max-w-[440px]",
+  lg: "max-w-[560px]",
+};
+
+export function Modal({
+  open,
+  onDismiss,
+  title,
+  labelledById,
+  children,
+  size = "md",
+  dismissable = true,
+}: ModalProps): JSX.Element | null {
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // Capture / restore focus + Escape handling.
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    // Defer to next tick so the panel mounts before focus moves.
+    const t = window.setTimeout(() => {
+      panelRef.current?.focus();
+    }, 0);
+
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape" && dismissable) {
+        e.stopPropagation();
+        onDismiss();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+
+    // Lock body scroll while modal is open.
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+      previouslyFocusedRef.current?.focus();
+    };
+  }, [open, onDismiss, dismissable]);
+
+  if (!open) return null;
+
+  const headingId = title
+    ? "modal-title"
+    : labelledById ?? undefined;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      {/* Backdrop — clicking it dismisses (when dismissable). */}
+      <button
+        type="button"
+        aria-label="Dismiss"
+        tabIndex={-1}
+        onClick={() => dismissable && onDismiss()}
+        className="absolute inset-0 bg-ink/30 backdrop-blur-sm"
+      />
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        className={[
+          "relative w-full rounded-lg bg-surface p-6 shadow-modal",
+          "animate-fade-up",
+          SIZE_PX[size],
+        ].join(" ")}
+      >
+        {dismissable && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-ink-muted hover:bg-bg hover:text-ink"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+        {title && (
+          <h2 id="modal-title" className="mb-3 font-display text-xl font-semibold text-ink">
+            {title}
+          </h2>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useId, useState, type ReactNode } from "react";
+
+// Phase 12j — Tooltip primitive. CSS-positioned, hover/focus
+// activated, lightweight. Not a fully featured popover — for short
+// label-style hints (SIGNAL rating explanation, depth-tier hover
+// hints). Multi-paragraph content should use Modal instead.
+
+export interface TooltipProps {
+  label: ReactNode;
+  children: ReactNode;
+  // Tooltip placement relative to the trigger. The 12j surfaces all
+  // use top + bottom; left/right are kept for completeness.
+  side?: "top" | "bottom" | "left" | "right";
+}
+
+const SIDE_CLASSES: Record<NonNullable<TooltipProps["side"]>, string> = {
+  top: "bottom-full left-1/2 -translate-x-1/2 mb-2",
+  bottom: "top-full left-1/2 -translate-x-1/2 mt-2",
+  left: "right-full top-1/2 -translate-y-1/2 mr-2",
+  right: "left-full top-1/2 -translate-y-1/2 ml-2",
+};
+
+export function Tooltip({
+  label,
+  children,
+  side = "top",
+}: TooltipProps): JSX.Element {
+  const [visible, setVisible] = useState(false);
+  const id = useId();
+
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+    >
+      <span aria-describedby={visible ? id : undefined}>{children}</span>
+      {visible && (
+        <span
+          role="tooltip"
+          id={id}
+          className={[
+            "pointer-events-none absolute z-50 whitespace-nowrap rounded-md",
+            "bg-ink px-2 py-1 text-xs font-medium text-bg shadow-card",
+            "animate-fade-up",
+            SIDE_CLASSES[side],
+          ].join(" ")}
+        >
+          {label}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/lib/highlight.tsx
+++ b/frontend/src/lib/highlight.tsx
@@ -60,7 +60,7 @@ export function highlightText(text: string, terms: string[]): ReactNode {
     lowered.has(part.toLowerCase()) ? (
       <mark
         key={idx}
-        className="rounded bg-amber-100 px-0.5 text-inherit"
+        className="rounded-sm bg-warn/20 px-0.5 text-inherit"
       >
         {part}
       </mark>

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,5 +1,12 @@
 import type { Config } from "tailwindcss";
 
+// Phase 12j — design tokens. CSS variables live in globals.css at
+// :root level; this config wires them into Tailwind's color theme.
+// The shadcn-style HSL variables (--background, --foreground, etc.)
+// are preserved for the handful of legacy ui/* primitives that still
+// reference them; new code references the new tokens directly
+// (bg-bg, text-ink, etc.).
+
 const config: Config = {
   darkMode: ["class"],
   content: [
@@ -9,13 +16,56 @@ const config: Config = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "1rem",
       screens: {
-        "2xl": "1400px",
+        // Reading-oriented surface — narrower than the typical SaaS
+        // container. The 12j brief calls for a 680–720px feed column.
+        DEFAULT: "100%",
+        sm: "100%",
+        md: "100%",
+        lg: "720px",
+        xl: "720px",
+        "2xl": "720px",
       },
     },
     extend: {
+      // ----- New design tokens (12j) -----
+      fontFamily: {
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        serif: ["var(--font-serif)", "Georgia", "serif"],
+        mono: ["var(--font-mono)", "ui-monospace", "monospace"],
+        display: ["var(--font-serif)", "Georgia", "serif"],
+      },
       colors: {
+        // Surfaces + text
+        bg: "var(--bg)",
+        surface: "var(--surface)",
+        ink: {
+          DEFAULT: "var(--ink)",
+          muted: "var(--ink-muted)",
+        },
+        line: "var(--line)",
+        // Primary accent (CTAs / links / focus)
+        accent: {
+          DEFAULT: "var(--accent)",
+          hover: "var(--accent-hover)",
+          fg: "var(--accent-fg)",
+        },
+        // Sector accents. Used as left-borders, dots, badge backgrounds,
+        // section-header underlines.
+        sector: {
+          ai: "var(--ai)",
+          finance: "var(--finance)",
+          semis: "var(--semis)",
+        },
+        // Semantic
+        ok: "var(--ok)",
+        warn: "var(--warn)",
+        err: "var(--err)",
+
+        // ----- Legacy shadcn tokens (kept so existing ui/* primitives
+        // don't break; values redirected to the new palette in globals
+        // so they look right with the new design without a code touch).
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
@@ -33,10 +83,6 @@ const config: Config = {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",
         },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
@@ -47,9 +93,46 @@ const config: Config = {
         },
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        lg: "10px",
+        md: "8px",
+        sm: "6px",
+        pill: "9999px",
+      },
+      boxShadow: {
+        // Subtle elevation for cards. The two-stop pattern is what
+        // makes the surface feel "lifted" without a harsh drop shadow.
+        card: "0 1px 2px rgba(26,24,22,0.04), 0 2px 6px rgba(26,24,22,0.04)",
+        "card-hover":
+          "0 2px 4px rgba(26,24,22,0.06), 0 8px 24px rgba(26,24,22,0.06)",
+        modal: "0 8px 32px rgba(26,24,22,0.16)",
+      },
+      keyframes: {
+        // Feed card stagger entrance — opacity + a 4px upward translate.
+        "fade-up": {
+          from: { opacity: "0", transform: "translateY(4px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        // Trial-badge pulse at ≤1 day remaining. Slow opacity breathe;
+        // not a hard flash.
+        breathe: {
+          "0%,100%": { opacity: "1" },
+          "50%": { opacity: "0.65" },
+        },
+        "shimmer-x": {
+          from: { backgroundPosition: "-200% 0" },
+          to: { backgroundPosition: "200% 0" },
+        },
+      },
+      animation: {
+        "fade-up": "fade-up 320ms cubic-bezier(0.2, 0.8, 0.2, 1) both",
+        breathe: "breathe 2.8s ease-in-out infinite",
+        shimmer: "shimmer-x 1.6s linear infinite",
+      },
+      transitionTimingFunction: {
+        "soft-out": "cubic-bezier(0.2, 0.8, 0.2, 1)",
+      },
+      maxWidth: {
+        reading: "720px",
       },
     },
   },


### PR DESCRIPTION
## Summary

First half of the 12j/k/l design-system pass. Lands the foundation (tokens, fonts, primitives), the signature components, the chrome (top nav), and the centerpiece Feed surface. Chunks 5–6 (story detail, search, saved, /upgrade, auth, onboarding, unsubscribe) ship in a separate PR after browser verification on this one.

Four commits, one per chunk:

1. **`d135af1` — foundation.** `next/font` (Newsreader / IBM Plex Sans / JetBrains Mono), Tailwind config extension (new tokens, fonts, shadows, animations, reading container), `globals.css` (tokens at `:root`, legacy shadcn HSL variables redirected to the new palette, scrollbar / focus / selection / link defaults). Four primitives: Button (3 variants × 3 sizes), Card (interactive + sectorAccent), Badge (7 tones × filled/tinted), Input (sized, leading-icon support).

2. **`9f76693` — signature components.** Redesigned DepthToggle with a sliding active indicator (200ms ease-soft-out translateX between segments), Modal primitive (centered overlay, backdrop blur, Escape/click-outside dismiss, focus capture+restore, body-scroll lock), SectorBadge rewired through Badge with sector tones + colored dot, Tooltip (CSS-positioned, four-side, lightweight). SearchLimitModal rebuilt on top of Modal. UpgradeCtaButton restyled to match the primary Button variant.

3. **`0f04cee` — chrome.** Header: warm bg with backdrop blur, serif "SIGNAL" wordmark tracked +0.18em, right rail = TrialBadge → TeamSwitcher → Search button (⌘K hint) → Saved icon → avatar menu, all aligned with the 720px reading container. TrialBadge: accent-tinted pill for `pro_trial`, warn pill + breathe animation when ≤1 day, subtle accent text-link for free.

4. **`33c264b` — Feed surface.** "Your Briefing" page header in font-display. Personalization line below: humanized role label + sector badges from the user's profile (immediate signal that the surface is customized). Today's date in JetBrains Mono. StoryCard rebuilt on Card primitive: sector left-border accent, serif headline, source attribution line, three-line commentary preview, mono timestamp, save in bottom-right. GatedStoryCard with gradient-masked blur + warm semi-transparent upgrade overlay. Loading skeleton + error + empty states. Per-card 40ms stagger animation-delay capped at 10 cards.

## Design decisions locked

- **Fonts:** Newsreader (serif display) + IBM Plex Sans (body) + JetBrains Mono (data/timestamp).
- **Colors:** All AA-verified against both backgrounds (cream + white). Three sector accents were bumped slightly darker from the initial picks so they comfortably clear AA for body text — see `d135af1` commit message for the contrast table.
- **Reading width:** 720px container, single-column.
- **Dark mode:** Deferred, post-launch.

## Gates

- Frontend `tsc --noEmit`: clean. The pre-existing `vitest.config.ts` `@vitejs/plugin-react` resolution error persists (worktree npm-install issue, unrelated, per the memory note).
- Backend untouched in this phase.

## What I cannot verify

CLAUDE.md says "For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete." I can't run the dev server. **You are the eyes for this PR.** Specifically worth sanity-checking before merging:

- Font pairing in context — does Newsreader read editorial without antique?
- Accent color (`#0A6D79`) — does it feel "warm blue-teal" or did I drift toward cyan?
- Card sector accents at 3px — visible but not dominant?
- Trial-badge breathe at ≤1 day — too aggressive? Too subtle?
- "Your Briefing" + personalization line layout — comfortable on 375px mobile?
- Gated card overlay — does the gradient-masked blur read as "more content, gated" or as a broken render?

If any of the above lands wrong, redirect before chunks 5–6 propagate the choice across 6 more surfaces.

## Post-merge

Chunks 5–6 in a separate session:
- Story detail surface (depth toggle integration, inline upgrade prompt, commentary layout, coverage section)
- Search page, Saved page, /upgrade marketing page, auth pages, onboarding restyling, unsubscribe page

🤖 Generated with [Claude Code](https://claude.com/claude-code)