### PR TITLE
feat: HN self-post support (Show HN / Ask HN)

### DIFF
--- a/backend/src/jobs/ingestion/adapters/hackerNews.ts
+++ b/backend/src/jobs/ingestion/adapters/hackerNews.ts
@@ -1,9 +1,17 @@
 // Hacker News API adapter (Phase 12e.5e).
 //
-// Two-phase fetch: topstories list → per-item detail. Filters to
-// story-type items with score >= HN_MIN_SCORE and an external URL.
-// No domain whitelist — the LLM relevance gate (12e.4) handles
-// off-sector filtering.
+// Two-phase fetch: topstories list → per-item detail. Accepts:
+//   - external-link stories — `url` points off-site, behaves like any
+//     other source.
+//   - self-posts (Ask HN / Show HN) — `url` empty, `text` carries the
+//     post body. source_url is the HN thread page; the post body is
+//     stripped to plain text and passed downstream as pre-fetched
+//     content so the heuristic seam skips fetch+readability on the
+//     thread page (which is HN nav chrome, not the post body).
+//
+// Filter: score >= HN_MIN_SCORE, type=story, not dead/deleted. No
+// domain whitelist — the LLM relevance gate (12e.4) handles off-sector
+// filtering downstream.
 //
 // Concurrency: item fetches run in batches of HN_FETCH_CONCURRENCY to
 // stay within Firebase's undocumented rate limits while keeping the
@@ -55,18 +63,54 @@ interface HnItem {
   type?: string;
   title?: string;
   url?: string;
+  text?: string;
   score?: number;
   time?: number;
   dead?: boolean;
   deleted?: boolean;
 }
 
