### PR TITLE
feat: OG image thumbnails on feed cards and story detail

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "run-ingestion-poll": "ts-node src/scripts/runIngestionPoll.ts",
     "regenerate-depth-variants": "ts-node src/scripts/regenerateDepthVariants.ts",
     "backfill-generic-commentary": "ts-node src/scripts/backfillGenericCommentary.ts",
+    "backfill-og-images": "ts-node src/scripts/backfillOgImages.ts",
     "fix-broken-sources": "ts-node src/scripts/fixBrokenSources.ts",
     "smoke": "ts-node src/scripts/smokeTest.ts"
   },

--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -74,6 +74,7 @@ interface StoryRow {
   genericCommentary: string | null;
   sourceUrl: string;
   sourceName: string | null;
+  imageUrl: string | null;
   publishedAt: Date | null;
   createdAt: Date;
   authorId: string | null;
@@ -124,6 +125,9 @@ function shapeStory(row: StoryRow, role: string | null): Record<string, unknown>
     sources: [
       { url: row.sourceUrl, name: row.sourceName, role: "primary" as const },
     ],
+    // Phase 12k — og:image URL or null. Null is the no-image path;
+    // frontend renders no thumbnail / hero in that case.
+    image_url: row.imageUrl,
     published_at: row.publishedAt,
     created_at: row.createdAt,
     author: row.authorId
@@ -150,6 +154,7 @@ interface EventRow {
   genericCommentary: string | null;
   primarySourceUrl: string;
   primarySourceName: string | null;
+  imageUrl: string | null;
   publishedAt: Date | null;
   createdAt: Date;
   authorId: string | null;
@@ -197,6 +202,8 @@ function shapeEvent(
     source_name: row.primarySourceName,
     primary_source_url: row.primarySourceUrl,
     sources,
+    // Phase 12k — see shapeStory: null when no og:image was found.
+    image_url: row.imageUrl,
     published_at: row.publishedAt,
     created_at: row.createdAt,
     author: row.authorId
@@ -385,6 +392,7 @@ const baseStoryColumns = {
   genericCommentary: stories.genericCommentary,
   sourceUrl: stories.sourceUrl,
   sourceName: stories.sourceName,
+  imageUrl: stories.imageUrl,
   publishedAt: stories.publishedAt,
   createdAt: stories.createdAt,
   authorId: writers.id,
@@ -497,6 +505,7 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
         genericCommentary: events.genericCommentary,
         primarySourceUrl: events.primarySourceUrl,
         primarySourceName: events.primarySourceName,
+        imageUrl: events.imageUrl,
         publishedAt: events.publishedAt,
         createdAt: events.createdAt,
         authorId: writers.id,
@@ -703,6 +712,7 @@ export async function getStoryById(
           whyItMattersTemplate: events.whyItMattersTemplate,
           primarySourceUrl: events.primarySourceUrl,
           primarySourceName: events.primarySourceName,
+          imageUrl: events.imageUrl,
           publishedAt: events.publishedAt,
           createdAt: events.createdAt,
           authorId: writers.id,

--- a/backend/src/db/migrations/0033_phase12k_image_url.sql
+++ b/backend/src/db/migrations/0033_phase12k_image_url.sql
@@ -1,0 +1,22 @@
+-- Phase 12k — Open Graph image URLs on stories and events.
+-- Two columns added: `stories.image_url` and `events.image_url`. Plain
+-- TEXT, nullable.
+--
+-- Source of truth at write time:
+--   - events: extracted from the source HTML during the enrichment body
+--     fetch (no extra HTTP request — same fetch that feeds readability).
+--     The bodyExtractor reads <meta property="og:image"> and falls back
+--     to <meta name="twitter:image">. Persisted on `ingestion_candidates`
+--     during the heuristic stage, then carried into `events.image_url`
+--     by writeEvent.
+--   - stories: hand-curated content from Phase 4.5. Backfilled by
+--     `npm run backfill-og-images` (refetches the source URL, runs the
+--     same extractor).
+--
+-- Existing rows are NULL until backfill / next enrichment run. The
+-- read-side branch on the frontend renders a thumbnail only when the
+-- column is non-null; NULL is the no-image path (no placeholder).
+
+ALTER TABLE "stories" ADD COLUMN IF NOT EXISTS "image_url" text;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "image_url" text;--> statement-breakpoint
+ALTER TABLE "ingestion_candidates" ADD COLUMN IF NOT EXISTS "image_url" text;

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -261,6 +261,11 @@ export const stories = pgTable(
     sourceName: varchar("source_name", { length: 255 }),
     authorId: uuid("author_id").references(() => writers.id, { onDelete: "set null" }),
     publishedAt: timestamp("published_at", { withTimezone: true }),
+    // Phase 12k — og:image URL extracted from the source page during
+    // enrichment (or backfilled for legacy curated rows). Null when the
+    // source page didn't carry an og:image / twitter:image meta tag —
+    // the frontend renders no thumbnail in that case (no placeholder).
+    imageUrl: text("image_url"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -638,6 +643,10 @@ export const events = pgTable(
     facts: jsonb("facts").$type<Record<string, unknown>>().notNull().default({}),
     embedding: vector("embedding", { dimensions: 1536 }),
     publishedAt: timestamp("published_at", { withTimezone: true }),
+    // Phase 12k — og:image URL from the primary source page, populated
+    // by writeEvent from the candidate row. Null when extraction failed
+    // or the page didn't carry one.
+    imageUrl: text("image_url"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -715,6 +724,12 @@ export const ingestionCandidates = pgTable(
     // jobs/ingestion/enrichmentRecovery.ts owns these reads + writes.
     recoveryAttempts: integer("recovery_attempts").notNull().default(0),
     enrichmentFailed: boolean("enrichment_failed").notNull().default(false),
+    // Phase 12k — og:image URL extracted alongside body text during the
+    // heuristic stage. Persisted here and carried into events.image_url
+    // by writeEvent. Null when the page didn't carry an og:image /
+    // twitter:image meta tag or extraction failed (extraction is soft —
+    // never blocks the candidate).
+    imageUrl: text("image_url"),
   },
   (t) => ({
     sourceExternalIdUnique: unique("ingestion_candidates_source_external_id_key").on(

--- a/backend/src/jobs/ingestion/bodyExtractor.ts
+++ b/backend/src/jobs/ingestion/bodyExtractor.ts
@@ -50,8 +50,62 @@ export function detectPaywall(rawUrl: string, html: string): boolean {
 }
 
 export type BodyExtractionResult =
-  | { success: true; text: string; truncated: boolean }
+  | { success: true; text: string; truncated: boolean; imageUrl: string | null }
   | { success: false; reason: HeuristicReason };
+
+// Phase 12k — extract the page's og:image (or twitter:image fallback)
+// from the parsed HTML. Returns null when:
+//   - neither meta tag is present
+//   - the content attribute is missing / empty
+//   - the URL is malformed
+//   - the URL is not http(s) (e.g. data: URI, javascript:, file:, etc.)
+//
+// Resolved against `baseUrl` so relative `og:image` paths (rare but
+// they happen) become absolute. Soft-fail discipline: any DOM parse
+// problem returns null, never throws. The caller treats null as "no
+// image" — not an error condition.
+export function extractOgImage(
+  document: Document,
+  baseUrl: string,
+): string | null {
+  const candidates: ReadonlyArray<{ selector: string }> = [
+    { selector: 'meta[property="og:image"]' },
+    { selector: 'meta[property="og:image:url"]' },
+    { selector: 'meta[name="twitter:image"]' },
+    { selector: 'meta[name="twitter:image:src"]' },
+  ];
+  for (const { selector } of candidates) {
+    const el = document.querySelector(selector);
+    if (!el) continue;
+    const raw = el.getAttribute("content");
+    if (!raw) continue;
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    // Reject data: / javascript: / file: / mailto: outright before
+    // attempting URL resolution — `new URL('data:...')` succeeds, so we
+    // can't rely on the constructor alone to enforce http(s).
+    const lower = trimmed.toLowerCase();
+    if (
+      lower.startsWith("data:") ||
+      lower.startsWith("javascript:") ||
+      lower.startsWith("file:") ||
+      lower.startsWith("mailto:")
+    ) {
+      continue;
+    }
+    let resolved: URL;
+    try {
+      resolved = new URL(trimmed, baseUrl);
+    } catch {
+      continue;
+    }
+    if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+      continue;
+    }
+    return resolved.toString();
+  }
+  return null;
+}
 
 export interface FetchAndExtractOptions {
   userAgent: string;
@@ -125,10 +179,17 @@ export async function fetchAndExtractBody(
     return { success: false, reason: HEURISTIC_REASONS.FILTERED_PAYWALL };
   }
 
-  // Parse with jsdom and run readability.
+  // Parse with jsdom and run readability. The same parsed document also
+  // feeds the og:image extractor — single DOM parse, two consumers.
   let textContent: string;
+  let imageUrl: string | null = null;
   try {
     const dom = new JSDOM(html, { url });
+    // Pull og:image first — readability's parse() can mutate document
+    // structure (or, on some pages, throw). Doing meta-tag extraction
+    // before readability isolates the cheap, reliable pass from the
+    // expensive, occasionally-fragile one.
+    imageUrl = extractOgImage(dom.window.document, url);
     const article = new Readability(dom.window.document).parse();
     if (!article || typeof article.textContent !== "string") {
       return { success: false, reason: HEURISTIC_REASONS.BODY_PARSE_ERROR };
@@ -143,7 +204,8 @@ export async function fetchAndExtractBody(
       success: true,
       text: textContent.slice(0, BODY_SIZE_CAP_BYTES),
       truncated: true,
+      imageUrl,
     };
   }
-  return { success: true, text: textContent, truncated: false };
+  return { success: true, text: textContent, truncated: false, imageUrl };
 }

--- a/backend/src/jobs/ingestion/enrichmentJob.ts
+++ b/backend/src/jobs/ingestion/enrichmentJob.ts
@@ -86,7 +86,11 @@ export interface EnrichmentSeams {
   runHeuristic?: (candidateId: string) => Promise<{
     pass: boolean;
     reason?: HeuristicReason;
-    body?: { text: string; truncated: boolean };
+    // Phase 12k: `imageUrl` on the body shape is optional so existing
+    // test fixtures (and the real seam shape) can omit it when no
+    // og:image was extracted — treated as null downstream. The real
+    // seam always populates it (string or null) from the body fetch.
+    body?: { text: string; truncated: boolean; imageUrl?: string | null };
   }>;
   runRelevanceGate?: (
     candidateId: string,
@@ -339,12 +343,19 @@ export async function processEnrichmentJob(
       processedAt: Date;
       bodyText?: string;
       statusReason?: string;
+      imageUrl?: string | null;
     } = {
       status: "heuristic_passed",
       processedAt: new Date(),
     };
     if (result.body) {
       updates.bodyText = result.body.text;
+      // Phase 12k — og:image extracted from the same fetch; nullable
+      // and never blocks the candidate. Coalesce undefined → null so
+      // a seam that omits the field doesn't leave the column at its
+      // prior value (UPDATE … SET image_url = NULL is the explicit
+      // "we ran, found nothing" signal).
+      updates.imageUrl = result.body.imageUrl ?? null;
       if (result.body.truncated) {
         updates.statusReason = HEURISTIC_REASONS.BODY_TRUNCATED;
       }

--- a/backend/src/jobs/ingestion/heuristicSeam.ts
+++ b/backend/src/jobs/ingestion/heuristicSeam.ts
@@ -36,7 +36,7 @@ import {
 export type HeuristicSeamResult = {
   pass: boolean;
   reason?: HeuristicReason;
-  body?: { text: string; truncated: boolean };
+  body?: { text: string; truncated: boolean; imageUrl: string | null };
 };
 
 export interface HeuristicSeamDeps {
@@ -148,6 +148,10 @@ export async function runHeuristicSeam(
 
   return {
     pass: true,
-    body: { text: fetchResult.text, truncated: fetchResult.truncated },
+    body: {
+      text: fetchResult.text,
+      truncated: fetchResult.truncated,
+      imageUrl: fetchResult.imageUrl,
+    },
   };
 }

--- a/backend/src/jobs/ingestion/reenrichEvent.ts
+++ b/backend/src/jobs/ingestion/reenrichEvent.ts
@@ -189,6 +189,7 @@ export async function reenrichEvent(
     facts: refreshed.facts,
     tierOutputs: refreshed.tierOutputs,
     embedding: null,
+    imageUrl: null,
     sourceDisplayName: "",
     sourcePairedWriterId: null,
   };

--- a/backend/src/jobs/ingestion/writeEvent.ts
+++ b/backend/src/jobs/ingestion/writeEvent.ts
@@ -155,6 +155,7 @@ export interface CandidateRowForWrite {
   facts: Record<string, unknown> | null;
   tierOutputs: Record<string, unknown> | null;
   embedding: number[] | null;
+  imageUrl: string | null;
   sourceDisplayName: string;
   sourcePairedWriterId: string | null;
 }
@@ -176,6 +177,7 @@ async function loadCandidateForWrite(
       facts: ingestionCandidates.facts,
       tierOutputs: ingestionCandidates.tierOutputs,
       embedding: ingestionCandidates.embedding,
+      imageUrl: ingestionCandidates.imageUrl,
       sourceDisplayName: ingestionSources.displayName,
       sourcePairedWriterId: ingestionSources.pairedWriterId,
     })
@@ -347,6 +349,7 @@ async function writeEventOnce(
         facts: factsBlob,
         publishedAt: candidate.rawPublishedAt,
         embedding: candidate.embedding,
+        imageUrl: candidate.imageUrl,
       })
       .returning({ id: events.id });
 

--- a/backend/src/scripts/backfillOgImages.ts
+++ b/backend/src/scripts/backfillOgImages.ts
@@ -1,0 +1,242 @@
+// Phase 12k — backfill stories.image_url and events.image_url for rows
+// that landed before the og:image extractor was wired into the
+// enrichment body fetch.
+//
+// Strategy: refetch each row's source URL (stories.source_url /
+// events.primary_source_url) and run the same `extractOgImage` helper
+// the live pipeline uses against the parsed HTML. Two flavors of work
+// share one tight rate limiter so we don't accidentally double-rate
+// against a single host across the two tables.
+//
+// Idempotency: only touches rows where image_url IS NULL. Re-runs are
+// safe; if the process is interrupted (Ctrl-C, broken pipe), restarting
+// resumes exactly where it left off because completed rows are no
+// longer NULL.
+//
+// Politeness: 2 requests per second across the whole run (one row every
+// 500ms). 15s per-request timeout (matches DEFAULT_BODY_TIMEOUT_MS in
+// bodyExtractor.ts so this script can't out-trust the live pipeline).
+//
+// Progress: a one-line log every 50 rows with running counts.
+//
+// CLI:
+//   npm run backfill-og-images
+//   npm run backfill-og-images -- --dry-run
+//   npm run backfill-og-images -- --table=stories
+//   npm run backfill-og-images -- --table=events
+
+import "dotenv/config";
+import { JSDOM } from "jsdom";
+import { eq, isNull } from "drizzle-orm";
+
+import { db } from "../db";
+import { events, stories } from "../db/schema";
+import {
+  DEFAULT_BODY_USER_AGENT,
+  DEFAULT_BODY_TIMEOUT_MS,
+  extractOgImage,
+} from "../jobs/ingestion/bodyExtractor";
+
+const RATE_LIMIT_MS = 500;
+const LOG_EVERY = 50;
+
+interface Args {
+  dryRun: boolean;
+  table: "stories" | "events" | "both";
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const dryRun = argv.includes("--dry-run");
+  let table: Args["table"] = "both";
+  for (const arg of argv) {
+    if (arg === "--table=stories") table = "stories";
+    else if (arg === "--table=events") table = "events";
+    else if (arg === "--table=both") table = "both";
+  }
+  return { dryRun, table };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface FetchOgImageResult {
+  imageUrl: string | null;
+  reason: "ok" | "no_meta" | "fetch_error" | "wrong_content_type" | "parse_error";
+}
+
+// Self-contained og:image fetch. Mirrors the bodyExtractor fetch shape
+// (User-Agent, timeout, content-type gate, JSDOM parse) but skips the
+// readability pass — we only need the meta tag. Keeping it inline
+// avoids dragging in the readability dependency, paywall detection, and
+// body-size logic for a backfill that only cares about one tag.
+async function fetchOgImage(url: string): Promise<FetchOgImageResult> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), DEFAULT_BODY_TIMEOUT_MS);
+  let res: Response;
+  try {
+    try {
+      res = await fetch(url, {
+        headers: {
+          "User-Agent": DEFAULT_BODY_USER_AGENT,
+          Accept: "text/html, */*;q=0.5",
+        },
+        signal: ctrl.signal,
+      });
+    } catch {
+      return { imageUrl: null, reason: "fetch_error" };
+    }
+    if (res.status < 200 || res.status >= 300) {
+      try {
+        await res.text();
+      } catch {
+        /* ignore */
+      }
+      return { imageUrl: null, reason: "fetch_error" };
+    }
+    const contentType =
+      res.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() ?? "";
+    if (contentType !== "text/html") {
+      try {
+        await res.text();
+      } catch {
+        /* ignore */
+      }
+      return { imageUrl: null, reason: "wrong_content_type" };
+    }
+    let html: string;
+    try {
+      html = await res.text();
+    } catch {
+      return { imageUrl: null, reason: "fetch_error" };
+    }
+    let imageUrl: string | null;
+    try {
+      const dom = new JSDOM(html, { url });
+      imageUrl = extractOgImage(dom.window.document, url);
+    } catch {
+      return { imageUrl: null, reason: "parse_error" };
+    }
+    return { imageUrl, reason: imageUrl ? "ok" : "no_meta" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface BackfillStats {
+  scanned: number;
+  updated: number;
+  noImage: number;
+  errors: number;
+}
+
+function logProgress(
+  label: string,
+  index: number,
+  total: number,
+  stats: BackfillStats,
+): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[backfill-og-images][${label}] ${index}/${total} scanned=${stats.scanned} updated=${stats.updated} noImage=${stats.noImage} errors=${stats.errors}`,
+  );
+}
+
+async function backfillStoriesTable(dryRun: boolean): Promise<BackfillStats> {
+  const stats: BackfillStats = { scanned: 0, updated: 0, noImage: 0, errors: 0 };
+  const rows = await db
+    .select({ id: stories.id, sourceUrl: stories.sourceUrl })
+    .from(stories)
+    .where(isNull(stories.imageUrl));
+  const total = rows.length;
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    stats.scanned += 1;
+    const result = await fetchOgImage(row.sourceUrl);
+    if (result.reason === "ok" && result.imageUrl) {
+      if (!dryRun) {
+        await db
+          .update(stories)
+          .set({ imageUrl: result.imageUrl })
+          .where(eq(stories.id, row.id));
+      }
+      stats.updated += 1;
+    } else if (result.reason === "no_meta") {
+      stats.noImage += 1;
+    } else {
+      stats.errors += 1;
+    }
+    if (stats.scanned % LOG_EVERY === 0) {
+      logProgress("stories", i + 1, total, stats);
+    }
+    if (i < rows.length - 1) await sleep(RATE_LIMIT_MS);
+  }
+  logProgress("stories", total, total, stats);
+  return stats;
+}
+
+async function backfillEventsTable(dryRun: boolean): Promise<BackfillStats> {
+  const stats: BackfillStats = { scanned: 0, updated: 0, noImage: 0, errors: 0 };
+  const rows = await db
+    .select({ id: events.id, primarySourceUrl: events.primarySourceUrl })
+    .from(events)
+    .where(isNull(events.imageUrl));
+  const total = rows.length;
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    stats.scanned += 1;
+    const result = await fetchOgImage(row.primarySourceUrl);
+    if (result.reason === "ok" && result.imageUrl) {
+      if (!dryRun) {
+        await db
+          .update(events)
+          .set({ imageUrl: result.imageUrl })
+          .where(eq(events.id, row.id));
+      }
+      stats.updated += 1;
+    } else if (result.reason === "no_meta") {
+      stats.noImage += 1;
+    } else {
+      stats.errors += 1;
+    }
+    if (stats.scanned % LOG_EVERY === 0) {
+      logProgress("events", i + 1, total, stats);
+    }
+    if (i < rows.length - 1) await sleep(RATE_LIMIT_MS);
+  }
+  logProgress("events", total, total, stats);
+  return stats;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  // eslint-disable-next-line no-console
+  console.log(
+    `[backfill-og-images] table=${args.table} dryRun=${args.dryRun} rate=2req/s`,
+  );
+
+  if (args.table === "stories" || args.table === "both") {
+    const s = await backfillStoriesTable(args.dryRun);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[backfill-og-images][stories] DONE scanned=${s.scanned} updated=${s.updated} noImage=${s.noImage} errors=${s.errors}`,
+    );
+  }
+  if (args.table === "events" || args.table === "both") {
+    const e = await backfillEventsTable(args.dryRun);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[backfill-og-images][events]  DONE scanned=${e.scanned} updated=${e.updated} noImage=${e.noImage} errors=${e.errors}`,
+    );
+  }
+
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("[backfill-og-images] FAILED", err);
+    process.exit(1);
+  });
+}

--- a/backend/tests/ingestion/bodyExtractor.test.ts
+++ b/backend/tests/ingestion/bodyExtractor.test.ts
@@ -260,4 +260,101 @@ describe("fetchAndExtractBody", () => {
       });
     });
   });
+
+  describe("og:image extraction (12k)", () => {
+    it("populates imageUrl from <meta property=\"og:image\">", async () => {
+      const html =
+        '<!doctype html><html><head>' +
+        '<meta property="og:image" content="https://cdn.example.com/og.jpg">' +
+        '</head><body><article><h1>X</h1><p>' +
+        "lorem ipsum ".repeat(200) +
+        "</p></article></body></html>";
+      mockHtml(html);
+      const result = await fetchAndExtractBody("https://example.com/a", {
+        userAgent: DEFAULT_BODY_USER_AGENT,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.imageUrl).toBe("https://cdn.example.com/og.jpg");
+    });
+
+    it("falls back to twitter:image when og:image is absent", async () => {
+      const html =
+        '<!doctype html><html><head>' +
+        '<meta name="twitter:image" content="https://cdn.example.com/tw.png">' +
+        '</head><body><article><h1>X</h1><p>' +
+        "lorem ipsum ".repeat(200) +
+        "</p></article></body></html>";
+      mockHtml(html);
+      const result = await fetchAndExtractBody("https://example.com/a", {
+        userAgent: DEFAULT_BODY_USER_AGENT,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.imageUrl).toBe("https://cdn.example.com/tw.png");
+    });
+
+    it("returns imageUrl=null when neither meta tag is present (no error)", async () => {
+      const html =
+        '<!doctype html><html><body><article><h1>X</h1><p>' +
+        "lorem ipsum ".repeat(200) +
+        "</p></article></body></html>";
+      mockHtml(html);
+      const result = await fetchAndExtractBody("https://example.com/a", {
+        userAgent: DEFAULT_BODY_USER_AGENT,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.imageUrl).toBeNull();
+    });
+
+    it("resolves a relative og:image against the page URL", async () => {
+      const html =
+        '<!doctype html><html><head>' +
+        '<meta property="og:image" content="/static/og.jpg">' +
+        '</head><body><article><h1>X</h1><p>' +
+        "lorem ipsum ".repeat(200) +
+        "</p></article></body></html>";
+      mockHtml(html);
+      const result = await fetchAndExtractBody("https://example.com/path/article", {
+        userAgent: DEFAULT_BODY_USER_AGENT,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.imageUrl).toBe("https://example.com/static/og.jpg");
+    });
+
+    it("rejects a data: URI og:image and returns null", async () => {
+      const html =
+        '<!doctype html><html><head>' +
+        '<meta property="og:image" content="data:image/png;base64,iVBOR">' +
+        '</head><body><article><h1>X</h1><p>' +
+        "lorem ipsum ".repeat(200) +
+        "</p></article></body></html>";
+      mockHtml(html);
+      const result = await fetchAndExtractBody("https://example.com/a", {
+        userAgent: DEFAULT_BODY_USER_AGENT,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.imageUrl).toBeNull();
+    });
+
+    it("prefers og:image when both og:image and twitter:image are present", async () => {
+      const html =
+        '<!doctype html><html><head>' +
+        '<meta property="og:image" content="https://cdn.example.com/og.jpg">' +
+        '<meta name="twitter:image" content="https://cdn.example.com/tw.png">' +
+        '</head><body><article><h1>X</h1><p>' +
+        "lorem ipsum ".repeat(200) +
+        "</p></article></body></html>";
+      mockHtml(html);
+      const result = await fetchAndExtractBody("https://example.com/a", {
+        userAgent: DEFAULT_BODY_USER_AGENT,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.imageUrl).toBe("https://cdn.example.com/og.jpg");
+    });
+  });
 });

--- a/backend/tests/ingestion/heuristicSeam.test.ts
+++ b/backend/tests/ingestion/heuristicSeam.test.ts
@@ -28,11 +28,16 @@ function makeRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function fetchOk(text: string, truncated = false): jest.Mock {
+function fetchOk(
+  text: string,
+  truncated = false,
+  imageUrl: string | null = null,
+): jest.Mock {
   return jest.fn().mockResolvedValue({
     success: true,
     text,
     truncated,
+    imageUrl,
   } satisfies BodyExtractionResult);
 }
 
@@ -186,6 +191,24 @@ describe("runHeuristicSeam", () => {
       const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
       expect(result.pass).toBe(true);
       expect(result.body?.truncated).toBe(true);
+    });
+
+    it("propagates imageUrl from fetchBody onto the body shape (12k)", async () => {
+      mock.queueSelect([makeRow()]);
+      const longBody = "x".repeat(800);
+      const fetchBody = fetchOk(longBody, false, "https://cdn.example.com/og.jpg");
+      const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
+      expect(result.pass).toBe(true);
+      expect(result.body?.imageUrl).toBe("https://cdn.example.com/og.jpg");
+    });
+
+    it("propagates imageUrl=null when fetchBody found no og:image (12k)", async () => {
+      mock.queueSelect([makeRow()]);
+      const longBody = "x".repeat(800);
+      const fetchBody = fetchOk(longBody, false, null);
+      const result = await runHeuristicSeam(CANDIDATE_ID, { fetchBody });
+      expect(result.pass).toBe(true);
+      expect(result.body?.imageUrl).toBeNull();
     });
   });
 

--- a/backend/tests/ingestion/writeEvent.test.ts
+++ b/backend/tests/ingestion/writeEvent.test.ts
@@ -48,6 +48,7 @@ function fullCandidate(
       },
     },
     embedding: [0.1, 0.2, 0.3],
+    imageUrl: null,
     sourceDisplayName: "Example Source",
     sourcePairedWriterId: WRITER_ID,
     ...overrides,

--- a/frontend/src/components/stories/StoryCard.test.tsx
+++ b/frontend/src/components/stories/StoryCard.test.tsx
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Story } from "@/types/story";
+
+// Phase 12k — the card lazy-loads commentary via IntersectionObserver.
+// In jsdom that observer isn't available, so the hook never fires the
+// effect that depends on `shouldLoad`. Mock the hook to a stable idle
+// state so the render path is deterministic — we're testing the
+// thumbnail slot, not the commentary pipeline.
+vi.mock("@/hooks/useStoryCommentary", () => ({
+  useStoryCommentary: () => ({
+    data: undefined,
+    isFetching: false,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useStorySave", () => ({
+  useStorySave: () => ({
+    isSaved: false,
+    toggleSave: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (
+    props: React.ImgHTMLAttributes<HTMLImageElement> & {
+      src: string;
+      alt: string;
+    },
+  ) => {
+    // next/image renders an <img> under the hood with the same src/alt;
+    // stubbing it directly keeps the assertions on real DOM nodes
+    // without dragging Next's runtime image optimizer into jsdom.
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  },
+}));
+
+import { StoryCard } from "./StoryCard";
+
+function baseStory(overrides: Partial<Story> = {}): Story {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    sector: "ai",
+    headline: "Test headline",
+    context: "Test context",
+    why_it_matters: "Why it matters body.",
+    gated: false,
+    why_it_matters_to_you: "Why it matters to you body.",
+    commentary: null,
+    commentary_source: null,
+    source_url: "https://example.com/article",
+    source_name: "Example",
+    primary_source_url: "https://example.com/article",
+    sources: [
+      { url: "https://example.com/article", name: "Example", role: "primary" },
+    ],
+    image_url: null,
+    published_at: "2026-05-10T00:00:00Z",
+    created_at: "2026-05-10T00:00:00Z",
+    author: null,
+    is_saved: false,
+    save_count: 0,
+    comment_count: 0,
+    ...overrides,
+  };
+}
+
+function renderCard(story: Story): { container: HTMLElement } {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<StoryCard story={story} />, { wrapper: Wrapper });
+}
+
+describe("StoryCard og:image thumbnail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the thumbnail when story.image_url is non-null", () => {
+    const { container } = renderCard(
+      baseStory({ image_url: "https://cdn.example.com/og.jpg" }),
+    );
+    // Use querySelector — the thumbnail is decorative (alt=""), so it
+    // has no "img" ARIA role and getByRole("img") wouldn't find it.
+    const img = container.querySelector("img[src=\"https://cdn.example.com/og.jpg\"]");
+    expect(img).not.toBeNull();
+  });
+
+  it("does not render any img element when story.image_url is null", () => {
+    const { container } = renderCard(baseStory({ image_url: null }));
+    // The card has no other <img> elements when image_url is null —
+    // the SaveButton uses lucide-react SVGs, not raster images, and
+    // the SectorBadge is text.
+    const imgs = container.querySelectorAll("img");
+    expect(imgs.length).toBe(0);
+  });
+});

--- a/frontend/src/components/stories/StoryCard.tsx
+++ b/frontend/src/components/stories/StoryCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { MessageSquare } from "lucide-react";
 import { SectorBadge } from "./SectorBadge";
@@ -110,25 +111,45 @@ export function StoryCard({ story, index = 0 }: StoryCardProps): JSX.Element {
       style={{ animationDelay: staggerDelay }}
     >
       <Link href={`/stories/${story.id}`} className="group block hover:no-underline">
-        <h2 className="mb-1 font-display text-[20px] font-semibold leading-snug text-ink transition-colors duration-150 group-hover:text-accent">
-          {story.headline}
-        </h2>
-        {sourceLabel && (
-          <p className="mb-3 text-xs text-ink-muted">{sourceLabel}</p>
-        )}
-        <p
-          className="mb-4 text-sm leading-relaxed text-ink-muted"
-          style={{
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
-          }}
-        >
-          {isCommentaryLoading
-            ? "Generating your briefing…"
-            : primaryParagraph(previewText)}
-        </p>
+        {/* Phase 12k — right-aligned supplemental thumbnail. The headline +
+            commentary stay primary; thumbnail is rendered to the right at
+            a fixed compact size. When story.image_url is null, no slot is
+            reserved (the card lays out exactly as it did pre-12k). */}
+        <div className="flex items-start gap-4">
+          <div className="min-w-0 flex-1">
+            <h2 className="mb-1 font-display text-[20px] font-semibold leading-snug text-ink transition-colors duration-150 group-hover:text-accent">
+              {story.headline}
+            </h2>
+            {sourceLabel && (
+              <p className="mb-3 text-xs text-ink-muted">{sourceLabel}</p>
+            )}
+            <p
+              className="mb-4 text-sm leading-relaxed text-ink-muted"
+              style={{
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {isCommentaryLoading
+                ? "Generating your briefing…"
+                : primaryParagraph(previewText)}
+            </p>
+          </div>
+          {story.image_url && (
+            <Image
+              src={story.image_url}
+              alt=""
+              width={120}
+              height={80}
+              unoptimized
+              loading="lazy"
+              className="flex-none rounded-md object-cover"
+              style={{ width: 120, height: 80 }}
+            />
+          )}
+        </div>
       </Link>
 
       <div className="flex items-center justify-between gap-3 text-xs text-ink-muted">

--- a/frontend/src/components/stories/StoryDetail.test.tsx
+++ b/frontend/src/components/stories/StoryDetail.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Story } from "@/types/story";
+
+vi.mock("@/hooks/useStoryCommentary", () => ({
+  useStoryCommentary: () => ({
+    data: undefined,
+    isFetching: false,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useStorySave", () => ({
+  useStorySave: () => ({
+    isSaved: false,
+    toggleSave: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/useTier", () => ({
+  useTier: () => ({ data: { tier: "pro", trial_available: false } }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (
+    props: React.ImgHTMLAttributes<HTMLImageElement> & {
+      src: string;
+      alt: string;
+    },
+  ) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  },
+}));
+
+import { StoryDetail } from "./StoryDetail";
+
+function baseStory(overrides: Partial<Story> = {}): Story {
+  return {
+    id: "22222222-2222-2222-2222-222222222222",
+    sector: "ai",
+    headline: "Detail headline",
+    context: "<p>Detail context body.</p>",
+    why_it_matters: "Why it matters body.",
+    gated: false,
+    why_it_matters_to_you: "Why it matters to you body.",
+    commentary: null,
+    commentary_source: null,
+    source_url: "https://example.com/article",
+    source_name: "Example",
+    primary_source_url: "https://example.com/article",
+    sources: [
+      { url: "https://example.com/article", name: "Example", role: "primary" },
+    ],
+    image_url: null,
+    published_at: "2026-05-10T00:00:00Z",
+    created_at: "2026-05-10T00:00:00Z",
+    author: null,
+    is_saved: false,
+    save_count: 0,
+    comment_count: 0,
+    ...overrides,
+  };
+}
+
+function renderDetail(story: Story): { container: HTMLElement } {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<StoryDetail story={story} />, { wrapper: Wrapper });
+}
+
+describe("StoryDetail og:image hero", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the hero when story.image_url is non-null", () => {
+    const { container } = renderDetail(
+      baseStory({ image_url: "https://cdn.example.com/hero.jpg" }),
+    );
+    // Decorative alt="" → no ARIA img role; query via DOM directly.
+    const img = container.querySelector(
+      "img[src=\"https://cdn.example.com/hero.jpg\"]",
+    );
+    expect(img).not.toBeNull();
+  });
+
+  it("does not render an img element when story.image_url is null", () => {
+    const { container } = renderDetail(baseStory({ image_url: null }));
+    // Detail has no other <img> elements when image_url is null.
+    const imgs = container.querySelectorAll("img");
+    expect(imgs.length).toBe(0);
+  });
+});

--- a/frontend/src/components/stories/StoryDetail.tsx
+++ b/frontend/src/components/stories/StoryDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { ExternalLink, Lock, MessageSquare } from "lucide-react";
 import { SectorBadge } from "./SectorBadge";
 import { StorySaveButton } from "./StorySaveButton";
@@ -66,6 +67,24 @@ export function StoryDetail({ story }: StoryDetailProps): JSX.Element {
 
   return (
     <article className="space-y-7">
+      {/* Phase 12k — hero image above the headline when an og:image is
+          available. Full-width, capped at ~300px tall, object-cover. No
+          placeholder when image_url is null — the article opens with the
+          headline as it did pre-12k. */}
+      {story.image_url && (
+        <div className="relative -mx-1 overflow-hidden rounded-lg" style={{ maxHeight: 300 }}>
+          <Image
+            src={story.image_url}
+            alt=""
+            width={1200}
+            height={600}
+            unoptimized
+            loading="lazy"
+            className="h-auto w-full object-cover"
+            style={{ maxHeight: 300 }}
+          />
+        </div>
+      )}
       <header className="space-y-4">
         <h1 className="font-display text-[28px] font-semibold leading-tight text-ink md:text-[30px]">
           {story.headline}

--- a/frontend/src/types/story.ts
+++ b/frontend/src/types/story.ts
@@ -97,6 +97,10 @@ export interface Story {
   // so the wire shape is uniform across legacy and ingestion items.
   primary_source_url: string | null;
   sources: Array<{ url: string; name: string | null; role: "primary" | "alternate" }>;
+  // Phase 12k — og:image URL extracted from the source page during
+  // enrichment. Null when no og:image / twitter:image was found; the UI
+  // renders no thumbnail / hero in that case (no placeholder).
+  image_url: string | null;
   published_at: string | null;
   created_at: string;
   author: StoryAuthor | null;


### PR DESCRIPTION
## Summary

- Extracts `og:image` (with `twitter:image` fallback) from each source page during the existing enrichment body fetch — no extra HTTP request — and persists it to `stories`/`events`/`ingestion_candidates`.
- Feed cards render a 120×80 right-aligned thumbnail; story detail renders a full-width hero capped at 300px. Both surfaces lay out unchanged when `image_url` is null (no placeholder).
- Migration 0033 adds the column nullable. Backfill script `npm run backfill-og-images` refetches null rows at 2 req/s, idempotent on resume.

## Notes

- `extractOgImage` rejects `data:`/`javascript:`/`file:`/`mailto:` URIs and any non-http(s) protocol; relative paths resolve against the source URL.
- Extraction is soft — any parse / DOM failure falls back to `image_url=null` and never blocks a candidate.
- Frontend uses `next/image` with `unoptimized` so we don't need to configure `remotePatterns` for the open set of source domains; `loading="lazy"` for scroll perf.
- Thumbnails use empty `alt` (decorative supplement to the headline + commentary, not primary content).

## Test plan

- [x] Backend type-check + lint clean
- [x] Backend tests: 992 pass / 4 pre-existing jsdom suite failures (htmlStrip, bodyExtractor, heuristicSeam, rssAdapter — same set as on main per the `ea2df57` jsdom cluster). New cases added to bodyExtractor.test.ts (og:image, twitter fallback, no-meta-null, relative URL, data: rejection, og:image preferred) and heuristicSeam.test.ts (imageUrl propagation).
- [x] Frontend type-check + lint clean
- [x] Frontend tests: 60 pass, including new StoryCard / StoryDetail render-with-and-without-image cases. 2 pre-existing failures in `feed/page.test.tsx` (missing `getMyProfileRequest` in mock from a prior 12g/12j addition — unrelated to this work)
- [ ] Run `npm run backfill-og-images -- --dry-run` against prod to check what % of rows we expect to populate before running for real
- [ ] Manual smoke: load /feed and a /stories/:id page on a row that has an og:image and one that doesn't; verify no layout shift for the null case

🤖 Generated with [Claude Code](https://claude.com/claude-code)