### PR TITLE
feat(feed): source-diversity cap on ranked feed pool

### DIFF
--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -35,6 +35,7 @@ import {
   W2,
   W3,
 } from "../feed/rankingConstants";
+import { applyDiversityCap } from "../feed/diversityCap";
 
 const MAX_LIMIT = 50;
 const DEFAULT_LIMIT = 10;
@@ -162,6 +163,9 @@ interface EventRow {
   genericCommentary: string | null;
   primarySourceUrl: string;
   primarySourceName: string | null;
+  // Phase 12 — 'native' (SIGNAL-authored) vs 'ingested'. Used by the
+  // feed diversity cap to exempt native posts; stripped before the wire.
+  sourceType: string;
   imageUrl: string | null;
   publishedAt: Date | null;
   createdAt: Date;
@@ -508,6 +512,7 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
         genericCommentary: events.genericCommentary,
         primarySourceUrl: events.primarySourceUrl,
         primarySourceName: events.primarySourceName,
+        sourceType: events.sourceType,
         imageUrl: events.imageUrl,
         publishedAt: events.publishedAt,
         createdAt: events.createdAt,
@@ -537,11 +542,19 @@ export async function getFeed(req: Request, res: Response, next: NextFunction): 
       const bTs = (b.publishedAt ?? b.createdAt).getTime();
       return bTs - aTs;
     });
+    // Phase 12 — source-diversity cap. Applied to the FULL ranked pool
+    // before pagination so no single source occupies more than
+    // MAX_PER_SOURCE slots in any DIVERSITY_WINDOW-position window.
+    // Running it pre-slice (not per-page) keeps the window invariant
+    // intact across the offset/limit page boundary and keeps pagination
+    // stable. Does not touch ranking scores — pure post-ranking reorder.
+    // Native posts are exempt (never capped).
+    const diversified = applyDiversityCap(ranked);
     // Phase 12m — honor `offset` so infinite-scroll pages return distinct
     // slices of the ranked pool. The prior `slice(0, limit)` ignored
     // offset, so every page re-returned the top `limit` events and the
     // frontend river rendered the same articles on every page.
-    const pageItems = ranked.slice(offset, offset + limit);
+    const pageItems = diversified.slice(offset, offset + limit);
 
     // Batch-fetch event_sources for the events on this page. Skip the
     // round-trip when the page is empty.