+function hasUrl(item: HnItem): boolean {
+  return typeof item.url === "string" && item.url.trim().length > 0;
+}
+
+function hasText(item: HnItem): boolean {
+  return typeof item.text === "string" && item.text.trim().length > 0;
+}
+
 function isUsableItem(item: HnItem): boolean {
   if (item.dead || item.deleted) return false;
   if (item.type !== "story") return false;
-  if (!item.url || item.url.trim().length === 0) return false;
+  // Either an external link or a self-post with body text. An item
+  // with neither is unusable (a deleted Ask HN, a story marker with
+  // no payload, etc).
+  if (!hasUrl(item) && !hasText(item)) return false;
   if ((item.score ?? 0) < HN_MIN_SCORE) return false;
   return true;
+}
+
+// Minimal HTML → plain text. HN self-post bodies carry a small tag
+// set (<p>, <br>, <a>, <code>, <pre>, <i>) and the standard XML
+// entity set. We turn block-level breaks into newlines, strip the
+// rest, and decode the entities Firebase actually emits. This is not
+// a general HTML sanitizer — it's a targeted normalizer for the HN
+// `text` field so it matches the readability-extracted plain text
+// shape that the downstream stages expect on body_text.
+function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    .replace(/<\s*\/\s*p\s*>/gi, "\n\n")
+    .replace(/<\s*p[^>]*>/gi, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 async function fetchItemBatch(ids: number[]): Promise<HnItem[]> {
@@ -77,6 +121,37 @@ async function fetchItemBatch(ids: number[]): Promise<HnItem[]> {
     .filter((r): r is PromiseFulfilledResult<HnItem> => r.status === "fulfilled")
     .map((r) => r.value)
     .filter((item): item is HnItem => item !== null);
+}
+
+function buildCandidate(item: HnItem): Candidate {
+  const externalId = String(item.id);
+  const title = item.title ?? null;
+  const publishedAt = item.time ? new Date(item.time * 1000) : null;
+  const isSelfPost = !hasUrl(item);
+
+  const url = isSelfPost
+    ? `https://news.ycombinator.com/item?id=${item.id}`
+    : item.url!;
+
+  const bodyText = isSelfPost && item.text ? htmlToPlainText(item.text) : null;
+
+  // Stamp the community-post flag onto the persisted payload so a
+  // downstream consumer (debugging, future surface-level treatment)
+  // can tell self-posts from external links without re-deriving from
+  // `url`/`text`. The raw HN item already lives here unchanged.
+  const rawPayload: Record<string, unknown> = { ...(item as unknown as Record<string, unknown>) };
+  if (isSelfPost) rawPayload.is_community_post = true;
+
+  return {
+    externalId,
+    url,
+    title,
+    summary: null,
+    publishedAt,
+    contentHash: sha256Truncated(`${url}\n${title ?? ""}`),
+    bodyText,
+    rawPayload,
+  };
 }
 
 export async function hackerNewsAdapter(_ctx: AdapterContext): Promise<AdapterResult> {
@@ -100,20 +175,7 @@ export async function hackerNewsAdapter(_ctx: AdapterContext): Promise<AdapterRe
     const items = await fetchItemBatch(batch);
     for (const item of items) {
       if (!isUsableItem(item)) continue;
-      const url = item.url!;
-      const title = item.title ?? null;
-      const externalId = String(item.id);
-      const publishedAt = item.time ? new Date(item.time * 1000) : null;
-      const contentHash = sha256Truncated(`${url}\n${title ?? ""}`);
-      candidates.push({
-        externalId,
-        url,
-        title,
-        summary: null,
-        publishedAt,
-        contentHash,
-        rawPayload: item as unknown as Record<string, unknown>,
-      });
+      candidates.push(buildCandidate(item));
     }
   }
 

--- a/backend/src/jobs/ingestion/heuristicSeam.ts
+++ b/backend/src/jobs/ingestion/heuristicSeam.ts
@@ -55,6 +55,11 @@ interface CandidateRow {
   rawTitle: string | null;
   rawSummary: string | null;
   rawPublishedAt: Date | null;
+  // Pre-fetched body text written by the poll worker when the adapter
+  // supplied one (e.g. HN self-posts). Non-empty → skip the URL fetch
+  // and use this as the body directly. See Candidate.bodyText in
+  // types.ts.
+  bodyText: string | null;
   sourceUserAgent: string | null;
 }
 
@@ -69,6 +74,7 @@ async function loadCandidate(
       rawTitle: ingestionCandidates.rawTitle,
       rawSummary: ingestionCandidates.rawSummary,
       rawPublishedAt: ingestionCandidates.rawPublishedAt,
+      bodyText: ingestionCandidates.bodyText,
       sourceConfig: ingestionSources.config,
     })
     .from(ingestionCandidates)
@@ -88,6 +94,7 @@ async function loadCandidate(
     rawTitle: row.rawTitle,
     rawSummary: row.rawSummary,
     rawPublishedAt: row.rawPublishedAt,
+    bodyText: row.bodyText ?? null,
     sourceUserAgent: ua,
   };
 }
@@ -134,20 +141,35 @@ export async function runHeuristicSeam(
     return { pass: false, reason: HEURISTIC_REASONS.FILTERED_VIDEO_URL };
   }
 
