### PR TITLE
feat(feed): hook-as-title feed cards across lead, grid, and rail

### DIFF
--- a/frontend/src/components/feed/FeedLead.test.tsx
+++ b/frontend/src/components/feed/FeedLead.test.tsx
@@ -83,8 +83,35 @@ describe("FeedLead hero imagery", () => {
     expect(container.querySelectorAll("img").length).toBe(0);
   });
 
-  it("surfaces the personalization framing label", () => {
-    renderLead(baseStory({ why_it_matters_to_you: "A plain fallback summary." }));
+  // Hook-as-title: for ingested stories the personalization hook is
+  // promoted to the headline and the source article headline drops to a
+  // muted attribution line. The old "Why it matters to you" label is gone.
+  it("promotes the hook to the headline for an ingested story", () => {
+    renderLead(
+      baseStory({
+        headline: "Source wire headline",
+        why_it_matters_to_you: "This is the hook that should headline.",
+      }),
+    );
+    expect(
+      screen.getByText("This is the hook that should headline."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Source wire headline")).toBeInTheDocument();
+    expect(screen.queryByText("Why it matters to you")).not.toBeInTheDocument();
+  });
+
+  // Native (SIGNAL) stories keep the classic headline + framed commentary.
+  it("leaves native (SIGNAL) stories untouched", () => {
+    renderLead(
+      baseStory({
+        source_name: "SIGNAL",
+        sources: [{ url: "https://signal.so", name: "SIGNAL", role: "primary" }],
+        headline: "Editorial native headline",
+        why_it_matters_to_you: "Native commentary body.",
+      }),
+    );
+    expect(screen.getByText("Editorial native headline")).toBeInTheDocument();
     expect(screen.getByText("Why it matters to you")).toBeInTheDocument();
+    expect(screen.getByText("Native commentary body.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/feed/FeedLead.tsx
+++ b/frontend/src/components/feed/FeedLead.tsx
@@ -9,6 +9,7 @@ import { StorySaveButton } from "@/components/stories/StorySaveButton";
 import { useStoryCommentary } from "@/hooks/useStoryCommentary";
 import { useReadStoriesStore } from "@/store/readStoriesStore";
 import { timeAgo } from "@/lib/timeAgo";
+import { isNativeStory, resolveCardHeadline } from "@/lib/feedCard";
 import { isGatePayload, type Story } from "@/types/story";
 
 // "Intelligence Terminal × Editorial" front page — the lead story.
@@ -50,6 +51,8 @@ export function FeedLead({ story }: { story: Story }): JSX.Element {
   const sectorColor = SECTOR_VAR[story.sector] ?? "var(--ink-muted)";
   const sectorLabel = SECTOR_LABEL[story.sector] ?? story.sector;
   const source = story.source_name ?? story.sources[0]?.name ?? null;
+  const native = isNativeStory(story);
+  const headline = resolveCardHeadline(story, body);
 
   return (
     <motion.article
@@ -99,42 +102,74 @@ export function FeedLead({ story }: { story: Story }): JSX.Element {
           )}
         </div>
 
-        <h2
-          className={[
-            "font-display text-[32px] font-semibold leading-[1.08] tracking-tight transition-colors duration-150 md:text-[40px]",
-            isRead ? "text-ink-muted" : "text-ink group-hover:text-accent",
-          ].join(" ")}
-        >
-          {story.headline}
-        </h2>
-
-        <p className="mb-1.5 mt-5 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-accent">
-          Why it matters to you
-        </p>
-        <div className="relative min-h-[4.5rem]">
-          <AnimatePresence mode="wait" initial={false}>
-            <motion.p
-              key={loading ? "loading" : "body"}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.18, ease: EASE }}
-              className="max-w-[58ch] text-[16px] leading-relaxed text-ink-muted"
-              style={
-                loading
-                  ? { color: "var(--ink-muted)" }
-                  : {
-                      display: "-webkit-box",
-                      WebkitLineClamp: 3,
-                      WebkitBoxOrient: "vertical",
-                      overflow: "hidden",
-                    }
-              }
+        {native ? (
+          <>
+            {/* Native (SIGNAL editorial): classic headline + framed
+                commentary, left untouched by the hook-as-title swap. */}
+            <h2
+              className={[
+                "font-display text-[32px] font-semibold leading-[1.08] tracking-tight transition-colors duration-150 md:text-[40px]",
+                isRead ? "text-ink-muted" : "text-ink group-hover:text-accent",
+              ].join(" ")}
             >
-              {loading ? "Generating your briefing…" : body}
-            </motion.p>
-          </AnimatePresence>
-        </div>
+              {story.headline}
+            </h2>
+
+            <p className="mb-1.5 mt-5 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-accent">
+              Why it matters to you
+            </p>
+            <div className="relative min-h-[4.5rem]">
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.p
+                  key={loading ? "loading" : "body"}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.18, ease: EASE }}
+                  className="max-w-[58ch] text-[16px] leading-relaxed text-ink-muted"
+                  style={
+                    loading
+                      ? { color: "var(--ink-muted)" }
+                      : {
+                          display: "-webkit-box",
+                          WebkitLineClamp: 3,
+                          WebkitBoxOrient: "vertical",
+                          overflow: "hidden",
+                        }
+                  }
+                >
+                  {loading ? "Generating your briefing…" : body}
+                </motion.p>
+              </AnimatePresence>
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Ingested: the hook becomes the hero headline; the source
+                article headline drops to a secondary attribution line.
+                The "Why it matters to you" label is dropped — the hook
+                now speaks for itself as the headline. */}
+            <h2
+              className={[
+                "font-display text-[32px] font-semibold leading-[1.08] tracking-tight transition-colors duration-150 md:text-[40px]",
+                isRead ? "text-ink-muted" : "text-ink group-hover:text-accent",
+              ].join(" ")}
+              style={{
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }}
+            >
+              {headline.primary}
+            </h2>
+            {headline.attribution && (
+              <p className="mt-4 max-w-[58ch] truncate text-[15px] leading-relaxed text-ink-muted">
+                {headline.attribution}
+              </p>
+            )}
+          </>
+        )}
       </Link>
 
       {/* Editorial meta line */}

--- a/frontend/src/components/feed/FeedRailItem.test.tsx
+++ b/frontend/src/components/feed/FeedRailItem.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { Story } from "@/types/story";
+import { FeedRailItem } from "./FeedRailItem";
+
+function baseStory(overrides: Partial<Story> = {}): Story {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    sector: "ai",
+    headline: "Source wire headline",
+    context: "",
+    why_it_matters: "",
+    gated: false,
+    why_it_matters_to_you: "The hook that should headline.",
+    commentary: null,
+    commentary_source: null,
+    source_url: "https://example.com/a",
+    source_name: "OutletA",
+    primary_source_url: "https://example.com/a",
+    sources: [{ url: "https://example.com/a", name: "OutletA", role: "primary" }],
+    image_url: null,
+    published_at: "2026-05-10T00:00:00Z",
+    created_at: "2026-05-10T00:00:00Z",
+    author: null,
+    is_saved: false,
+    save_count: 0,
+    comment_count: 0,
+    reading_time_minutes: 4,
+    ...overrides,
+  };
+}
+
+describe("FeedRailItem hook-as-title", () => {
+  it("promotes the hook to the headline and demotes the source headline", () => {
+    render(<FeedRailItem story={baseStory()} rank={2} />);
+    expect(
+      screen.getByText("The hook that should headline."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Source wire headline")).toBeInTheDocument();
+  });
+
+  it("leaves native (SIGNAL) items on their editorial headline", () => {
+    render(
+      <FeedRailItem
+        story={baseStory({
+          source_name: "SIGNAL",
+          sources: [{ url: "https://signal.so", name: "SIGNAL", role: "primary" }],
+          headline: "Editorial native headline",
+          why_it_matters_to_you: "Native commentary that must not headline.",
+        })}
+        rank={3}
+      />,
+    );
+    expect(screen.getByText("Editorial native headline")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Native commentary that must not headline."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/feed/FeedRailItem.tsx
+++ b/frontend/src/components/feed/FeedRailItem.tsx
@@ -4,12 +4,20 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { useReadStoriesStore } from "@/store/readStoriesStore";
 import { timeAgo } from "@/lib/timeAgo";
+import { resolveCardHeadline } from "@/lib/feedCard";
 import type { Story } from "@/types/story";
 
 // Secondary "top stories" rail item. Deliberately dense and text-only:
 // sector kicker + source dateline, a tight serif headline (2 lines),
 // and a mono meta line. No imagery, no commentary body — the rail is
 // for fast triage of the next-most-important stories beside the lead.
+//
+// Hook-as-title: like the lead and grid cards, ingested rail items
+// headline with the personalization hook and drop the source article
+// headline to a muted attribution line. The rail has no lazy commentary
+// fetch, so the hook comes straight from `why_it_matters_to_you` (the
+// 12b template floor, always present on the wire). Native (SIGNAL)
+// items keep their editorial headline untouched.
 
 const EASE: [number, number, number, number] = [0.2, 0.8, 0.2, 1];
 
@@ -43,6 +51,10 @@ export function FeedRailItem({
   const isRead = useReadStoriesStore((s) => s.isRead(story.id));
   const sectorColor = SECTOR_VAR[story.sector] ?? "var(--ink-muted)";
   const source = story.source_name ?? story.sources[0]?.name ?? null;
+  // For native items resolveCardHeadline returns the editorial headline as
+  // primary with no attribution, so the rail renders byte-identically to
+  // before. For ingested items the hook becomes the headline.
+  const headline = resolveCardHeadline(story, story.why_it_matters_to_you);
 
   return (
     <motion.div variants={animated ? railItemVariants : undefined}>
@@ -80,8 +92,13 @@ export function FeedRailItem({
             overflow: "hidden",
           }}
         >
-          {story.headline}
+          {headline.primary}
         </h3>
+        {headline.attribution && (
+          <p className="mt-1 truncate text-xs leading-snug text-ink-muted">
+            {headline.attribution}
+          </p>
+        )}
         <div className="mt-2 flex items-center gap-3 text-ink-muted">
           {stamp && (
             <span className="font-mono text-[10px] uppercase tracking-wide">

--- a/frontend/src/components/stories/StoryCard.tsx
+++ b/frontend/src/components/stories/StoryCard.tsx
@@ -9,6 +9,7 @@ import { Card, type CardSectorAccent } from "@/components/ui/Card";
 import { useStoryCommentary } from "@/hooks/useStoryCommentary";
 import { useReadStoriesStore } from "@/store/readStoriesStore";
 import { timeAgo } from "@/lib/timeAgo";
+import { isNativeStory, resolveCardHeadline } from "@/lib/feedCard";
 import { isGatePayload, type Story } from "@/types/story";
 
 const VISIBILITY_ROOT_MARGIN = "1200px 0px";
@@ -84,6 +85,8 @@ export function StoryCard({
     shouldLoad && resolvedCommentary === null && commentaryQuery.isFetching;
 
   const previewText = resolvedCommentary?.thesis ?? story.why_it_matters_to_you;
+  const native = isNativeStory(story);
+  const headline = resolveCardHeadline(story, previewText);
   const sourceCount = story.sources.length;
   const primarySource = story.source_name ?? story.sources[0]?.name ?? null;
   const sourceLabel =
@@ -130,26 +133,55 @@ export function StoryCard({
             )}
           </div>
 
-          <h2
-            className={[
-              "mb-2 font-display text-[19px] font-semibold leading-snug transition-colors duration-150 group-hover:text-accent",
-              isRead ? "text-ink-muted" : "text-ink",
-            ].join(" ")}
-          >
-            {story.headline}
-          </h2>
-
-          <p
-            className="text-sm leading-relaxed text-ink-muted"
-            style={{
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-            }}
-          >
-            {isCommentaryLoading ? "Generating your briefing…" : previewText}
-          </p>
+          {native ? (
+            <>
+              {/* Native (SIGNAL editorial): classic headline-then-commentary
+                  layout, left untouched by the hook-as-title swap. */}
+              <h2
+                className={[
+                  "mb-2 font-display text-[19px] font-semibold leading-snug transition-colors duration-150 group-hover:text-accent",
+                  isRead ? "text-ink-muted" : "text-ink",
+                ].join(" ")}
+              >
+                {story.headline}
+              </h2>
+              <p
+                className="text-sm leading-relaxed text-ink-muted"
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                {isCommentaryLoading ? "Generating your briefing…" : previewText}
+              </p>
+            </>
+          ) : (
+            <>
+              {/* Ingested: the hook becomes the headline; the source
+                  article headline drops to a secondary attribution line. */}
+              <h2
+                className={[
+                  "mb-2 font-display text-[19px] font-semibold leading-snug transition-colors duration-150 group-hover:text-accent",
+                  isRead ? "text-ink-muted" : "text-ink",
+                ].join(" ")}
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                {headline.primary}
+              </h2>
+              {headline.attribution && (
+                <p className="truncate text-xs leading-relaxed text-ink-muted">
+                  {headline.attribution}
+                </p>
+              )}
+            </>
+          )}
         </Link>
 
         <div className="mt-4 flex items-center justify-between gap-3 border-t border-line pt-3 text-xs text-ink-muted">

--- a/frontend/src/lib/feedCard.test.ts
+++ b/frontend/src/lib/feedCard.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { Story } from "@/types/story";
+import {
+  NATIVE_SOURCE_NAME,
+  isNativeStory,
+  resolveCardHeadline,
+} from "./feedCard";
+
+function story(overrides: Partial<Story> = {}): Story {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    sector: "ai",
+    headline: "Source article headline",
+    context: "",
+    why_it_matters: "",
+    gated: false,
+    why_it_matters_to_you: "",
+    commentary: null,
+    commentary_source: null,
+    source_url: "https://example.com/a",
+    source_name: "OutletA",
+    primary_source_url: "https://example.com/a",
+    sources: [{ url: "https://example.com/a", name: "OutletA", role: "primary" }],
+    image_url: null,
+    published_at: null,
+    created_at: "2026-05-10T00:00:00Z",
+    author: null,
+    is_saved: false,
+    save_count: 0,
+    comment_count: 0,
+    ...overrides,
+  };
+}
+
+describe("isNativeStory", () => {
+  it("is true when source_name is the native display name", () => {
+    expect(isNativeStory(story({ source_name: NATIVE_SOURCE_NAME }))).toBe(true);
+  });
+
+  it("falls back to the primary source name when source_name is null", () => {
+    expect(
+      isNativeStory(
+        story({
+          source_name: null,
+          sources: [{ url: "u", name: NATIVE_SOURCE_NAME, role: "primary" }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for an ordinary ingested outlet", () => {
+    expect(isNativeStory(story({ source_name: "OutletA" }))).toBe(false);
+  });
+});
+
+describe("resolveCardHeadline", () => {
+  it("swaps hook to primary and source headline to attribution for ingested", () => {
+    const result = resolveCardHeadline(story(), "The hook that matters.");
+    expect(result.primary).toBe("The hook that matters.");
+    expect(result.attribution).toBe("Source article headline");
+  });
+
+  it("keeps the source headline primary for native (no swap)", () => {
+    const result = resolveCardHeadline(
+      story({ source_name: NATIVE_SOURCE_NAME }),
+      "A hook that should be ignored.",
+    );
+    expect(result.primary).toBe("Source article headline");
+    expect(result.attribution).toBeNull();
+  });
+
+  it("falls back to the source headline when the hook is empty", () => {
+    const result = resolveCardHeadline(story(), "   ");
+    expect(result.primary).toBe("Source article headline");
+    expect(result.attribution).toBeNull();
+  });
+
+  it("falls back to the source headline when the hook is null", () => {
+    const result = resolveCardHeadline(story(), null);
+    expect(result.primary).toBe("Source article headline");
+    expect(result.attribution).toBeNull();
+  });
+});

--- a/frontend/src/lib/feedCard.ts
+++ b/frontend/src/lib/feedCard.ts
@@ -1,0 +1,63 @@
+import type { Story } from "@/types/story";
+
+// Hook-as-title feed card model.
+//
+// For ingested stories the feed card inverts its hierarchy: the
+// accessible-tier commentary thesis (the "hook") becomes the primary
+// headline, and the source article's own headline drops to a secondary
+// attribution line. This sells the "why it matters to you" promise as
+// the entry point rather than re-printing the wire headline.
+//
+// Native posts (SIGNAL-authored editorial) are exempt — their headline
+// IS the editorial entry point already, so they keep the classic
+// headline-then-commentary layout. The feed wire intentionally strips
+// `source_type` (see storyController.ts), so the only native signal the
+// client has is the shared `source_name === "SIGNAL"` display name that
+// every native generator is seeded with.
+
+/** Display name shared by every native (SIGNAL-authored) generator. */
+export const NATIVE_SOURCE_NAME = "SIGNAL";
+
+type StorySourceFields = Pick<Story, "source_name" | "sources">;
+
+/** Effective source name: explicit `source_name`, else the primary source. */
+function effectiveSourceName(story: StorySourceFields): string | null {
+  return story.source_name ?? story.sources[0]?.name ?? null;
+}
+
+/**
+ * A story is "native" (SIGNAL editorial) when its effective source name is
+ * the shared native display name. Native cards are left untouched by the
+ * hook-as-title swap.
+ */
+export function isNativeStory(story: StorySourceFields): boolean {
+  return effectiveSourceName(story) === NATIVE_SOURCE_NAME;
+}
+
+export interface CardHeadline {
+  /** Bold primary headline. Never blank. */
+  primary: string;
+  /** Secondary source-headline attribution, or null when not applicable. */
+  attribution: string | null;
+}
+
+/**
+ * Resolve the primary headline + secondary attribution for a feed card.
+ *
+ * - Native story → classic layout: source headline stays primary, no
+ *   attribution swap (caller renders commentary below as before).
+ * - Ingested with a non-empty hook → hook becomes primary, the source
+ *   headline becomes the attribution line.
+ * - Ingested with an empty/missing hook → fall back to the source
+ *   headline as primary so the card never renders a blank headline.
+ */
+export function resolveCardHeadline(
+  story: Pick<Story, "headline" | "source_name" | "sources">,
+  hook: string | null | undefined,
+): CardHeadline {
+  const hookText = (hook ?? "").trim();
+  if (isNativeStory(story) || hookText === "") {
+    return { primary: story.headline, attribution: null };
+  }
+  return { primary: hookText, attribution: story.headline };
+}


### PR DESCRIPTION
## Summary
- Inverts feed card hierarchy for **ingested** stories: the accessible-tier commentary thesis (the "hook") becomes the primary headline; the source article headline drops to a muted secondary attribution line. Removes the redundant "Why it matters to you" label on the lead card.
- **Native (SIGNAL) posts are exempt** — they render byte-identically to before. Detection keys on `source_name === "SIGNAL"` (the feed wire strips `source_type`), via a new `isNativeStory` helper.
- Empty/missing hook falls back to the source headline so a card never renders blank.
- Applied consistently across all three feed surfaces: `StoryCard` (grid), `FeedLead` (hero), `FeedRailItem` (Top Stories rail). The rail reads the hook straight from `why_it_matters_to_you` (no lazy fetch).
- Logic centralized in `frontend/src/lib/feedCard.ts` (`isNativeStory`, `resolveCardHeadline`).

## Test plan
- [x] `tsc --noEmit` frontend + backend clean
- [x] Frontend `vitest run`: 21 files / 75 tests passed (helper unit tests + lead/rail hook-promotion + native-untouched)
- [x] Backend `jest`: 85 suites / 1262 passed (untouched — no backend edits)
- [ ] Post-deploy visual: Top Stories rail (#02–#05) headlines with hook text, not source titles; native (SIGNAL) cards unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)