### PR TITLE
feat(feed): three-section feed card (hook title + source attribution + commentary body)

### DIFF
--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -114,6 +114,10 @@ function shapeStory(row: StoryRow, role: string | null): Record<string, unknown>
       whyItMattersTemplate: row.whyItMattersTemplate,
       role,
     }),
+    // Phase 12n — role-neutral commentary on the wire (mirrors
+    // shapeEvent). Lets the feed card derive its hook title + body
+    // uniformly whether the row is a legacy story or an event.
+    generic_commentary: row.genericCommentary,
     // Phase 12c contract: feed-list responses never carry the
     // per-user commentary inline. The client hydrates it via
     // GET /stories/:id/commentary after the feed lands. Returning
@@ -204,6 +208,11 @@ function shapeEvent(
       whyItMattersTemplate: row.whyItMattersTemplate,
       role,
     }),
+    // Phase 12n — role-neutral commentary on the feed wire. The card
+    // derives its hook title (first sentence) + commentary body from
+    // this; it is present immediately (no lazy fetch) and is the same
+    // text free-tier users read on the detail page.
+    generic_commentary: row.genericCommentary,
     commentary: null,
     commentary_source: null,
     // `source_url` and `source_name` are kept on the wire for

--- a/frontend/src/components/feed/FeedLead.test.tsx
+++ b/frontend/src/components/feed/FeedLead.test.tsx
@@ -37,6 +37,7 @@ function baseStory(overrides: Partial<Story> = {}): Story {
     why_it_matters_to_you: "Why it matters to you body.",
     commentary: null,
     commentary_source: null,
+    generic_commentary: null,
     source_url: "https://example.com/article",
     source_name: "Example",
     primary_source_url: "https://example.com/article",
@@ -83,24 +84,33 @@ describe("FeedLead hero imagery", () => {
     expect(container.querySelectorAll("img").length).toBe(0);
   });
 
-  // Hook-as-title: for ingested stories the personalization hook is
-  // promoted to the headline and the source article headline drops to a
-  // muted attribution line. The old "Why it matters to you" label is gone.
-  it("promotes the hook to the headline for an ingested story", () => {
+  // Three-section model: for ingested stories the hook title (first
+  // sentence of generic_commentary) is the headline, the source article
+  // headline drops to a muted attribution line, and the commentary body
+  // (the remainder of generic_commentary) renders as its own paragraph.
+  // The old "Why it matters to you" label is gone for ingested rows.
+  it("splits generic_commentary into hook title + attribution + body", () => {
     renderLead(
       baseStory({
         headline: "Source wire headline",
-        why_it_matters_to_you: "This is the hook that should headline.",
+        generic_commentary:
+          "This is the hook that should headline. And here is why it matters.",
       }),
     );
+    // Section 1 — hook title (first sentence, trailing period stripped).
     expect(
-      screen.getByText("This is the hook that should headline."),
+      screen.getByText("This is the hook that should headline"),
     ).toBeInTheDocument();
+    // Section 2 — source headline demoted to muted attribution.
     expect(screen.getByText("Source wire headline")).toBeInTheDocument();
+    // Section 3 — commentary body (the remainder).
+    expect(screen.getByText("And here is why it matters.")).toBeInTheDocument();
     expect(screen.queryByText("Why it matters to you")).not.toBeInTheDocument();
   });
 
-  // Native (SIGNAL) stories keep the classic headline + framed commentary.
+  // Native (SIGNAL) stories keep the classic headline + framed commentary,
+  // untouched by the three-section split even though they also carry
+  // generic_commentary on the wire.
   it("leaves native (SIGNAL) stories untouched", () => {
     renderLead(
       baseStory({
@@ -108,10 +118,13 @@ describe("FeedLead hero imagery", () => {
         sources: [{ url: "https://signal.so", name: "SIGNAL", role: "primary" }],
         headline: "Editorial native headline",
         why_it_matters_to_you: "Native commentary body.",
+        generic_commentary: "Native hook. Native body that must not split.",
       }),
     );
     expect(screen.getByText("Editorial native headline")).toBeInTheDocument();
     expect(screen.getByText("Why it matters to you")).toBeInTheDocument();
     expect(screen.getByText("Native commentary body.")).toBeInTheDocument();
+    // The generic_commentary hook must NOT appear — native is exempt.
+    expect(screen.queryByText("Native hook")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/feed/FeedLead.tsx
+++ b/frontend/src/components/feed/FeedLead.tsx
@@ -9,7 +9,7 @@ import { StorySaveButton } from "@/components/stories/StorySaveButton";
 import { useStoryCommentary } from "@/hooks/useStoryCommentary";
 import { useReadStoriesStore } from "@/store/readStoriesStore";
 import { timeAgo } from "@/lib/timeAgo";
-import { isNativeStory, resolveCardHeadline } from "@/lib/feedCard";
+import { isNativeStory, splitHook } from "@/lib/feedCard";
 import { isGatePayload, type Story } from "@/types/story";
 
 // "Intelligence Terminal × Editorial" front page — the lead story.
@@ -39,20 +39,28 @@ export function FeedLead({ story }: { story: Story }): JSX.Element {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  const commentaryQuery = useStoryCommentary(story.id, { enabled: true });
+  // Only native (SIGNAL editorial) leads keep the lazy personalized
+  // commentary. Ingested leads build all three sections from
+  // `generic_commentary` on the wire, so they don't fetch.
+  const native = isNativeStory(story);
+  const commentaryQuery = useStoryCommentary(story.id, { enabled: native });
   const resolved =
     commentaryQuery.data && !isGatePayload(commentaryQuery.data)
       ? commentaryQuery.data.commentary
       : null;
-  const loading = resolved === null && commentaryQuery.isFetching;
+  const loading = native && resolved === null && commentaryQuery.isFetching;
   const body = resolved?.thesis ?? story.why_it_matters_to_you;
 
   const isRead = useReadStoriesStore((s) => s.isRead(story.id));
   const sectorColor = SECTOR_VAR[story.sector] ?? "var(--ink-muted)";
   const sectorLabel = SECTOR_LABEL[story.sector] ?? story.sector;
   const source = story.source_name ?? story.sources[0]?.name ?? null;
-  const native = isNativeStory(story);
-  const headline = resolveCardHeadline(story, body);
+  // Ingested three-section split: hook title (first sentence) + body.
+  const { hookTitle, commentaryBody } = splitHook(
+    story.generic_commentary,
+    story.headline,
+  );
+  const attribution = hookTitle === story.headline ? null : story.headline;
 
   return (
     <motion.article
@@ -145,10 +153,11 @@ export function FeedLead({ story }: { story: Story }): JSX.Element {
           </>
         ) : (
           <>
-            {/* Ingested: the hook becomes the hero headline; the source
-                article headline drops to a secondary attribution line.
-                The "Why it matters to you" label is dropped — the hook
-                now speaks for itself as the headline. */}
+            {/* Ingested: three sections — hook title (first sentence of
+                generic_commentary) as the hero headline, the source
+                article headline as muted attribution, then the commentary
+                body. The "Why it matters to you" label is dropped — the
+                hook now speaks for itself as the headline. */}
             <h2
               className={[
                 "font-display text-[32px] font-semibold leading-[1.08] tracking-tight transition-colors duration-150 md:text-[40px]",
@@ -161,11 +170,24 @@ export function FeedLead({ story }: { story: Story }): JSX.Element {
                 overflow: "hidden",
               }}
             >
-              {headline.primary}
+              {hookTitle}
             </h2>
-            {headline.attribution && (
-              <p className="mt-4 max-w-[58ch] truncate text-[15px] leading-relaxed text-ink-muted">
-                {headline.attribution}
+            {attribution && (
+              <p className="mt-3 max-w-[58ch] truncate text-[15px] leading-relaxed text-ink-muted">
+                {attribution}
+              </p>
+            )}
+            {commentaryBody && (
+              <p
+                className="mt-4 max-w-[58ch] text-[16px] leading-relaxed text-ink-muted"
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                {commentaryBody}
               </p>
             )}
           </>

--- a/frontend/src/components/feed/FeedRailItem.test.tsx
+++ b/frontend/src/components/feed/FeedRailItem.test.tsx
@@ -15,6 +15,7 @@ function baseStory(overrides: Partial<Story> = {}): Story {
     why_it_matters_to_you: "The hook that should headline.",
     commentary: null,
     commentary_source: null,
+    generic_commentary: null,
     source_url: "https://example.com/a",
     source_name: "OutletA",
     primary_source_url: "https://example.com/a",
@@ -32,12 +33,30 @@ function baseStory(overrides: Partial<Story> = {}): Story {
 }
 
 describe("FeedRailItem hook-as-title", () => {
-  it("promotes the hook to the headline and demotes the source headline", () => {
-    render(<FeedRailItem story={baseStory()} rank={2} />);
+  // The rail is compact: hook title (first sentence of generic_commentary)
+  // as the H3, source headline demoted to a muted attribution line, and NO
+  // commentary body (too dense for the secondary rail).
+  it("promotes the hook title and demotes the source headline", () => {
+    render(
+      <FeedRailItem
+        story={baseStory({
+          headline: "Source wire headline",
+          generic_commentary:
+            "The hook that should headline. Body text the rail omits.",
+        })}
+        rank={2}
+      />,
+    );
+    // Hook title (first sentence, trailing period stripped) is the H3.
     expect(
-      screen.getByText("The hook that should headline."),
+      screen.getByText("The hook that should headline"),
     ).toBeInTheDocument();
+    // Source headline survives as a muted attribution line.
     expect(screen.getByText("Source wire headline")).toBeInTheDocument();
+    // The commentary body is omitted on the rail.
+    expect(
+      screen.queryByText("Body text the rail omits."),
+    ).not.toBeInTheDocument();
   });
 
   it("leaves native (SIGNAL) items on their editorial headline", () => {
@@ -47,14 +66,14 @@ describe("FeedRailItem hook-as-title", () => {
           source_name: "SIGNAL",
           sources: [{ url: "https://signal.so", name: "SIGNAL", role: "primary" }],
           headline: "Editorial native headline",
-          why_it_matters_to_you: "Native commentary that must not headline.",
+          generic_commentary: "Native hook that must not headline. And a body.",
         })}
         rank={3}
       />,
     );
     expect(screen.getByText("Editorial native headline")).toBeInTheDocument();
     expect(
-      screen.queryByText("Native commentary that must not headline."),
+      screen.queryByText("Native hook that must not headline"),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/feed/FeedRailItem.tsx
+++ b/frontend/src/components/feed/FeedRailItem.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { useReadStoriesStore } from "@/store/readStoriesStore";
 import { timeAgo } from "@/lib/timeAgo";
-import { resolveCardHeadline } from "@/lib/feedCard";
+import { isNativeStory, splitHook } from "@/lib/feedCard";
 import type { Story } from "@/types/story";
 
 // Secondary "top stories" rail item. Deliberately dense and text-only:
@@ -12,12 +12,13 @@ import type { Story } from "@/types/story";
 // and a mono meta line. No imagery, no commentary body — the rail is
 // for fast triage of the next-most-important stories beside the lead.
 //
-// Hook-as-title: like the lead and grid cards, ingested rail items
-// headline with the personalization hook and drop the source article
-// headline to a muted attribution line. The rail has no lazy commentary
-// fetch, so the hook comes straight from `why_it_matters_to_you` (the
-// 12b template floor, always present on the wire). Native (SIGNAL)
-// items keep their editorial headline untouched.
+// Three-section model (compact): ingested rail items headline with the
+// hook title (first sentence of generic_commentary, straight off the
+// wire — no lazy fetch) and drop the source article headline to a muted
+// attribution line. The rail omits the commentary body — it's too
+// compact. Native (SIGNAL) items keep their editorial headline untouched
+// (splitHook falls back to story.headline when generic_commentary is
+// absent, and native rows are read identically here).
 
 const EASE: [number, number, number, number] = [0.2, 0.8, 0.2, 1];
 
@@ -51,10 +52,14 @@ export function FeedRailItem({
   const isRead = useReadStoriesStore((s) => s.isRead(story.id));
   const sectorColor = SECTOR_VAR[story.sector] ?? "var(--ink-muted)";
   const source = story.source_name ?? story.sources[0]?.name ?? null;
-  // For native items resolveCardHeadline returns the editorial headline as
-  // primary with no attribution, so the rail renders byte-identically to
-  // before. For ingested items the hook becomes the headline.
-  const headline = resolveCardHeadline(story, story.why_it_matters_to_you);
+  // Native items render byte-identically to before (editorial headline, no
+  // attribution). Ingested items headline with the hook title and drop the
+  // source headline to a muted attribution line.
+  const native = isNativeStory(story);
+  const { hookTitle } = splitHook(story.generic_commentary, story.headline);
+  const railTitle = native ? story.headline : hookTitle;
+  const attribution =
+    native || hookTitle === story.headline ? null : story.headline;
 
   return (
     <motion.div variants={animated ? railItemVariants : undefined}>
@@ -92,11 +97,11 @@ export function FeedRailItem({
             overflow: "hidden",
           }}
         >
-          {headline.primary}
+          {railTitle}
         </h3>
-        {headline.attribution && (
+        {attribution && (
           <p className="mt-1 truncate text-xs leading-snug text-ink-muted">
-            {headline.attribution}
+            {attribution}
           </p>
         )}
         <div className="mt-2 flex items-center gap-3 text-ink-muted">

--- a/frontend/src/components/stories/StoryCard.test.tsx
+++ b/frontend/src/components/stories/StoryCard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -54,6 +54,7 @@ function baseStory(overrides: Partial<Story> = {}): Story {
     why_it_matters_to_you: "Why it matters to you body.",
     commentary: null,
     commentary_source: null,
+    generic_commentary: null,
     source_url: "https://example.com/article",
     source_name: "Example",
     primary_source_url: "https://example.com/article",
@@ -102,5 +103,46 @@ describe("StoryCard imagery (text-forward river card)", () => {
     const { container } = renderCard(baseStory({ image_url: null }));
     const imgs = container.querySelectorAll("img");
     expect(imgs.length).toBe(0);
+  });
+});
+
+describe("StoryCard three-section model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Ingested cards build three sections from generic_commentary: the hook
+  // title (first sentence) as the headline, the source headline as muted
+  // attribution, and the remainder as the commentary body.
+  it("splits generic_commentary into hook title + attribution + body", () => {
+    renderCard(
+      baseStory({
+        headline: "Source wire headline",
+        generic_commentary:
+          "The hook that leads the card. Plus the body that follows it.",
+      }),
+    );
+    expect(screen.getByText("The hook that leads the card")).toBeInTheDocument();
+    expect(screen.getByText("Source wire headline")).toBeInTheDocument();
+    expect(
+      screen.getByText("Plus the body that follows it."),
+    ).toBeInTheDocument();
+  });
+
+  // Native (SIGNAL) cards keep the classic headline-then-commentary layout,
+  // untouched by the split even though they carry generic_commentary.
+  it("leaves native (SIGNAL) cards on their editorial headline", () => {
+    renderCard(
+      baseStory({
+        source_name: "SIGNAL",
+        sources: [{ url: "https://signal.so", name: "SIGNAL", role: "primary" }],
+        headline: "Editorial native headline",
+        generic_commentary: "Native hook that must not headline. And a body.",
+      }),
+    );
+    expect(screen.getByText("Editorial native headline")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Native hook that must not headline"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/stories/StoryCard.tsx
+++ b/frontend/src/components/stories/StoryCard.tsx
@@ -9,7 +9,7 @@ import { Card, type CardSectorAccent } from "@/components/ui/Card";
 import { useStoryCommentary } from "@/hooks/useStoryCommentary";
 import { useReadStoriesStore } from "@/store/readStoriesStore";
 import { timeAgo } from "@/lib/timeAgo";
-import { isNativeStory, resolveCardHeadline } from "@/lib/feedCard";
+import { isNativeStory, splitHook } from "@/lib/feedCard";
 import { isGatePayload, type Story } from "@/types/story";
 
 const VISIBILITY_ROOT_MARGIN = "1200px 0px";
@@ -75,18 +75,29 @@ export function StoryCard({
     return () => observer.disconnect();
   }, [shouldLoad]);
 
-  const commentaryQuery = useStoryCommentary(story.id, { enabled: shouldLoad });
+  // Only native cards still consume the per-user personalized commentary
+  // (they keep the classic lazy-loaded layout). Ingested cards build all
+  // three sections from `generic_commentary` on the wire, so they don't
+  // fetch — gating the query on `native` avoids a wasted request per card.
+  const native = isNativeStory(story);
+  const commentaryQuery = useStoryCommentary(story.id, {
+    enabled: shouldLoad && native,
+  });
   const apiCommentary =
     commentaryQuery.data && !isGatePayload(commentaryQuery.data)
       ? commentaryQuery.data.commentary
       : null;
   const resolvedCommentary = apiCommentary ?? story.commentary ?? null;
   const isCommentaryLoading =
-    shouldLoad && resolvedCommentary === null && commentaryQuery.isFetching;
+    shouldLoad && native && resolvedCommentary === null && commentaryQuery.isFetching;
 
   const previewText = resolvedCommentary?.thesis ?? story.why_it_matters_to_you;
-  const native = isNativeStory(story);
-  const headline = resolveCardHeadline(story, previewText);
+  // Ingested three-section split: hook title (first sentence) + body.
+  const { hookTitle, commentaryBody } = splitHook(
+    story.generic_commentary,
+    story.headline,
+  );
+  const attribution = hookTitle === story.headline ? null : story.headline;
   const sourceCount = story.sources.length;
   const primarySource = story.source_name ?? story.sources[0]?.name ?? null;
   const sourceLabel =
@@ -159,11 +170,12 @@ export function StoryCard({
             </>
           ) : (
             <>
-              {/* Ingested: the hook becomes the headline; the source
-                  article headline drops to a secondary attribution line. */}
+              {/* Ingested: three sections — hook title (first sentence of
+                  generic_commentary) as the headline, the source article
+                  headline as muted attribution, then the commentary body. */}
               <h2
                 className={[
-                  "mb-2 font-display text-[19px] font-semibold leading-snug transition-colors duration-150 group-hover:text-accent",
+                  "mb-1 font-display text-[19px] font-semibold leading-snug transition-colors duration-150 group-hover:text-accent",
                   isRead ? "text-ink-muted" : "text-ink",
                 ].join(" ")}
                 style={{
@@ -173,11 +185,24 @@ export function StoryCard({
                   overflow: "hidden",
                 }}
               >
-                {headline.primary}
+                {hookTitle}
               </h2>
-              {headline.attribution && (
-                <p className="truncate text-xs leading-relaxed text-ink-muted">
-                  {headline.attribution}
+              {attribution && (
+                <p className="mb-2 truncate text-xs leading-relaxed text-ink-muted">
+                  {attribution}
+                </p>
+              )}
+              {commentaryBody && (
+                <p
+                  className="text-sm leading-relaxed text-ink-muted"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}
+                >
+                  {commentaryBody}
                 </p>
               )}
             </>

--- a/frontend/src/components/stories/StoryDetail.test.tsx
+++ b/frontend/src/components/stories/StoryDetail.test.tsx
@@ -50,6 +50,7 @@ function baseStory(overrides: Partial<Story> = {}): Story {
     why_it_matters_to_you: "Why it matters to you body.",
     commentary: null,
     commentary_source: null,
+    generic_commentary: null,
     source_url: "https://example.com/article",
     source_name: "Example",
     primary_source_url: "https://example.com/article",

--- a/frontend/src/lib/feedCard.test.ts
+++ b/frontend/src/lib/feedCard.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { Story } from "@/types/story";
-import {
-  NATIVE_SOURCE_NAME,
-  isNativeStory,
-  resolveCardHeadline,
-} from "./feedCard";
+import { NATIVE_SOURCE_NAME, isNativeStory, splitHook } from "./feedCard";
 
 function story(overrides: Partial<Story> = {}): Story {
   return {
@@ -18,6 +14,7 @@ function story(overrides: Partial<Story> = {}): Story {
     why_it_matters_to_you: "",
     commentary: null,
     commentary_source: null,
+    generic_commentary: null,
     source_url: "https://example.com/a",
     source_name: "OutletA",
     primary_source_url: "https://example.com/a",
@@ -54,31 +51,59 @@ describe("isNativeStory", () => {
   });
 });
 
-describe("resolveCardHeadline", () => {
-  it("swaps hook to primary and source headline to attribution for ingested", () => {
-    const result = resolveCardHeadline(story(), "The hook that matters.");
-    expect(result.primary).toBe("The hook that matters.");
-    expect(result.attribution).toBe("Source article headline");
+describe("splitHook", () => {
+  it("falls back to the headline when generic is null", () => {
+    expect(splitHook(null, "Fallback headline")).toEqual({
+      hookTitle: "Fallback headline",
+      commentaryBody: null,
+    });
   });
 
-  it("keeps the source headline primary for native (no swap)", () => {
-    const result = resolveCardHeadline(
-      story({ source_name: NATIVE_SOURCE_NAME }),
-      "A hook that should be ignored.",
+  it("falls back to the headline when generic is empty/whitespace", () => {
+    expect(splitHook("   ", "Fallback headline")).toEqual({
+      hookTitle: "Fallback headline",
+      commentaryBody: null,
+    });
+  });
+
+  it("returns the whole text (period stripped) for a single sentence", () => {
+    expect(splitHook("This is the only sentence.", "fallback")).toEqual({
+      hookTitle: "This is the only sentence",
+      commentaryBody: null,
+    });
+  });
+
+  it("splits a multi-sentence string at the first sentence boundary", () => {
+    const { hookTitle, commentaryBody } = splitHook(
+      "Nvidia blew past estimates. The data-center segment doubled. Margins held.",
+      "fallback",
     );
-    expect(result.primary).toBe("Source article headline");
-    expect(result.attribution).toBeNull();
+    expect(hookTitle).toBe("Nvidia blew past estimates");
+    expect(commentaryBody).toBe("The data-center segment doubled. Margins held.");
   });
 
-  it("falls back to the source headline when the hook is empty", () => {
-    const result = resolveCardHeadline(story(), "   ");
-    expect(result.primary).toBe("Source article headline");
-    expect(result.attribution).toBeNull();
+  it("splits on an em-dash clause break, excluding the dash", () => {
+    const { hookTitle, commentaryBody } = splitHook(
+      "Apple's services pivot is working — the revenue mix shifted hard.",
+      "fallback",
+    );
+    expect(hookTitle).toBe("Apple's services pivot is working");
+    expect(commentaryBody).toBe("the revenue mix shifted hard.");
   });
 
-  it("falls back to the source headline when the hook is null", () => {
-    const result = resolveCardHeadline(story(), null);
-    expect(result.primary).toBe("Source article headline");
-    expect(result.attribution).toBeNull();
+  it("keeps an exclamation / question mark on the hook title", () => {
+    expect(splitHook("Huge news today! Here is why it matters.", "fallback")).toEqual(
+      { hookTitle: "Huge news today!", commentaryBody: "Here is why it matters." },
+    );
+  });
+
+  it("does not split on a period that is not a sentence boundary", () => {
+    // "U.S." has no following capital-after-space at the dot, so the first
+    // real boundary is after "markets".
+    const { hookTitle } = splitHook(
+      "The U.S. moved markets. More follows.",
+      "fallback",
+    );
+    expect(hookTitle).toBe("The U.S. moved markets");
   });
 });

--- a/frontend/src/lib/feedCard.ts
+++ b/frontend/src/lib/feedCard.ts
@@ -1,19 +1,23 @@
 import type { Story } from "@/types/story";
 
-// Hook-as-title feed card model.
+// Three-section feed card model.
 //
-// For ingested stories the feed card inverts its hierarchy: the
-// accessible-tier commentary thesis (the "hook") becomes the primary
-// headline, and the source article's own headline drops to a secondary
-// attribution line. This sells the "why it matters to you" promise as
-// the entry point rather than re-printing the wire headline.
+// For ingested stories the feed card is built from `generic_commentary`
+// (role-neutral, on the wire) split into two parts plus the source
+// headline:
+//   1. Hook title       — the first sentence of generic_commentary, shown
+//                          as the bold primary headline.
+//   2. Source attribution — the source article's own headline, muted and
+//                          smaller, directly below the hook title.
+//   3. Commentary body   — the remainder of generic_commentary after the
+//                          first sentence, as a separate paragraph.
 //
-// Native posts (SIGNAL-authored editorial) are exempt — their headline
-// IS the editorial entry point already, so they keep the classic
-// headline-then-commentary layout. The feed wire intentionally strips
-// `source_type` (see storyController.ts), so the only native signal the
-// client has is the shared `source_name === "SIGNAL"` display name that
-// every native generator is seeded with.
+// Native posts (SIGNAL-authored editorial) are exempt — their headline IS
+// the editorial entry point, so they keep the classic headline-then-
+// commentary layout. The feed wire intentionally strips `source_type`
+// (see storyController.ts), so the only native signal the client has is
+// the shared `source_name === "SIGNAL"` display name every native
+// generator is seeded with.
 
 /** Display name shared by every native (SIGNAL-authored) generator. */
 export const NATIVE_SOURCE_NAME = "SIGNAL";
@@ -28,36 +32,63 @@ function effectiveSourceName(story: StorySourceFields): string | null {
 /**
  * A story is "native" (SIGNAL editorial) when its effective source name is
  * the shared native display name. Native cards are left untouched by the
- * hook-as-title swap.
+ * three-section swap.
  */
 export function isNativeStory(story: StorySourceFields): boolean {
   return effectiveSourceName(story) === NATIVE_SOURCE_NAME;
 }
 
-export interface CardHeadline {
-  /** Bold primary headline. Never blank. */
-  primary: string;
-  /** Secondary source-headline attribution, or null when not applicable. */
-  attribution: string | null;
+export interface HookSplit {
+  /** Bold primary headline (first sentence of the hook). Never blank. */
+  hookTitle: string;
+  /** Remaining commentary after the first sentence, or null if none. */
+  commentaryBody: string | null;
 }
 
+/** Drop a single trailing period (but keep `!` / `?` — they carry punch). */
+function stripTrailingPeriod(s: string): string {
+  return s.replace(/\.\s*$/, "").trim();
+}
+
+// First sentence boundary: terminal punctuation (`.`/`!`/`?`) followed by
+// whitespace and a capital / opening quote, OR an em-dash clause break.
+// The two alternatives are scanned together so we split on whichever
+// occurs first, left to right.
+const BOUNDARY = /([.!?])\s+(?=[A-Z"'“‘])|\s*—\s*/;
+
 /**
- * Resolve the primary headline + secondary attribution for a feed card.
+ * Split `generic` into a hook title (first sentence) and a commentary body
+ * (the remainder). When `generic` is null/empty the hook title falls back
+ * to `fallbackHeadline` and the body is null, so a card never renders a
+ * blank headline.
  *
- * - Native story → classic layout: source headline stays primary, no
- *   attribution swap (caller renders commentary below as before).
- * - Ingested with a non-empty hook → hook becomes primary, the source
- *   headline becomes the attribution line.
- * - Ingested with an empty/missing hook → fall back to the source
- *   headline as primary so the card never renders a blank headline.
+ * The hook title is a single clean sentence — its trailing period is
+ * stripped for display (it reads as a headline, not prose).
  */
-export function resolveCardHeadline(
-  story: Pick<Story, "headline" | "source_name" | "sources">,
-  hook: string | null | undefined,
-): CardHeadline {
-  const hookText = (hook ?? "").trim();
-  if (isNativeStory(story) || hookText === "") {
-    return { primary: story.headline, attribution: null };
+export function splitHook(
+  generic: string | null | undefined,
+  fallbackHeadline: string,
+): HookSplit {
+  const text = (generic ?? "").trim();
+  if (text === "") {
+    return { hookTitle: fallbackHeadline, commentaryBody: null };
   }
-  return { primary: hookText, attribution: story.headline };
+
+  const match = BOUNDARY.exec(text);
+  if (!match) {
+    // Single sentence / no boundary — the whole thing is the hook.
+    return { hookTitle: stripTrailingPeriod(text), commentaryBody: null };
+  }
+
+  const idx = match.index;
+  const isPunctuation = match[1] != null;
+  // For punctuation keep the terminal mark with the hook (then strip a
+  // trailing period); for an em-dash break exclude the dash from both sides.
+  const hookRaw = isPunctuation ? text.slice(0, idx + 1) : text.slice(0, idx);
+  const body = text.slice(idx + match[0].length).trim();
+
+  return {
+    hookTitle: stripTrailingPeriod(hookRaw) || fallbackHeadline,
+    commentaryBody: body.length > 0 ? body : null,
+  };
 }

--- a/frontend/src/types/story.ts
+++ b/frontend/src/types/story.ts
@@ -90,6 +90,12 @@ export interface Story {
   // jsonb shape that lands in commentary_cache.
   commentary: CommentaryShape | null;
   commentary_source: CommentarySource | null;
+  // Phase 12n — role-neutral commentary, always present on the feed
+  // wire (null only for legacy rows never backfilled). The feed card
+  // splits this into a hook title (first sentence, shown as the
+  // headline) and a commentary body (the remainder). Null falls back to
+  // the source `headline` as the hook title.
+  generic_commentary: string | null;
   source_url: string;
   source_name: string | null;
   // Phase 12e.7a: multi-source attribution for ingestion-written events.


### PR DESCRIPTION
## Summary
- Splits role-neutral `generic_commentary` into three sections per ingested card: **hook title** (first sentence → headline), **source attribution** (source headline, muted), **commentary body** (remainder, own paragraph).
- Fixes PR #105, which used the wrong field (`why_it_matters_to_you`, a role-based 12c template) and left no body section.
- `generic_commentary` now rides the feed wire via `shapeEvent` **and** `shapeStory` (so saved/search match the feed). Applied across `FeedLead`, `StoryCard`, and `FeedRailItem` (rail omits the body — too compact).
- Native (SIGNAL) posts are exempt on every surface — rendering unchanged.
- `useStoryCommentary` is now gated on `native`: ingested cards read commentary off the wire instead of firing a wasted per-card lazy fetch.

## splitHook
`splitHook(generic, fallbackHeadline)` → `{ hookTitle, commentaryBody }`. Boundary regex `/([.!?])\s+(?=[A-Z\"'""])|\s*—\s*/` splits on the leftmost of terminal-punctuation-then-capital or em-dash clause break; abbreviation-safe (`U.S. moved` doesn't split). Null/empty → `hookTitle` falls back to `story.headline`, body null, so a card never renders blank.

## Test plan
- [x] Frontend tsc clean
- [x] Backend tsc clean
- [x] Frontend vitest — 21 files / 80 tests passed
- [x] Backend jest — 85 suites / 1262 passed / 0 failed
- [ ] Post-deploy visual: ingested cards show 3 distinct sections; native unchanged; rail shows hook title not source headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)