-  // 4. Body fetch.
-  const userAgent = candidate.sourceUserAgent ?? DEFAULT_BODY_USER_AGENT;
-  const fetchResult: BodyExtractionResult = await fetchBody(candidate.url, { userAgent });
-  if (!fetchResult.success) {
-    return { pass: false, reason: fetchResult.reason };
+  // 4. Body resolution. Adapter-supplied body short-circuits the fetch:
+  // the source format already carries the article body inline (e.g. HN
+  // self-posts where the post body is the article, and the URL would
+  // otherwise resolve to the HN thread page's nav chrome). For these
+  // candidates we run the length floor against the pre-fetched text and
+  // skip the network call entirely. URL-based candidates fall through
+  // to fetchAndExtractBody as before.
+  let bodyText: string;
+  let truncated: boolean;
+  if (candidate.bodyText && candidate.bodyText.length > 0) {
+    bodyText = candidate.bodyText;
+    truncated = false;
+  } else {
+    const userAgent = candidate.sourceUserAgent ?? DEFAULT_BODY_USER_AGENT;
+    const fetchResult: BodyExtractionResult = await fetchBody(candidate.url, { userAgent });
+    if (!fetchResult.success) {
+      return { pass: false, reason: fetchResult.reason };
+    }
+    bodyText = fetchResult.text;
+    truncated = fetchResult.truncated;
   }
 
-  // 5. Length floor (post-extraction).
-  if (!meetsLengthFloor(fetchResult.text)) {
+  // 5. Length floor (post-resolution).
+  if (!meetsLengthFloor(bodyText)) {
     return { pass: false, reason: HEURISTIC_REASONS.BODY_TOO_SHORT };
   }
 
   return {
     pass: true,
-    body: { text: fetchResult.text, truncated: fetchResult.truncated },
+    body: { text: bodyText, truncated },
   };
 }

--- a/backend/src/jobs/ingestion/sourcePollJob.ts
+++ b/backend/src/jobs/ingestion/sourcePollJob.ts
@@ -67,6 +67,11 @@ async function persistCandidates(
     rawPublishedAt: c.publishedAt,
     rawPayload: c.rawPayload,
     contentHash: c.contentHash,
+    // Pre-fetched body from adapters whose source format carries the
+    // article body inline (e.g. HN self-posts). When null/undefined the
+    // heuristic seam fetches the URL itself. See Candidate.bodyText in
+    // ../types.ts for the contract.
+    bodyText: c.bodyText ?? null,
   }));
 
   // onConflictDoNothing on the (ingestion_source_id, external_id) unique

--- a/backend/src/jobs/ingestion/types.ts
+++ b/backend/src/jobs/ingestion/types.ts
@@ -23,6 +23,14 @@ export interface Candidate {
   // to 32 chars. Persisted to ingestion_candidates.content_hash for the
   // event-clustering layer (12e.6) to use as a cross-source dedup signal.
   contentHash: string;
+  // Pre-fetched body text. When set, the heuristic seam writes it through
+  // to ingestion_candidates.body_text and skips the per-URL fetch +
+  // readability extraction. Used by adapters whose source format already
+  // carries the article body (e.g. HN self-posts / Ask HN / Show HN, where
+  // the `text` field is the post itself and the canonical "source_url" is
+  // the HN thread page, not an external article). Plain text — strip HTML
+  // before setting.
+  bodyText?: string | null;
   // Adapter-specific raw payload preserved for replay / debugging.
   // Persisted to ingestion_candidates.raw_payload as JSONB.
   rawPayload: Record<string, unknown>;

--- a/backend/tests/ingestion/hackerNewsAdapter.test.ts
+++ b/backend/tests/ingestion/hackerNewsAdapter.test.ts
@@ -20,6 +20,7 @@ interface HnItemFixture {
   type?: string;
   title?: string;
   url?: string;
+  text?: string;
   score?: number;
   time?: number;
   dead?: boolean;
@@ -152,8 +153,14 @@ describe("hackerNewsAdapter", () => {
       expect(result.candidates).toEqual([]);
     });
 
-    it("excludes items with no url (Ask HN / Show HN with no link)", async () => {
-      mockHn({ topIds: [1], items: { 1: story(1, { url: undefined }) } });
+    it("excludes items with neither url nor text (deleted self-posts, empty markers)", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { url: undefined, text: undefined }) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it("excludes items with empty url and empty text", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1, { url: "", text: "" }) } });
       const result = await hackerNewsAdapter(makeCtx());
       expect(result.candidates).toEqual([]);
     });
