### PR TITLE
feat(a11y): respect prefers-reduced-motion across the app

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, MotionConfig } from "framer-motion";
 import { useRequireOnboarded } from "@/hooks/useRequireOnboarded";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
@@ -23,26 +23,33 @@ export default function AppShellLayout({
   }
 
   return (
-    <div className="min-h-screen bg-bg">
-      <Header />
-      <div className="flex">
-        <Sidebar />
-        <main className="flex-1 px-4 py-8 md:px-8">
-          <div className="mx-auto max-w-6xl">
-            <AnimatePresence mode="wait" initial={false}>
-              <motion.div
-                key={pathname}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.15, ease: "easeInOut" }}
-              >
-                {children}
-              </motion.div>
-            </AnimatePresence>
-          </div>
-        </main>
+    // reducedMotion="user" makes every descendant motion component respect
+    // the OS-level prefers-reduced-motion setting: transform/layout
+    // animations (stagger slide-up, hover lift, save-button scale, depth-
+    // toggle pill, page-transition slide) snap to their end state, while
+    // opacity fades are preserved. Covers the whole authenticated app.
+    <MotionConfig reducedMotion="user">
+      <div className="min-h-screen bg-bg">
+        <Header />
+        <div className="flex">
+          <Sidebar />
+          <main className="flex-1 px-4 py-8 md:px-8">
+            <div className="mx-auto max-w-6xl">
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={pathname}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.15, ease: "easeInOut" }}
+                >
+                  {children}
+                </motion.div>
+              </AnimatePresence>
+            </div>
+          </main>
+        </div>
       </div>
-    </div>
+    </MotionConfig>
   );
 }


### PR DESCRIPTION
## Summary

Closes the one accessibility gap flagged during the editorial redesign (#98): the new Framer Motion animations didn't honor `prefers-reduced-motion`.

Wraps the authenticated app shell (`(app)/layout.tsx`) in **`<MotionConfig reducedMotion="user">`**, so every descendant motion component respects the OS-level setting:
- **Transform/layout animations snap to end state** for users who request reduced motion — feed lead/rail/river stagger, card hover lift, save-button spring bounce, depth-toggle pill slide, page-transition slide.
- **Opacity fades are preserved** (Framer Motion's `"user"` behavior), so content still appears gracefully rather than flickering.

Scope is the app interior (matches where the motion lives). No design-token, layout, or behavior changes for users without reduced-motion set.

## Test plan
- [x] `type-check` ✅
- [x] `lint` ✅ (zero warnings)
- [x] frontend tests ✅ 65/65
- [ ] Manual: set OS "Reduce motion" → reload feed; entrance/hover/save/depth transforms are instant, opacity fades remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)