--- a/backend/src/feed/diversityCap.ts
+++ b/backend/src/feed/diversityCap.ts
@@ -1,0 +1,93 @@
+// Phase 12 — post-ranking source-diversity cap for the feed.
+//
+// Pure, side-effect-free reordering pass applied to the already-ranked
+// event pool (by effective_score DESC) BEFORE pagination slicing. The
+// invariant it enforces: no single source occupies more than
+// MAX_PER_SOURCE slots within any window of DIVERSITY_WINDOW consecutive
+// feed positions. Displaced slots are backfilled greedily with the
+// next-ranked event from a source that still has room in the window.
+//
+// Why a sliding window rather than a global per-source cap: the goal is
+// to break up visible "runs" of one outlet near the top of the feed
+// without permanently demoting a prolific-but-high-quality source to the
+// bottom. A source that fills 3 of positions 1–20 can appear again at
+// position 21+, just not clustered.
+//
+// Why this runs on the FULL pool before `slice(offset, offset+limit)`:
+// the feed paginates with offset/limit (default page size 10), but the
+// window is 20 — it spans two pages. Capping per-page-slice would let a
+// source put 3 events at the bottom of page 1 and 3 more at the top of
+// page 2 (6 in one 20-window). Reordering the whole ranked pool once,
+// then slicing, keeps pagination stable and the invariant intact.
+//
+// Native posts (events.source_type === 'native', SIGNAL-authored
+// editorial) are exempt: they are never capped and never count toward
+// any source's window tally. There is only ever a handful of them and
+// they carry no external source identity to cluster on.
+
+/** Max events from one source within any DIVERSITY_WINDOW-position window. */
+export const MAX_PER_SOURCE = 3;
+
+/** Sliding-window size, in feed positions, the cap is measured over. */
+export const DIVERSITY_WINDOW = 20;
+
+/** events.source_type value flagging a SIGNAL-authored native post. */
+export const NATIVE_SOURCE_TYPE = "native";
+
+/** Minimal row shape the cap reasons over. */
+export interface DiversityItem {
+  primarySourceName: string | null;
+  sourceType: string;
+}
+
+/**
+ * Reorder `ranked` (highest-priority first) so that within every window
+ * of `windowSize` consecutive output positions, no single source appears
+ * more than `maxPerSource` times. Native posts are exempt. Stable for
+ * non-conflicting input: an item is only moved later when placing it
+ * would breach the window cap, and it is then backfilled with the
+ * highest-ranked eligible item.
+ *
+ * The pass never drops items. In the degenerate case where every
+ * remaining item belongs to a source already at cap in the trailing
+ * window, the highest-ranked remaining item is placed anyway — the cap
+ * is a best-effort spread, not a hard filter that could shrink the feed.
+ */
+export function applyDiversityCap<T extends DiversityItem>(
+  ranked: readonly T[],
+  maxPerSource: number = MAX_PER_SOURCE,
+  windowSize: number = DIVERSITY_WINDOW,
+): T[] {
+  const result: T[] = [];
+  const remaining: T[] = [...ranked];
+
+  const isNative = (item: T): boolean => item.sourceType === NATIVE_SOURCE_TYPE;
+  const sourceKey = (item: T): string => item.primarySourceName ?? "(unknown)";
+
+  // Can `item` be placed at the next position without breaching the
+  // window cap? Natives always can. For others, count same-source
+  // (non-native) items already placed in the trailing window-1 slots;
+  // placing is allowed while that count is below the cap.
+  const fitsWindow = (item: T): boolean => {
+    if (isNative(item)) return true;
+    const key = sourceKey(item);
+    const windowStart = Math.max(0, result.length - (windowSize - 1));
+    let count = 0;
+    for (let i = windowStart; i < result.length; i++) {
+      const placed = result[i];
+      if (!isNative(placed) && sourceKey(placed) === key) count++;
+    }
+    return count < maxPerSource;
+  };
+
+  while (remaining.length > 0) {
+    let pickIndex = remaining.findIndex((item) => fitsWindow(item));
+    // Degenerate fallback: nothing fits the window. Place the
+    // highest-ranked remaining item rather than drop it or loop forever.
+    if (pickIndex === -1) pickIndex = 0;
+    const [picked] = remaining.splice(pickIndex, 1);
+    result.push(picked);
+  }
+
+  return result;
+}