@@ -168,6 +175,125 @@ describe("hackerNewsAdapter", () => {
       mockHn({ topIds: [1], items: { 1: story(1, { score: 100 }) } });
       const result = await hackerNewsAdapter(makeCtx());
       expect(result.candidates.length).toBe(1);
+    });
+  });
+
+  describe("self-posts (Ask HN / Show HN)", () => {
+    it("accepts a self-post when url is missing but text is present", async () => {
+      mockHn({
+        topIds: [42],
+        items: {
+          42: {
+            id: 42,
+            type: "story",
+            title: "Ask HN: How do you debug X?",
+            text: "<p>We've been seeing Y when we try Z.</p>",
+            score: 150,
+            time: 1714000000,
+          },
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates.length).toBe(1);
+    });
+
+    it("sets source_url to the HN thread URL for self-posts", async () => {
+      mockHn({
+        topIds: [42],
+        items: {
+          42: {
+            id: 42,
+            type: "story",
+            title: "Show HN: A small thing",
+            text: "<p>Built a small thing this weekend, here's how it works.</p>",
+            score: 200,
+            time: 1714000000,
+          },
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates[0]!.url).toBe("https://news.ycombinator.com/item?id=42");
+    });
+
+    it("passes self-post text as pre-fetched bodyText (HTML stripped)", async () => {
+      mockHn({
+        topIds: [42],
+        items: {
+          42: {
+            id: 42,
+            type: "story",
+            title: "Ask HN: Help with X",
+            text: "<p>First paragraph.</p><p>Second paragraph with <i>emphasis</i> &amp; an entity.</p>",
+            score: 150,
+            time: 1714000000,
+          },
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates[0]!.bodyText).toBe(
+        "First paragraph.\n\nSecond paragraph with emphasis & an entity.",
+      );
+    });
+
+    it("tags self-posts with is_community_post=true on rawPayload", async () => {
+      mockHn({
+        topIds: [42],
+        items: {
+          42: {
+            id: 42,
+            type: "story",
+            title: "Show HN: thing",
+            text: "<p>body</p>",
+            score: 200,
+            time: 1714000000,
+          },
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates[0]!.rawPayload.is_community_post).toBe(true);
+    });
+
+    it("respects score floor for self-posts", async () => {
+      mockHn({
+        topIds: [42],
+        items: {
+          42: {
+            id: 42,
+            type: "story",
+            title: "Ask HN",
+            text: "<p>some text</p>",
+            score: 99,
+            time: 1714000000,
+          },
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates).toEqual([]);
+    });
+
+    it("leaves external-link candidates with bodyText=null and no is_community_post flag", async () => {
+      mockHn({ topIds: [1], items: { 1: story(1) } });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates[0]!.bodyText).toBeNull();
+      expect(result.candidates[0]!.rawPayload.is_community_post).toBeUndefined();
+    });
+
+    it("treats <br> as a newline in self-post text", async () => {
+      mockHn({
+        topIds: [42],
+        items: {
+          42: {
+            id: 42,
+            type: "story",
+            title: "Ask HN",
+            text: "line one<br>line two<br/>line three",
+            score: 150,
+            time: 1714000000,
+          },
+        },
+      });
+      const result = await hackerNewsAdapter(makeCtx());
+      expect(result.candidates[0]!.bodyText).toBe("line one\nline two\nline three");
     });
   });
 

--- a/backend/tests/ingestion/heuristicSeam.test.ts
+++ b/backend/tests/ingestion/heuristicSeam.test.ts
@@ -10,6 +10,19 @@ jest.mock("../../src/db", () => ({
   },
 }));
 
+// Stub bodyExtractor so loading heuristicSeam does not pull in jsdom.
+// The seam tests inject their own `fetchBody`, so the real module's
+// fetchAndExtractBody is never invoked here. Mocking it out keeps
+// parse5's ESM-only entry from breaking the suite under jest-cjs.
+// DEFAULT_BODY_USER_AGENT is mirrored verbatim because the
+// "uses default UA when source.config.userAgent is unset" test below
+// asserts this exact string.
+jest.mock("../../src/jobs/ingestion/bodyExtractor", () => ({
+  fetchAndExtractBody: jest.fn(),
+  DEFAULT_BODY_USER_AGENT: "SIGNAL/12e.3 (+contact@signal.so)",
+  DEFAULT_BODY_TIMEOUT_MS: 15_000,
+}));
+
 // Import after mock so module bindings resolve to mocked db.
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const { runHeuristicSeam } = require("../../src/jobs/ingestion/heuristicSeam");
@@ -186,6 +199,36 @@ describe("runHeuristicSeam", () => {
       const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
       expect(result.pass).toBe(true);
       expect(result.body?.truncated).toBe(true);
+    });
+  });
+
+  describe("pre-fetched body (adapter-supplied bodyText)", () => {
+    it("skips fetchBody and passes when pre-fetched body meets length floor", async () => {
+      const preFetched = "y".repeat(800);
+      mock.queueSelect([makeRow({ bodyText: preFetched })]);
+      const fetchBody = fetchOk("should not be called");
+      const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
+      expect(fetchBody).not.toHaveBeenCalled();
+      expect(result.pass).toBe(true);
+      expect(result.body?.text).toBe(preFetched);
+      expect(result.body?.truncated).toBe(false);
+    });
+
+    it("skips fetchBody and rejects when pre-fetched body is below length floor", async () => {
+      mock.queueSelect([makeRow({ bodyText: "too short" })]);
+      const fetchBody = fetchOk("should not be called");
+      const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
+      expect(fetchBody).not.toHaveBeenCalled();
+      expect(result.pass).toBe(false);
+      expect(result.reason).toBe(HEURISTIC_REASONS.BODY_TOO_SHORT);
+    });
+
+    it("falls through to fetchBody when bodyText is empty string", async () => {
+      mock.queueSelect([makeRow({ bodyText: "" })]);
+      const fetchBody = fetchOk("z".repeat(800));
+      const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
+      expect(fetchBody).toHaveBeenCalledTimes(1);
+      expect(result.pass).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- HN adapter now accepts Show HN / Ask HN posts (no external `url`). Source URL becomes the HN thread (`item?id=<id>`); the post's `text` field is stripped to plain text and passed downstream as pre-fetched body so the enrichment pipeline doesn't scrape the HN thread chrome.
- New optional `Candidate.bodyText` field — adapter-supplied body persisted into `ingestion_candidates.body_text`. The heuristic seam short-circuits the URL fetch when the row already has body text, then runs the same length-floor check.
- Score floor (>=100), top-150 cap, batched concurrency, and the downstream relevance gate + clustering paths are unchanged. Self-posts go through the same pipeline as any other source.

## What's tagged

`rawPayload.is_community_post = true` on self-posts, for future surface-level treatment / debugging. No UI changes.

## Test plan

- [x] `npm run type-check --workspace=backend` — clean
- [x] `npm run lint --workspace=backend` — clean
- [x] `npm test --workspace=backend` — **1022 passing** (was 992 at branch baseline); +30 net
- [x] HN adapter tests: 7 new self-post cases (accept, thread URL, HTML stripped, `is_community_post` flag, score floor enforced for self-posts, external-link regression, `<br>` handling) + neither-url-nor-text drop case
- [x] Heuristic seam tests: 3 new pre-fetched-body cases (skip fetch + pass, skip fetch + reject when too short, fall through to fetch when bodyText is empty string)

## Pre-existing test infra note

The seam test file was blocked at baseline because loading `heuristicSeam.ts` transitively imports `jsdom` → `parse5` (ESM-only entry), and the project's jest config only maps `@exodus/bytes` (the `ea2df57` jsdom fix). I added a one-line `jest.mock("../../src/jobs/ingestion/bodyExtractor", …)` to unblock the suite — the file injects its own `fetchBody` so the real module load was never needed. The same root cause still blocks `htmlStrip.test.ts`, `rssAdapter.test.ts`, and `bodyExtractor.test.ts` at baseline; those need a `moduleNameMapper` stub for `parse5` in a separate cleanup pass, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)