### PR TITLE
fix(deps): pin ioredis to 5.10.1 to match bullmq (unblocks Railway build)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,7 @@
     "express": "^4.21.1",
     "express-rate-limit": "^7.4.1",
     "helmet": "^8.0.0",
-    "ioredis": "^5.4.1",
+    "ioredis": "5.10.1",
     "jsdom": "^22.1.0",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "express": "^4.21.1",
         "express-rate-limit": "^7.4.1",
         "helmet": "^8.0.0",
-        "ioredis": "^5.4.1",
+        "ioredis": "5.10.1",
         "jsdom": "^22.1.0",
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^3.0.3",


### PR DESCRIPTION
## Summary

The Railway backend build was failing `tsc` in **every file that passes a Redis connection to a BullMQ `Queue`/`Worker`** — `jobs/aggregation*`, `jobs/email*`, `jobs/ingestion/*`, `scripts/smoke12e5c.ts`, `scripts/smoke12e6.ts` — a structural type mismatch between the top-level `ioredis` and the `ioredis` bullmq bundles.

### Root cause
- `bullmq@5.74.1` pins `ioredis` to an **exact** `"5.10.1"`.
- The backend declared `"ioredis": "^5.4.1"` (a **range**).
- The backend **Dockerfile copies only `package.json` (no lockfile) and runs `npm install`** (not `npm ci`), so the range re-resolves to the latest 5.x on each build. When that's newer than 5.10.1, npm can't dedupe it with bullmq's exact pin → bullmq gets a **nested** `ioredis` → the two `Redis` types diverge → type error at every `connection:` call site.
- Local trees that already had `5.10.1` deduped passed type-check, which masked it.

### Fix
Pin the backend's `ioredis` to exactly **`5.10.1`** (bullmq's pin), so a single shared instance is always installed. Verified: one deduped `ioredis@5.10.1`, no nested copy under bullmq. **No `as any` casts needed** — version alignment resolves all 10 files.

## Test plan
- [x] `npm install` → single deduped `ioredis@5.10.1`, no nesting
- [x] backend `type-check` ✅ clean
- [x] backend `lint` ✅ clean
- [x] lockfile diff is minimal (ioredis spec only)
- [ ] Railway build succeeds on merge

## Recommended follow-up (not in this PR)
Because the Dockerfile does a **lockfile-less `npm install`**, `bullmq` itself also floats (`^5.21.2`). This pin holds only while the floated bullmq keeps pinning `ioredis 5.10.1`. The durable fix is to **pin `bullmq` too**, or change the Dockerfile to install from the committed lockfile (`npm ci`). Happy to do either in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)