### PR TITLE
fix(ingestion): silence jsdom VirtualConsole in og:image extractors

### DIFF
--- a/backend/src/jobs/ingestion/bodyExtractor.ts
+++ b/backend/src/jobs/ingestion/bodyExtractor.ts
@@ -11,7 +11,7 @@
 // User-Agent: caller provides. Falls back to a per-stage default if
 // the source's config.userAgent is unset upstream.
 
-import { JSDOM } from "jsdom";
+import { JSDOM, VirtualConsole } from "jsdom";
 import { Readability } from "@mozilla/readability";
 
 import { BODY_SIZE_CAP_BYTES, HEURISTIC_REASONS, type HeuristicReason } from "./heuristics";
@@ -181,10 +181,19 @@ export async function fetchAndExtractBody(
 
   // Parse with jsdom and run readability. The same parsed document also
   // feeds the og:image extractor — single DOM parse, two consumers.
+  //
+  // Silent VirtualConsole: by default jsdom forwards every CSS parse
+  // warning, resource-load error, and script-runtime message from the
+  // parsed page to Node's `console`. In the worker that's a stream of
+  // junk into Railway logs (and into local-test stdout) on every
+  // enrichment. A fresh VirtualConsole with no sendTo() drops it all;
+  // bodyExtractor only consumes the DOM via querySelector + readability,
+  // neither of which depends on those events.
   let textContent: string;
   let imageUrl: string | null = null;
   try {
-    const dom = new JSDOM(html, { url });
+    const virtualConsole = new VirtualConsole();
+    const dom = new JSDOM(html, { url, virtualConsole });
     // Pull og:image first — readability's parse() can mutate document
     // structure (or, on some pages, throw). Doing meta-tag extraction
     // before readability isolates the cheap, reliable pass from the

--- a/backend/src/scripts/backfillOgImages.ts
+++ b/backend/src/scripts/backfillOgImages.ts
@@ -26,7 +26,7 @@
 //   npm run backfill-og-images -- --table=events
 
 import "dotenv/config";
-import { JSDOM } from "jsdom";
+import { JSDOM, VirtualConsole } from "jsdom";
 import { eq, isNull } from "drizzle-orm";
 
 import { db } from "../db";
@@ -112,7 +112,14 @@ async function fetchOgImage(url: string): Promise<FetchOgImageResult> {
     }
     let imageUrl: string | null;
     try {
-      const dom = new JSDOM(html, { url });
+      // Silent VirtualConsole — by default jsdom forwards CSS parse
+      // warnings, resource-load errors, and other internal noise from
+      // the parsed page to Node's console. That's the source of the
+      // raw HTML/CSS dump that pollutes the backfill log. A fresh
+      // VirtualConsole with no `sendTo()` swallows it all; the
+      // backfill only cares about extracted meta tags.
+      const virtualConsole = new VirtualConsole();
+      const dom = new JSDOM(html, { url, virtualConsole });
       imageUrl = extractOgImage(dom.window.document, url);
     } catch {
       return { imageUrl: null, reason: "parse_error" };


### PR DESCRIPTION
## Summary

- jsdom's default `VirtualConsole` forwards every CSS parse warning, resource-load error, and script-runtime message from the parsed page to Node's stdout. Inside the enrichment worker that's a stream of junk into Railway logs on every candidate; in the og:image backfill script (#95) it dumps inline `<style>` content alongside the progress lines.
- Pass an empty `VirtualConsole` (no `sendTo()`) to both `JSDOM` constructors — neither caller consumes the forwarded events. `bodyExtractor` already catches its own parse errors via try/catch, and the backfill only queries meta tags.

## Test plan

- [x] Backend type-check + lint clean
- [x] 75 suites, 1081 tests pass (no behavior change; just silences a stream)
- [ ] Manual: after deploy, watch a few enrichment worker runs in Railway logs — should be clean of CSS parse spam
- [ ] Manual: re-run `npm run backfill-og-images -- --dry-run` against any source — output should be the four progress/DONE lines only

🤖 Generated with [Claude Code](https://claude.com/claude-code)