--- a/backend/tests/feed/diversityCap.test.ts
+++ b/backend/tests/feed/diversityCap.test.ts
@@ -1,0 +1,168 @@
+// Phase 12 — source-diversity cap tests.
+//
+// `applyDiversityCap` is a pure reorder over the already-ranked event
+// pool. Note on window size: the cap is "≤ maxPerSource per source in
+// any window of `windowSize` positions". When the whole input fits
+// inside one window (input length ≤ windowSize), a source with more than
+// `maxPerSource` items CANNOT be spread out — there is nowhere outside
+// the window to move them. That is the degenerate case, and the cap
+// falls back to best-effort (never drops items). So the displacement /
+// invariant cases below use a small explicit `windowSize` (where moving
+// an item past the window is actually possible), and the default-param
+// cases use large, satisfiable inputs.
+
+import {
+  applyDiversityCap,
+  MAX_PER_SOURCE,
+  DIVERSITY_WINDOW,
+  NATIVE_SOURCE_TYPE,
+  type DiversityItem,
+} from "../../src/feed/diversityCap";
+
+interface TestRow extends DiversityItem {
+  id: string;
+}
+
+function ingested(id: string, source: string): TestRow {
+  return { id, primarySourceName: source, sourceType: "ingested" };
+}
+
+function native(id: string): TestRow {
+  return { id, primarySourceName: "SIGNAL", sourceType: NATIVE_SOURCE_TYPE };
+}
+
+/** Max occurrences of any one non-native source in any window of `size`. */
+function maxSourceRunInAnyWindow(rows: TestRow[], size: number): number {
+  let worst = 0;
+  for (let start = 0; start < rows.length; start++) {
+    const window = rows.slice(start, start + size);
+    const counts = new Map<string, number>();
+    for (const r of window) {
+      if (r.sourceType === NATIVE_SOURCE_TYPE) continue;
+      const key = r.primarySourceName ?? "(unknown)";
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    for (const c of counts.values()) worst = Math.max(worst, c);
+  }
+  return worst;
+}
+
+const idSet = (rows: TestRow[]): Set<string> => new Set(rows.map((r) => r.id));
+
+describe("applyDiversityCap", () => {
+  it("(a) displaces the over-cap item and backfills with the next source", () => {
+    // window=4, cap=2: three A's clustered at the top, then B and C.
+    // The 3rd A must drop below B and C; B (higher-ranked) backfills first.
+    const input: TestRow[] = [
+      ingested("a1", "A"),
+      ingested("a2", "A"),
+      ingested("a3", "A"),
+      ingested("b1", "B"),
+      ingested("c1", "C"),
+    ];
+    const out = applyDiversityCap(input, 2, 4);
+
+    // First two slots keep the two highest A's (cap allows 2).
+    expect(out[0].id).toBe("a1");
+    expect(out[1].id).toBe("a2");
+    // a3 is pushed past both backfilled sources.
+    const idx = (id: string): number => out.findIndex((r) => r.id === id);
+    expect(idx("a3")).toBeGreaterThan(idx("b1"));
+    expect(idx("a3")).toBeGreaterThan(idx("c1"));
+    // Invariant holds for the chosen window, and nothing was dropped.
+    expect(maxSourceRunInAnyWindow(out, 4)).toBeLessThanOrEqual(2);
+    expect(idSet(out)).toEqual(idSet(input));
+  });
+
+  it("(b) spreads an over-represented source clustered at the top", () => {
+    // The realistic shape the cap targets: one firehose source dominates
+    // the top of the ranking (8 of the top 12), the rest of the pool is
+    // varied. Rank-greedy backfill must spread the firehose to ≤3 per
+    // window using the next-ranked other-source events, with no window
+    // anywhere exceeding the cap.
+    const input: TestRow[] = [
+      ingested("f0", "Firehose"),
+      ingested("f1", "Firehose"),
+      ingested("f2", "Firehose"),
+      ingested("o0", "OutletA"),
+      ingested("f3", "Firehose"),
+      ingested("f4", "Firehose"),
+      ingested("o1", "OutletB"),
+      ingested("f5", "Firehose"),
+      ingested("f6", "Firehose"),
+      ingested("o2", "OutletC"),
+      ingested("f7", "Firehose"),
+      ingested("o3", "OutletD"),
+    ];
+    // Pad the tail with unique sources so the firehose has room to spread.
+    for (let i = 0; i < 48; i++) input.push(ingested(`u${i}`, `Unique${i}`));
+
+    const out = applyDiversityCap(input, MAX_PER_SOURCE, DIVERSITY_WINDOW);
+
+    expect(maxSourceRunInAnyWindow(out, DIVERSITY_WINDOW)).toBeLessThanOrEqual(
+      MAX_PER_SOURCE,
+    );
+    expect(idSet(out)).toEqual(idSet(input));
+    // The first three firehose items keep their lead positions; the cap
+    // only relocates the overflow.
+    const firehosePositions = out
+      .map((r, i) => ({ r, i }))
+      .filter((x) => x.r.primarySourceName === "Firehose")
+      .map((x) => x.i);
+    expect(firehosePositions.slice(0, 3)).toEqual([0, 1, 2]);
+  });
+
+  it("(c) never caps native posts — a run of natives survives in order", () => {
+    const input: TestRow[] = [];
+    for (let i = 0; i < 10; i++) input.push(native(`n${i}`));
+    const out = applyDiversityCap(input, MAX_PER_SOURCE, DIVERSITY_WINDOW);
+    expect(out.map((r) => r.id)).toEqual(input.map((r) => r.id));
+  });
+
+  it("(c2) natives interleaved with a capped source are never displaced", () => {
+    // window=4, cap=2. Natives spacing the A's must all stay put, and the
+    // invariant (over non-native sources) still holds.
+    const input: TestRow[] = [
+      ingested("a1", "A"),
+      native("n1"),
+      ingested("a2", "A"),
+      native("n2"),
+      ingested("a3", "A"),
+      native("n3"),
+    ];
+    const out = applyDiversityCap(input, 2, 4);
+    // Every native is still present.
+    for (const n of ["n1", "n2", "n3"]) {
+      expect(out.some((r) => r.id === n)).toBe(true);
+    }
+    expect(maxSourceRunInAnyWindow(out, 4)).toBeLessThanOrEqual(2);
+    expect(idSet(out)).toEqual(idSet(input));
+  });
+
+  it("(d) returns a permutation — no items dropped or duplicated", () => {
+    const input: TestRow[] = [];
+    for (let i = 0; i < 50; i++) input.push(ingested(`x${i}`, `S${i % 4}`));
+    const out = applyDiversityCap(input, MAX_PER_SOURCE, DIVERSITY_WINDOW);
+    expect(out).toHaveLength(input.length);
+    expect(idSet(out)).toEqual(idSet(input));
+  });
+
+  it("(e) degenerate single-source input is returned intact (no drops)", () => {
+    // Unsatisfiable under window 20 (8 of one source, all in one window):
+    // the fallback must keep every item rather than discard the overflow.
+    const input: TestRow[] = [];
+    for (let i = 0; i < 8; i++) input.push(ingested(`a${i}`, "A"));
+    const out = applyDiversityCap(input, MAX_PER_SOURCE, DIVERSITY_WINDOW);
+    expect(out).toHaveLength(8);
+    expect(idSet(out)).toEqual(idSet(input));
+  });
+
+  it("(f) empty input returns empty output", () => {
+    expect(applyDiversityCap([], MAX_PER_SOURCE, DIVERSITY_WINDOW)).toEqual([]);
+  });
+
+  it("(g) exposes the spec'd default constants", () => {
+    expect(MAX_PER_SOURCE).toBe(3);
+    expect(DIVERSITY_WINDOW).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a post-ranking source-diversity pass so no single source occupies more than **3** slots in any window of **20** consecutive feed positions (`MAX_PER_SOURCE` / `DIVERSITY_WINDOW` named constants).
- New pure module `backend/src/feed/diversityCap.ts` (`applyDiversityCap`); wired into `getFeed` between the in-memory rank sort and the offset/limit slice.
- Applied to the **full ranked pool before slicing** — per-page capping would let a source place 3 at the bottom of page 1 and 3 at the top of page 2 (6 in one window). Pre-slice keeps the invariant intact and pagination stable.

## Behavior
- Rank-greedy: each slot takes the highest-ranked remaining event whose source still has room in the trailing window; displaced slots backfill with the next-ranked other-source event.
- **Never drops or duplicates** items — output is a permutation, so `total`/`has_more` math is unchanged.
- **Native posts** (`source_type='native'`) are exempt: never capped, never counted toward any source tally.
- Degenerate fallback (every remaining item at-cap): place the highest-ranked anyway rather than drop it.

## Scope honored
- Ranking scores/weights **untouched** — pure post-ranking reorder.
- Top Stories rail is a client-side slice of the same feed response (`nonGated.slice(0,4)`), so it inherits the diversified ordering — **no separate query**, no separate handling.

## Test plan
- [x] `backend/tests/feed/diversityCap.test.ts` — 8 cases: displacement+backfill, window invariant on an over-represented source, native exemption (x2), permutation/no-drop, degenerate single-source, empty input, constants pinned.
- [x] `npm run type-check --workspace=backend` + `--workspace=frontend`
- [x] `npm run lint --workspace=backend`
- [x] `npx jest` → 85 suites passed, 1262 passed / 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)