### PR TITLE
fix(search): rewrite getRelatedStories to query events table

### DIFF
--- a/backend/src/controllers/storyController.ts
+++ b/backend/src/controllers/storyController.ts
@@ -1161,13 +1161,30 @@ export async function getRelatedStories(
     const userId = requireUserId(req);
     const { id } = idParamSchema.parse(req.params);
 
-    const [current] = await db
+    // Phase 12q — dual-table anchor lookup: try `stories` (legacy hand-
+    // curated rows) first, then `events` (ingestion pipeline). Mirrors
+    // the same pattern in getStoryById. Clients reach this route from both
+    // surfaces — a legacy story detail and an event detail both call
+    // GET /stories/:id/related with their respective UUIDs.
+    let anchorSector: string;
+    const [storyAnchor] = await db
       .select({ id: stories.id, sector: stories.sector })
       .from(stories)
       .where(eq(stories.id, id))
       .limit(1);
-    if (!current) {
-      throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
+
+    if (storyAnchor) {
+      anchorSector = storyAnchor.sector;
+    } else {
+      const [eventAnchor] = await db
+        .select({ id: events.id, sector: events.sector })
+        .from(events)
+        .where(eq(events.id, id))
+        .limit(1);
+      if (!eventAnchor) {
+        throw new AppError("STORY_NOT_FOUND", "Story not found", 404);
+      }
+      anchorSector = eventAnchor.sector;
     }
 
     const [profile] = await db
@@ -1176,20 +1193,66 @@ export async function getRelatedStories(
       .where(eq(userProfiles.userId, userId))
       .limit(1);
 
+    // Phase 12q — related content now queries `events`. Similarity
+    // mechanism unchanged: same sector, newest first (COALESCE on
+    // publishedAt / createdAt). The `events` table has an `embedding`
+    // column (pgvector) but vector similarity is deferred to a future
+    // phase; sector + recency gives reasonable recall at zero extra cost.
+    // Covered by events_sector_published_at_idx on (sector, published_at).
     const rows = (await db
       .select({
-        ...baseStoryColumns,
-        isSaved: isSavedExpr(userId),
-        saveCount: saveCountExpr(),
-        commentCount: commentCountExpr(),
+        id: events.id,
+        sector: events.sector,
+        headline: events.headline,
+        context: events.context,
+        whyItMatters: events.whyItMatters,
+        whyItMattersTemplate: events.whyItMattersTemplate,
+        genericCommentary: events.genericCommentary,
+        primarySourceUrl: events.primarySourceUrl,
+        primarySourceName: events.primarySourceName,
+        sourceType: events.sourceType,
+        generatorSlug: eventGeneratorSlugExpr(),
+        imageUrl: events.imageUrl,
+        publishedAt: events.publishedAt,
+        createdAt: events.createdAt,
+        authorId: writers.id,
+        authorName: writers.name,
+        authorBio: writers.bio,
+        isSaved: isEventSavedExpr(userId),
+        saveCount: eventSaveCountExpr(),
+        commentCount: eventCommentCountExpr(),
+        effectiveScore: sql<number>`0`,
       })
-      .from(stories)
-      .leftJoin(writers, eq(writers.id, stories.authorId))
-      .where(and(eq(stories.sector, current.sector), ne(stories.id, current.id)))
-      .orderBy(desc(sql`COALESCE(${stories.publishedAt}, ${stories.createdAt})`))
-      .limit(RELATED_LIMIT)) as StoryRow[];
+      .from(events)
+      .leftJoin(writers, eq(writers.id, events.authorId))
+      .where(and(eq(events.sector, anchorSector), ne(events.id, id)))
+      .orderBy(desc(sql`COALESCE(${events.publishedAt}, ${events.createdAt})`))
+      .limit(RELATED_LIMIT)) as EventRow[];
 
-    const shaped = rows.map((row) => shapeStory(row, profile?.role ?? null));
+    // Batch-fetch event_sources — same pattern as getFeed / searchStories.
+    const eventIds = rows.map((r) => r.id);
+    const allSources =
+      eventIds.length > 0
+        ? await db
+            .select({
+              eventId: eventSources.eventId,
+              url: eventSources.url,
+              name: eventSources.name,
+              role: eventSources.role,
+            })
+            .from(eventSources)
+            .where(inArray(eventSources.eventId, eventIds))
+        : [];
+    const sourcesByEventId = new Map<string, EventSourceRow[]>();
+    for (const s of allSources) {
+      const arr = sourcesByEventId.get(s.eventId) ?? [];
+      arr.push({ url: s.url, name: s.name, role: s.role });
+      sourcesByEventId.set(s.eventId, arr);
+    }
+
+    const shaped = rows.map((row) =>
+      shapeEvent(row, profile?.role ?? null, sourcesByEventId.get(row.id) ?? []),
+    );
     res.json({ data: { stories: shaped } });
   } catch (error) {
     next(error);

--- a/backend/tests/stories.integration.test.ts
+++ b/backend/tests/stories.integration.test.ts
@@ -399,14 +399,19 @@ describe("stories endpoints", () => {
     });
   });
 
+  // Phase 12q — getRelatedStories was rewritten to query `events`.
+  // Anchor lookup tries `stories` first, then `events` (dual-table
+  // pattern matching getStoryById). Related content is fetched from
+  // `events` with a sources batch-fetch, shaped via shapeEvent.
   describe("GET /api/v1/stories/:id/related", () => {
     it("returns 401 without a token", async () => {
       const res = await request(app).get(`/api/v1/stories/${storyId}/related`);
       expect(res.status).toBe(401);
     });
 
-    it("returns 404 when base story is missing", async () => {
-      mock.queueSelect([]);
+    it("returns 404 when neither stories nor events contains the id", async () => {
+      mock.queueSelect([]); // stories anchor miss
+      mock.queueSelect([]); // events anchor miss
 
       const res = await request(app)
         .get(`/api/v1/stories/${storyId}/related`)
@@ -416,13 +421,14 @@ describe("stories endpoints", () => {
       expect(res.body.error.code).toBe("STORY_NOT_FOUND");
     });
 
-    it("returns same-sector stories excluding the current one", async () => {
-      mock.queueSelect([{ id: storyId, sector: "ai" }]);
-      mock.queueSelect([{ role: "engineer" }]);
-      mock.queueSelect([
-        makeRow({ id: "22222222-2222-2222-2222-222222222222" }),
-        makeRow({ id: "33333333-3333-3333-3333-333333333333" }),
+    it("returns same-sector events when anchor is a legacy story id", async () => {
+      mock.queueSelect([{ id: storyId, sector: "ai" }]); // stories anchor found
+      mock.queueSelect([{ role: "engineer" }]);           // profile
+      mock.queueSelect([                                  // related events
+        makeEventRow({ id: "22222222-2222-2222-2222-222222222222" }),
+        makeEventRow({ id: "44444444-4444-4444-4444-444444444444" }),
       ]);
+      mock.queueSelect([]);                               // event_sources batch
 
       const res = await request(app)
         .get(`/api/v1/stories/${storyId}/related`)
@@ -433,6 +439,27 @@ describe("stories endpoints", () => {
       expect(res.body.data.stories[0].id).not.toBe(storyId);
       expect(res.body.data.stories[0].why_it_matters_to_you).toContain(
         "As an engineer",
+      );
+    });
+
+    it("returns same-sector events when anchor is an event id", async () => {
+      mock.queueSelect([]);                                     // stories anchor miss
+      mock.queueSelect([{ id: eventId, sector: "finance" }]);  // events anchor found
+      mock.queueSelect([{ role: "analyst" }]);                  // profile
+      mock.queueSelect([                                        // related events
+        makeEventRow({ id: storyId, sector: "finance" }),
+      ]);
+      mock.queueSelect([]);                                     // event_sources batch
+
+      const res = await request(app)
+        .get(`/api/v1/stories/${eventId}/related`)
+        .set(...auth(token));
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.stories).toHaveLength(1);
+      expect(res.body.data.stories[0].sector).toBe("finance");
+      expect(res.body.data.stories[0].why_it_matters_to_you).toContain(
+        "As an analyst",
       );
     });
   });


### PR DESCRIPTION
## Summary

- **Anchor lookup** now tries `stories` first then falls back to `events` — mirrors `getStoryById`. Previously any event UUID threw 404 immediately.
- **Related query** switched from `stories` (20 seeded rows) to `events` with identical sector-match + recency ordering. Sources batch-fetched; shaped via `shapeEvent`.
- No migration needed — `events_sector_published_at_idx` covers the sector filter; `RELATED_LIMIT=5` makes the COALESCE ordering cost negligible.

## Test plan

- [ ] Updated 404 test: now queues two misses (stories + events)
- [ ] Updated happy-path test: rows use `makeEventRow` + sources batch mock
- [ ] New test: event-UUID anchor exercises the fallback path end-to-end
- [ ] 85 suites / 1263 passed (1 new test vs baseline 1262)

🤖 Generated with [Claude Code](https://claude.com/claude-code)